### PR TITLE
Configure admin and API startup probes

### DIFF
--- a/base/admin-deployment.yaml
+++ b/base/admin-deployment.yaml
@@ -95,16 +95,24 @@ spec:
               memory: "900Mi"
           ports:
             - containerPort: 6012
-          readinessProbe:
-            tcpSocket:
+          startupProbe:
+            httpGet:
+              path: /_status
               port: 6012
-            initialDelaySeconds: 3
+            initialDelaySeconds: 10
             periodSeconds: 3
+            timeoutSeconds: 1
+            successThreshold: 3
+            failureThreshold: 10
           livenessProbe:
-            tcpSocket:
+            httpGet:
+              path: /_status
               port: 6012
-            initialDelaySeconds: 3
+            initialDelaySeconds: 0
             periodSeconds: 3
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler

--- a/base/api-deployment.yaml
+++ b/base/api-deployment.yaml
@@ -183,18 +183,24 @@ spec:
               memory: "900Mi"
           ports:
             - containerPort: 6011
-          readinessProbe:
+          startupProbe:
             httpGet:
-              path: /
+              path: /_status
               port: 6011
             initialDelaySeconds: 10
             periodSeconds: 3
+            timeoutSeconds: 1
+            successThreshold: 3
+            failureThreshold: 10
           livenessProbe:
             httpGet:
-              path: /
+              path: /_status
               port: 6011
-            initialDelaySeconds: 10
+            initialDelaySeconds: 0
             periodSeconds: 3
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler


### PR DESCRIPTION
Change to startup probes as we did in https://github.com/cds-snc/notification-staging-tf/pull/13 now that we have a compatible cluster version

CI is failing at the moment but it'll be fixed when https://github.com/cds-snc/notification-manifests/pull/1 is merged