### PR TITLE
feat: Changes celery worker to fargate deployment and adds service account

### DIFF
--- a/base/celery-deployment.yaml
+++ b/base/celery-deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   labels:
     app: celery
-    # profile: fargate
+    profile: fargate
   name:  celery
   namespace: notification-canada-ca
 spec:
@@ -21,7 +21,7 @@ spec:
     metadata:
       labels:
         app: celery
-        # profile: fargate
+        profile: fargate
     spec:
       containers:
         - image: api
@@ -92,10 +92,8 @@ spec:
               value: '$(NEW_RELIC_MONITOR_MODE)'
           command: ["/bin/sh"]
           args: ["-c", "sh /app/scripts/run_celery.sh"]
-          # command: ["sh", "-c", "tail -f /dev/null"]
-      dnsPolicy: ClusterFirst
-      restartPolicy: Always
-      schedulerName: default-scheduler
-      securityContext: {}
+      securityContext:
+        fsGroup: 65534
+      serviceAccountName: notification-service-account
       terminationGracePeriodSeconds: 30
 status: {}

--- a/env/staging/kustomization.yaml
+++ b/env/staging/kustomization.yaml
@@ -3,6 +3,7 @@ bases:
 
 resources:
   - cwagent-fluentd-quickstart.yaml
+  - notification-service-account.yaml
   - api-target-group.yaml
   - admin-target-group.yaml
   - document-download-api-target-group.yaml

--- a/env/staging/notification-service-account.yaml
+++ b/env/staging/notification-service-account.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  namespace: notification-canada-ca
+  name: notification-service-account
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::239043911459:role/notification-service-account-role


### PR DESCRIPTION
This PR changes the existing celery worker pod to run in Fargate. Regular pods on EC2 nodes inherit their AWS credentials from the instance metadata endpoint (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html). Fargate pods do not and therefore need a specialized service account (https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) which are then attached to the pods. As a result we are adding a new service account object to the cluster as well.