### PR TITLE
[AUTO-PR] Automatically generated new release 2020-11-25T19:38:16.017Z

### DIFF
--- a/env/production/kustomization.yaml
+++ b/env/production/kustomization.yaml
@@ -1,330 +1,324 @@
-# See https://github.com/kubernetes-sigs/kustomize/blob/v2.0.3/examples/remoteBuild.md
 bases:
   - github.com/cds-snc/notification-manifests//base?ref=v0.10.0
-
 resources:
   - cwagent-fluentd-quickstart.yaml
   - api-target-group.yaml
   - admin-target-group.yaml
   - document-download-api-target-group.yaml
   - document-download-frontend-target-group.yaml
-
 images:
   - name: admin
-    newName: gcr.io/cdssnc/notify/admin:33f5819
+    newName: gcr.io/cdssnc/notify/admin:a47ee76
   - name: api
-    newName: gcr.io/cdssnc/notify/api:823c3f0
+    newName: gcr.io/cdssnc/notify/api:8a1de76
   - name: document-download-api
     newName: gcr.io/cdssnc/notify/document-download-api:3f040c2b
   - name: document-download-frontend
     newName: gcr.io/cdssnc/notify/document-download-frontend:60d40eb
-
 configMapGenerator:
-- name: application-config
-  env: .env
-
+  - name: application-config
+    env: .env
 patches:
- - replica_count.yaml
-
+  - replica_count.yaml
 vars:
-- name: ADMIN_CLIENT_USER_NAME
-  objref:
-    kind: ConfigMap
-    name: application-config
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.ADMIN_CLIENT_USER_NAME
-- name: ADMIN_CLIENT_SECRET
-  objref:
-    kind: ConfigMap
-    name: application-config
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.ADMIN_CLIENT_SECRET
-- name: ASSET_UPLOAD_BUCKET_NAME
-  objref:
-    kind: ConfigMap
-    name: application-config
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.ASSET_UPLOAD_BUCKET_NAME
-- name: ASSET_DOMAIN
-  objref:
-    kind: ConfigMap
-    name: application-config
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.ASSET_DOMAIN
-- name: AUTH_TOKENS
-  objref:
-    kind: ConfigMap
-    name: application-config
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.AUTH_TOKENS
-- name: AWS_PINPOINT_APP_ID
-  objref:
-    kind: ConfigMap
-    name: application-config
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.AWS_PINPOINT_APP_ID
-- name: AWS_PINPOINT_KEYWORD
-  objref:
-    kind: ConfigMap
-    name: application-config
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.AWS_PINPOINT_KEYWORD
-- name: AWS_REGION
-  objref:
-    kind: ConfigMap
-    name: application-config
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.AWS_REGION
-- name: AWS_ROUTE53_ZONE
-  objref:
-    kind: ConfigMap
-    name: application-config
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.AWS_ROUTE53_ZONE
-- name: AWS_SES_REGION
-  objref:
-    kind: ConfigMap
-    name: application-config
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.AWS_SES_REGION
-- name: AWS_SES_SMTP
-  objref:
-    kind: ConfigMap
-    name: application-config
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.AWS_SES_SMTP
-- name: AWS_SES_ACCESS_KEY
-  objref:
-    kind: ConfigMap
-    name: application-config
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.AWS_SES_ACCESS_KEY
-- name: AWS_SES_SECRET_KEY
-  objref:
-    kind: ConfigMap
-    name: application-config
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.AWS_SES_SECRET_KEY
-- name: BASE_DOMAIN
-  objref:
-    kind: ConfigMap
-    name: application-config
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.BASE_DOMAIN
-- name: BULK_SEND_AWS_ACCESS_KEY
-  objref:
-    kind: ConfigMap
-    name: application-config
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.BULK_SEND_AWS_ACCESS_KEY
-- name: BULK_SEND_AWS_SECRET_KEY
-  objref:
-    kind: ConfigMap
-    name: application-config
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.BULK_SEND_AWS_SECRET_KEY
-- name: BULK_SEND_AWS_BUCKET
-  objref:
-    kind: ConfigMap
-    name: application-config
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.BULK_SEND_AWS_BUCKET
-- name: BULK_SEND_AWS_REGION
-  objref:
-    kind: ConfigMap
-    name: application-config
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.BULK_SEND_AWS_REGION
-- name: BULK_SEND_TEST_SERVICE_ID
-  objref:
-    kind: ConfigMap
-    name: application-config
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.BULK_SEND_TEST_SERVICE_ID
-- name: CONTACT_EMAIL
-  objref:
-    kind: ConfigMap
-    name: application-config
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.CONTACT_EMAIL
-- name: CSV_UPLOAD_BUCKET_NAME
-  objref:
-    kind: ConfigMap
-    name: application-config
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.CSV_UPLOAD_BUCKET_NAME
-- name: CLUSTER_NAME
-  objref:
-    kind: ConfigMap
-    name: application-config
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.CLUSTER_NAME
-- name: DOCUMENTS_BUCKET
-  objref:
-    kind: ConfigMap
-    name: application-config
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.DOCUMENTS_BUCKET
-- name: DANGEROUS_SALT
-  objref:
-    kind: ConfigMap
-    name: application-config
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.DANGEROUS_SALT
-- name: ENVIRONMENT
-  objref:
-    kind: ConfigMap
-    name: application-config
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.ENVIRONMENT
-- name: FRESH_DESK_API_URL
-  objref:
-    kind: ConfigMap
-    name: application-config
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.FRESH_DESK_API_URL
-- name: FRESH_DESK_API_KEY
-  objref:
-    kind: ConfigMap
-    name: application-config
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.FRESH_DESK_API_KEY
-- name: HASURA_ACCESS_KEY
-  objref:
-    kind: ConfigMap
-    name: application-config
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.HASURA_ACCESS_KEY
-- name: HASURA_JWT_KEY
-  objref:
-    kind: ConfigMap
-    name: application-config
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.HASURA_JWT_KEY
-- name: HC_EN_SERVICE_ID
-  objref:
-    kind: ConfigMap
-    name: application-config
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.HC_EN_SERVICE_ID
-- name: MLWR_HOST
-  objref:
-    kind: ConfigMap
-    name: application-config
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.MLWR_HOST
-- name: MLWR_USER
-  objref:
-    kind: ConfigMap
-    name: application-config
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.MLWR_USER
-- name: MLWR_KEY
-  objref:
-    kind: ConfigMap
-    name: application-config
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.MLWR_KEY
-- name: NEW_RELIC_LICENSE_KEY
-  objref:
-    kind: ConfigMap
-    name: application-config
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.NEW_RELIC_LICENSE_KEY
-- name: NEW_RELIC_MONITOR_MODE
-  objref:
-    kind: ConfigMap
-    name: application-config
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.NEW_RELIC_MONITOR_MODE
-- name: POSTGRES_HOST
-  objref:
-    kind: ConfigMap
-    name: application-config
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.POSTGRES_HOST
-- name: POSTGRES_SQL
-  objref:
-    kind: ConfigMap
-    name: application-config
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.POSTGRES_SQL
-- name: SECRET_KEY
-  objref:
-    kind: ConfigMap
-    name: application-config
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.SECRET_KEY
-- name: SENDGRID_API_KEY
-  objref:
-    kind: ConfigMap
-    name: application-config
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.SENDGRID_API_KEY
-- name: TWILIO_ACCOUNT_SID
-  objref:
-    kind: ConfigMap
-    name: application-config
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.TWILIO_ACCOUNT_SID
-- name: TWILIO_AUTH_TOKEN
-  objref:
-    kind: ConfigMap
-    name: application-config
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.TWILIO_AUTH_TOKEN
-- name: TWILIO_FROM_NUMBER
-  objref:
-    kind: ConfigMap
-    name: application-config
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.TWILIO_FROM_NUMBER
-- name: SENTRY_URL
-  objref:
-    kind: ConfigMap
-    name: application-config
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.SENTRY_URL
+  - name: ADMIN_CLIENT_USER_NAME
+    objref:
+      kind: ConfigMap
+      name: application-config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.ADMIN_CLIENT_USER_NAME
+  - name: ADMIN_CLIENT_SECRET
+    objref:
+      kind: ConfigMap
+      name: application-config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.ADMIN_CLIENT_SECRET
+  - name: ASSET_UPLOAD_BUCKET_NAME
+    objref:
+      kind: ConfigMap
+      name: application-config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.ASSET_UPLOAD_BUCKET_NAME
+  - name: ASSET_DOMAIN
+    objref:
+      kind: ConfigMap
+      name: application-config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.ASSET_DOMAIN
+  - name: AUTH_TOKENS
+    objref:
+      kind: ConfigMap
+      name: application-config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.AUTH_TOKENS
+  - name: AWS_PINPOINT_APP_ID
+    objref:
+      kind: ConfigMap
+      name: application-config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.AWS_PINPOINT_APP_ID
+  - name: AWS_PINPOINT_KEYWORD
+    objref:
+      kind: ConfigMap
+      name: application-config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.AWS_PINPOINT_KEYWORD
+  - name: AWS_REGION
+    objref:
+      kind: ConfigMap
+      name: application-config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.AWS_REGION
+  - name: AWS_ROUTE53_ZONE
+    objref:
+      kind: ConfigMap
+      name: application-config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.AWS_ROUTE53_ZONE
+  - name: AWS_SES_REGION
+    objref:
+      kind: ConfigMap
+      name: application-config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.AWS_SES_REGION
+  - name: AWS_SES_SMTP
+    objref:
+      kind: ConfigMap
+      name: application-config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.AWS_SES_SMTP
+  - name: AWS_SES_ACCESS_KEY
+    objref:
+      kind: ConfigMap
+      name: application-config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.AWS_SES_ACCESS_KEY
+  - name: AWS_SES_SECRET_KEY
+    objref:
+      kind: ConfigMap
+      name: application-config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.AWS_SES_SECRET_KEY
+  - name: BASE_DOMAIN
+    objref:
+      kind: ConfigMap
+      name: application-config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.BASE_DOMAIN
+  - name: BULK_SEND_AWS_ACCESS_KEY
+    objref:
+      kind: ConfigMap
+      name: application-config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.BULK_SEND_AWS_ACCESS_KEY
+  - name: BULK_SEND_AWS_SECRET_KEY
+    objref:
+      kind: ConfigMap
+      name: application-config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.BULK_SEND_AWS_SECRET_KEY
+  - name: BULK_SEND_AWS_BUCKET
+    objref:
+      kind: ConfigMap
+      name: application-config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.BULK_SEND_AWS_BUCKET
+  - name: BULK_SEND_AWS_REGION
+    objref:
+      kind: ConfigMap
+      name: application-config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.BULK_SEND_AWS_REGION
+  - name: BULK_SEND_TEST_SERVICE_ID
+    objref:
+      kind: ConfigMap
+      name: application-config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.BULK_SEND_TEST_SERVICE_ID
+  - name: CONTACT_EMAIL
+    objref:
+      kind: ConfigMap
+      name: application-config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.CONTACT_EMAIL
+  - name: CSV_UPLOAD_BUCKET_NAME
+    objref:
+      kind: ConfigMap
+      name: application-config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.CSV_UPLOAD_BUCKET_NAME
+  - name: CLUSTER_NAME
+    objref:
+      kind: ConfigMap
+      name: application-config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.CLUSTER_NAME
+  - name: DOCUMENTS_BUCKET
+    objref:
+      kind: ConfigMap
+      name: application-config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.DOCUMENTS_BUCKET
+  - name: DANGEROUS_SALT
+    objref:
+      kind: ConfigMap
+      name: application-config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.DANGEROUS_SALT
+  - name: ENVIRONMENT
+    objref:
+      kind: ConfigMap
+      name: application-config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.ENVIRONMENT
+  - name: FRESH_DESK_API_URL
+    objref:
+      kind: ConfigMap
+      name: application-config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.FRESH_DESK_API_URL
+  - name: FRESH_DESK_API_KEY
+    objref:
+      kind: ConfigMap
+      name: application-config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.FRESH_DESK_API_KEY
+  - name: HASURA_ACCESS_KEY
+    objref:
+      kind: ConfigMap
+      name: application-config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.HASURA_ACCESS_KEY
+  - name: HASURA_JWT_KEY
+    objref:
+      kind: ConfigMap
+      name: application-config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.HASURA_JWT_KEY
+  - name: HC_EN_SERVICE_ID
+    objref:
+      kind: ConfigMap
+      name: application-config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.HC_EN_SERVICE_ID
+  - name: MLWR_HOST
+    objref:
+      kind: ConfigMap
+      name: application-config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.MLWR_HOST
+  - name: MLWR_USER
+    objref:
+      kind: ConfigMap
+      name: application-config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.MLWR_USER
+  - name: MLWR_KEY
+    objref:
+      kind: ConfigMap
+      name: application-config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.MLWR_KEY
+  - name: NEW_RELIC_LICENSE_KEY
+    objref:
+      kind: ConfigMap
+      name: application-config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.NEW_RELIC_LICENSE_KEY
+  - name: NEW_RELIC_MONITOR_MODE
+    objref:
+      kind: ConfigMap
+      name: application-config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.NEW_RELIC_MONITOR_MODE
+  - name: POSTGRES_HOST
+    objref:
+      kind: ConfigMap
+      name: application-config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.POSTGRES_HOST
+  - name: POSTGRES_SQL
+    objref:
+      kind: ConfigMap
+      name: application-config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.POSTGRES_SQL
+  - name: SECRET_KEY
+    objref:
+      kind: ConfigMap
+      name: application-config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.SECRET_KEY
+  - name: SENDGRID_API_KEY
+    objref:
+      kind: ConfigMap
+      name: application-config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.SENDGRID_API_KEY
+  - name: TWILIO_ACCOUNT_SID
+    objref:
+      kind: ConfigMap
+      name: application-config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.TWILIO_ACCOUNT_SID
+  - name: TWILIO_AUTH_TOKEN
+    objref:
+      kind: ConfigMap
+      name: application-config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.TWILIO_AUTH_TOKEN
+  - name: TWILIO_FROM_NUMBER
+    objref:
+      kind: ConfigMap
+      name: application-config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.TWILIO_FROM_NUMBER
+  - name: SENTRY_URL
+    objref:
+      kind: ConfigMap
+      name: application-config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.SENTRY_URL


### PR DESCRIPTION
## What are you changing?
- [ ] Releasing a new version of Notify
- [ ] Changing kubernetes configuration

## Provide some background on the changes
ADMIN: 

 - [Disable honeypot field on contact page (#830)](https://github.com/cds-snc/notification-admin/commit/a47ee76fa3b2752985907ed3b36c5f714d37f867) by Antoine Augusti
- [fix a few CSS bugs (#827)](https://github.com/cds-snc/notification-admin/commit/9758e75ca6f04c2d759566126da0d3b704bd73e0) by Bethany Dunfield
- [Remove hardcoded alpha domain (#825)](https://github.com/cds-snc/notification-admin/commit/3be13a9ac6a3122600151a7e8386b2100019fe68) by Antoine Augusti
- [Update logo and assets domain (#823)](https://github.com/cds-snc/notification-admin/commit/af6e3805703464f7446979f936db14b8ec5a627e) by Antoine Augusti
- [Bump utils to 43.2.0 (#824)](https://github.com/cds-snc/notification-admin/commit/d66155517007e4680219cc3676734020e0162684) by Antoine Augusti
- [More css component tailwind work (#822)](https://github.com/cds-snc/notification-admin/commit/67ec33d230430014961673c514722b03e7eb99c5) by Bethany Dunfield 

 API: 

 - [Remove hardcoded domain from branding request (#1182)](https://github.com/cds-snc/notification-api/commit/8a1de76bd92ac20c08a2e1d953f2c8fba84d5c26) by Antoine Augusti
- [Bump utils to 43.2.0 (#1180)](https://github.com/cds-snc/notification-api/commit/be0b4ddc0c9cbaf7daf557a0a8ae9647b1aa7e7a) by Antoine Augusti
- [fix: The celery dependency should be in the docker-compose workers (#1179)](https://github.com/cds-snc/notification-api/commit/d9dc67f978b58790a90e8069e83c2682bccbc178) by Jimmy Royer

## If you are releasing a new version of notify, what components are you updating
- [ ] API
- [ ] Admin
- [ ] Document API
- [ ] Document UI

## Checklist if releasing new version:
- [ ] I made sure that both API and Admin changes are present in Notify
- [ ] I have checked if the docker images I am referencing exist - ex: https://gcr.io/cdssnc/notify/admin:7ddcb76

## Checklist if making changes to Kubernetes:
- [ ] I know how to get kubectl credentials in case it catches on fire
