### PR TITLE
[AUTO-PR] Automatically generated new release 2020-11-30T02:37:12.986Z

### DIFF
--- a/env/production/kustomization.yaml
+++ b/env/production/kustomization.yaml
@@ -1,330 +1,324 @@
-# See https://github.com/kubernetes-sigs/kustomize/blob/v2.0.3/examples/remoteBuild.md
 bases:
   - github.com/cds-snc/notification-manifests//base?ref=v0.10.0
-
 resources:
   - cwagent-fluentd-quickstart.yaml
   - api-target-group.yaml
   - admin-target-group.yaml
   - document-download-api-target-group.yaml
   - document-download-frontend-target-group.yaml
-
 images:
   - name: admin
-    newName: gcr.io/cdssnc/notify/admin:a47ee76
+    newName: gcr.io/cdssnc/notify/admin:8666188
   - name: api
     newName: gcr.io/cdssnc/notify/api:1fd2b42
   - name: document-download-api
     newName: gcr.io/cdssnc/notify/document-download-api:266bbc54
   - name: document-download-frontend
     newName: gcr.io/cdssnc/notify/document-download-frontend:60d40eb
-
 configMapGenerator:
-- name: application-config
-  env: .env
-
+  - name: application-config
+    env: .env
 patches:
- - replica_count.yaml
-
+  - replica_count.yaml
 vars:
-- name: ADMIN_CLIENT_USER_NAME
-  objref:
-    kind: ConfigMap
-    name: application-config
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.ADMIN_CLIENT_USER_NAME
-- name: ADMIN_CLIENT_SECRET
-  objref:
-    kind: ConfigMap
-    name: application-config
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.ADMIN_CLIENT_SECRET
-- name: ASSET_UPLOAD_BUCKET_NAME
-  objref:
-    kind: ConfigMap
-    name: application-config
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.ASSET_UPLOAD_BUCKET_NAME
-- name: ASSET_DOMAIN
-  objref:
-    kind: ConfigMap
-    name: application-config
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.ASSET_DOMAIN
-- name: AUTH_TOKENS
-  objref:
-    kind: ConfigMap
-    name: application-config
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.AUTH_TOKENS
-- name: AWS_PINPOINT_APP_ID
-  objref:
-    kind: ConfigMap
-    name: application-config
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.AWS_PINPOINT_APP_ID
-- name: AWS_PINPOINT_KEYWORD
-  objref:
-    kind: ConfigMap
-    name: application-config
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.AWS_PINPOINT_KEYWORD
-- name: AWS_REGION
-  objref:
-    kind: ConfigMap
-    name: application-config
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.AWS_REGION
-- name: AWS_ROUTE53_ZONE
-  objref:
-    kind: ConfigMap
-    name: application-config
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.AWS_ROUTE53_ZONE
-- name: AWS_SES_REGION
-  objref:
-    kind: ConfigMap
-    name: application-config
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.AWS_SES_REGION
-- name: AWS_SES_SMTP
-  objref:
-    kind: ConfigMap
-    name: application-config
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.AWS_SES_SMTP
-- name: AWS_SES_ACCESS_KEY
-  objref:
-    kind: ConfigMap
-    name: application-config
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.AWS_SES_ACCESS_KEY
-- name: AWS_SES_SECRET_KEY
-  objref:
-    kind: ConfigMap
-    name: application-config
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.AWS_SES_SECRET_KEY
-- name: BASE_DOMAIN
-  objref:
-    kind: ConfigMap
-    name: application-config
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.BASE_DOMAIN
-- name: BULK_SEND_AWS_ACCESS_KEY
-  objref:
-    kind: ConfigMap
-    name: application-config
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.BULK_SEND_AWS_ACCESS_KEY
-- name: BULK_SEND_AWS_SECRET_KEY
-  objref:
-    kind: ConfigMap
-    name: application-config
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.BULK_SEND_AWS_SECRET_KEY
-- name: BULK_SEND_AWS_BUCKET
-  objref:
-    kind: ConfigMap
-    name: application-config
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.BULK_SEND_AWS_BUCKET
-- name: BULK_SEND_AWS_REGION
-  objref:
-    kind: ConfigMap
-    name: application-config
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.BULK_SEND_AWS_REGION
-- name: BULK_SEND_TEST_SERVICE_ID
-  objref:
-    kind: ConfigMap
-    name: application-config
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.BULK_SEND_TEST_SERVICE_ID
-- name: CONTACT_EMAIL
-  objref:
-    kind: ConfigMap
-    name: application-config
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.CONTACT_EMAIL
-- name: CSV_UPLOAD_BUCKET_NAME
-  objref:
-    kind: ConfigMap
-    name: application-config
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.CSV_UPLOAD_BUCKET_NAME
-- name: CLUSTER_NAME
-  objref:
-    kind: ConfigMap
-    name: application-config
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.CLUSTER_NAME
-- name: DOCUMENTS_BUCKET
-  objref:
-    kind: ConfigMap
-    name: application-config
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.DOCUMENTS_BUCKET
-- name: DANGEROUS_SALT
-  objref:
-    kind: ConfigMap
-    name: application-config
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.DANGEROUS_SALT
-- name: ENVIRONMENT
-  objref:
-    kind: ConfigMap
-    name: application-config
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.ENVIRONMENT
-- name: FRESH_DESK_API_URL
-  objref:
-    kind: ConfigMap
-    name: application-config
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.FRESH_DESK_API_URL
-- name: FRESH_DESK_API_KEY
-  objref:
-    kind: ConfigMap
-    name: application-config
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.FRESH_DESK_API_KEY
-- name: HASURA_ACCESS_KEY
-  objref:
-    kind: ConfigMap
-    name: application-config
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.HASURA_ACCESS_KEY
-- name: HASURA_JWT_KEY
-  objref:
-    kind: ConfigMap
-    name: application-config
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.HASURA_JWT_KEY
-- name: HC_EN_SERVICE_ID
-  objref:
-    kind: ConfigMap
-    name: application-config
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.HC_EN_SERVICE_ID
-- name: MLWR_HOST
-  objref:
-    kind: ConfigMap
-    name: application-config
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.MLWR_HOST
-- name: MLWR_USER
-  objref:
-    kind: ConfigMap
-    name: application-config
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.MLWR_USER
-- name: MLWR_KEY
-  objref:
-    kind: ConfigMap
-    name: application-config
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.MLWR_KEY
-- name: NEW_RELIC_LICENSE_KEY
-  objref:
-    kind: ConfigMap
-    name: application-config
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.NEW_RELIC_LICENSE_KEY
-- name: NEW_RELIC_MONITOR_MODE
-  objref:
-    kind: ConfigMap
-    name: application-config
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.NEW_RELIC_MONITOR_MODE
-- name: POSTGRES_HOST
-  objref:
-    kind: ConfigMap
-    name: application-config
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.POSTGRES_HOST
-- name: POSTGRES_SQL
-  objref:
-    kind: ConfigMap
-    name: application-config
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.POSTGRES_SQL
-- name: SECRET_KEY
-  objref:
-    kind: ConfigMap
-    name: application-config
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.SECRET_KEY
-- name: SENDGRID_API_KEY
-  objref:
-    kind: ConfigMap
-    name: application-config
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.SENDGRID_API_KEY
-- name: TWILIO_ACCOUNT_SID
-  objref:
-    kind: ConfigMap
-    name: application-config
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.TWILIO_ACCOUNT_SID
-- name: TWILIO_AUTH_TOKEN
-  objref:
-    kind: ConfigMap
-    name: application-config
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.TWILIO_AUTH_TOKEN
-- name: TWILIO_FROM_NUMBER
-  objref:
-    kind: ConfigMap
-    name: application-config
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.TWILIO_FROM_NUMBER
-- name: SENTRY_URL
-  objref:
-    kind: ConfigMap
-    name: application-config
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.SENTRY_URL
+  - name: ADMIN_CLIENT_USER_NAME
+    objref:
+      kind: ConfigMap
+      name: application-config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.ADMIN_CLIENT_USER_NAME
+  - name: ADMIN_CLIENT_SECRET
+    objref:
+      kind: ConfigMap
+      name: application-config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.ADMIN_CLIENT_SECRET
+  - name: ASSET_UPLOAD_BUCKET_NAME
+    objref:
+      kind: ConfigMap
+      name: application-config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.ASSET_UPLOAD_BUCKET_NAME
+  - name: ASSET_DOMAIN
+    objref:
+      kind: ConfigMap
+      name: application-config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.ASSET_DOMAIN
+  - name: AUTH_TOKENS
+    objref:
+      kind: ConfigMap
+      name: application-config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.AUTH_TOKENS
+  - name: AWS_PINPOINT_APP_ID
+    objref:
+      kind: ConfigMap
+      name: application-config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.AWS_PINPOINT_APP_ID
+  - name: AWS_PINPOINT_KEYWORD
+    objref:
+      kind: ConfigMap
+      name: application-config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.AWS_PINPOINT_KEYWORD
+  - name: AWS_REGION
+    objref:
+      kind: ConfigMap
+      name: application-config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.AWS_REGION
+  - name: AWS_ROUTE53_ZONE
+    objref:
+      kind: ConfigMap
+      name: application-config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.AWS_ROUTE53_ZONE
+  - name: AWS_SES_REGION
+    objref:
+      kind: ConfigMap
+      name: application-config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.AWS_SES_REGION
+  - name: AWS_SES_SMTP
+    objref:
+      kind: ConfigMap
+      name: application-config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.AWS_SES_SMTP
+  - name: AWS_SES_ACCESS_KEY
+    objref:
+      kind: ConfigMap
+      name: application-config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.AWS_SES_ACCESS_KEY
+  - name: AWS_SES_SECRET_KEY
+    objref:
+      kind: ConfigMap
+      name: application-config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.AWS_SES_SECRET_KEY
+  - name: BASE_DOMAIN
+    objref:
+      kind: ConfigMap
+      name: application-config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.BASE_DOMAIN
+  - name: BULK_SEND_AWS_ACCESS_KEY
+    objref:
+      kind: ConfigMap
+      name: application-config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.BULK_SEND_AWS_ACCESS_KEY
+  - name: BULK_SEND_AWS_SECRET_KEY
+    objref:
+      kind: ConfigMap
+      name: application-config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.BULK_SEND_AWS_SECRET_KEY
+  - name: BULK_SEND_AWS_BUCKET
+    objref:
+      kind: ConfigMap
+      name: application-config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.BULK_SEND_AWS_BUCKET
+  - name: BULK_SEND_AWS_REGION
+    objref:
+      kind: ConfigMap
+      name: application-config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.BULK_SEND_AWS_REGION
+  - name: BULK_SEND_TEST_SERVICE_ID
+    objref:
+      kind: ConfigMap
+      name: application-config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.BULK_SEND_TEST_SERVICE_ID
+  - name: CONTACT_EMAIL
+    objref:
+      kind: ConfigMap
+      name: application-config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.CONTACT_EMAIL
+  - name: CSV_UPLOAD_BUCKET_NAME
+    objref:
+      kind: ConfigMap
+      name: application-config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.CSV_UPLOAD_BUCKET_NAME
+  - name: CLUSTER_NAME
+    objref:
+      kind: ConfigMap
+      name: application-config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.CLUSTER_NAME
+  - name: DOCUMENTS_BUCKET
+    objref:
+      kind: ConfigMap
+      name: application-config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.DOCUMENTS_BUCKET
+  - name: DANGEROUS_SALT
+    objref:
+      kind: ConfigMap
+      name: application-config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.DANGEROUS_SALT
+  - name: ENVIRONMENT
+    objref:
+      kind: ConfigMap
+      name: application-config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.ENVIRONMENT
+  - name: FRESH_DESK_API_URL
+    objref:
+      kind: ConfigMap
+      name: application-config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.FRESH_DESK_API_URL
+  - name: FRESH_DESK_API_KEY
+    objref:
+      kind: ConfigMap
+      name: application-config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.FRESH_DESK_API_KEY
+  - name: HASURA_ACCESS_KEY
+    objref:
+      kind: ConfigMap
+      name: application-config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.HASURA_ACCESS_KEY
+  - name: HASURA_JWT_KEY
+    objref:
+      kind: ConfigMap
+      name: application-config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.HASURA_JWT_KEY
+  - name: HC_EN_SERVICE_ID
+    objref:
+      kind: ConfigMap
+      name: application-config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.HC_EN_SERVICE_ID
+  - name: MLWR_HOST
+    objref:
+      kind: ConfigMap
+      name: application-config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.MLWR_HOST
+  - name: MLWR_USER
+    objref:
+      kind: ConfigMap
+      name: application-config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.MLWR_USER
+  - name: MLWR_KEY
+    objref:
+      kind: ConfigMap
+      name: application-config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.MLWR_KEY
+  - name: NEW_RELIC_LICENSE_KEY
+    objref:
+      kind: ConfigMap
+      name: application-config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.NEW_RELIC_LICENSE_KEY
+  - name: NEW_RELIC_MONITOR_MODE
+    objref:
+      kind: ConfigMap
+      name: application-config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.NEW_RELIC_MONITOR_MODE
+  - name: POSTGRES_HOST
+    objref:
+      kind: ConfigMap
+      name: application-config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.POSTGRES_HOST
+  - name: POSTGRES_SQL
+    objref:
+      kind: ConfigMap
+      name: application-config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.POSTGRES_SQL
+  - name: SECRET_KEY
+    objref:
+      kind: ConfigMap
+      name: application-config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.SECRET_KEY
+  - name: SENDGRID_API_KEY
+    objref:
+      kind: ConfigMap
+      name: application-config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.SENDGRID_API_KEY
+  - name: TWILIO_ACCOUNT_SID
+    objref:
+      kind: ConfigMap
+      name: application-config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.TWILIO_ACCOUNT_SID
+  - name: TWILIO_AUTH_TOKEN
+    objref:
+      kind: ConfigMap
+      name: application-config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.TWILIO_AUTH_TOKEN
+  - name: TWILIO_FROM_NUMBER
+    objref:
+      kind: ConfigMap
+      name: application-config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.TWILIO_FROM_NUMBER
+  - name: SENTRY_URL
+    objref:
+      kind: ConfigMap
+      name: application-config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.SENTRY_URL


### PR DESCRIPTION
## What are you changing?
- [ ] Releasing a new version of Notify
- [ ] Changing kubernetes configuration

## Provide some background on the changes
ADMIN: 

 - [Disable IP geolookup locally (#829)](https://github.com/cds-snc/notification-admin/commit/86661887a8c69f074de7e4e82c99a37a40495f15) by Antoine Augusti
- [Select default logo branding upon service creation (#832)](https://github.com/cds-snc/notification-admin/commit/dd2aa7d7899a04cf136789110c4d193d3772c655) by Jimmy Royer
- [Table css (#826)](https://github.com/cds-snc/notification-admin/commit/54ae522e9b29703d39ae1cac1e763d4e06055626) by Bethany Dunfield
- [Update Live config to Production (#834)](https://github.com/cds-snc/notification-admin/commit/abc925f3b60c4837e07be097b39741498f5ec62a) by Antoine Augusti
- [add french translation to csv and localization func for string (#833)](https://github.com/cds-snc/notification-admin/commit/378c5ca6dc7421bcc657e14ed0ba2659d7d62cb4) by dorianjp 

 API: 

 

## If you are releasing a new version of notify, what components are you updating
- [ ] API
- [ ] Admin
- [ ] Document API
- [ ] Document UI

## Checklist if releasing new version:
- [ ] I made sure that both API and Admin changes are present in Notify
- [ ] I have checked if the docker images I am referencing exist - ex: https://gcr.io/cdssnc/notify/admin:7ddcb76

## Checklist if making changes to Kubernetes:
- [ ] I know how to get kubectl credentials in case it catches on fire
