### PR TITLE
feat: allocate resources for Redis

### DIFF
--- a/base/redis-deployment.yaml
+++ b/base/redis-deployment.yaml
@@ -23,3 +23,10 @@ spec:
           env:
           - name: PORT
             value: "6379"
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "100Mi"
+            limits:
+              cpu: "200m"
+              memory: "200Mi"


### PR DESCRIPTION
## What are you changing?
- [ ] Releasing a new version of Notify
- [x] Changing Kubernetes configuration

## Provide some background on the changes
We run a single Redis instance at the moment. Before moving to AWS Elasticache, make sure that we define sensible resources for our pod to make sure that it has a decent amount of CPU and memory.
