### PR TITLE
Disable HPA in prod

### DIFF
--- a/env/production/replica_count.yaml
+++ b/env/production/replica_count.yaml
@@ -26,7 +26,7 @@ metadata:
   name:  celery
   namespace: notification-canada-ca
 spec:
-  replicas: 4
+  replicas: 6
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -45,7 +45,7 @@ metadata:
   namespace: notification-canada-ca
 spec:
   minReplicas: 2
-  maxReplicas: 4
+  maxReplicas: 2
 ---
 apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
@@ -54,7 +54,7 @@ metadata:
   namespace: notification-canada-ca
 spec:
   minReplicas: 4
-  maxReplicas: 8
+  maxReplicas: 4
 ---
 apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
@@ -62,5 +62,5 @@ metadata:
   name: celery-hpa
   namespace: notification-canada-ca
 spec:
-  minReplicas: 4
-  maxReplicas: 10
+  minReplicas: 6
+  maxReplicas: 6


### PR DESCRIPTION
Temporarily disable HPA in production by hardcoding min/max to expected and sensible values: 2 admin, 4 API, 6 Celery workers