### PR TITLE
feat: adjust resources for documentation deployment

### DIFF
--- a/base/documentation-deployment.yaml
+++ b/base/documentation-deployment.yaml
@@ -27,11 +27,11 @@ spec:
             - containerPort: 80
           resources:
             requests:
+              cpu: "50m"
+              memory: "50Mi"
+            limits:
               cpu: "100m"
               memory: "100Mi"
-            limits:
-              cpu: "200m"
-              memory: "200Mi"
           readinessProbe:
             httpGet:
               path: /index.html


### PR DESCRIPTION
## What are you changing?
- [ ] Releasing a new version of Notify
- [x] Changing kubernetes configuration

## Provide some background on the changes
After doing a load test in staging, we saw that the CPU and memory stayed very low even under 20k requests per minute. Therefore, I'm adjusting resources accordingly.

Slack thread: https://gcdigital.slack.com/archives/CV38DBNVA/p1611084988016900
