### PR TITLE
Bump production to 0.22.0

### DIFF
--- a/env/production/kustomization.yaml
+++ b/env/production/kustomization.yaml
@@ -1,5 +1,5 @@
 bases:
-  - github.com/cds-snc/notification-manifests//base?ref=v0.21.0
+  - github.com/cds-snc/notification-manifests//base?ref=v0.22.0
 resources:
   - cwagent-fluentd-quickstart.yaml
   - api-target-group.yaml


### PR DESCRIPTION
## What are you changing?
- [ ] Releasing a new version of Notify
- [x] Changing Kubernetes configuration

## Provide some background on the changes
Releasing https://github.com/cds-snc/notification-manifests/pull/173 to production

## Checklist if making changes to Kubernetes:
- [x] I know how to get kubectl credentials in case it catches on fire
