### PR TITLE
Update number of Celery pods in production

### DIFF
--- a/env/production/replica_count.yaml
+++ b/env/production/replica_count.yaml
@@ -26,7 +26,7 @@ metadata:
   name:  celery
   namespace: notification-canada-ca
 spec:
-  replicas: 6
+  replicas: 3
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -62,5 +62,5 @@ metadata:
   name: celery-hpa
   namespace: notification-canada-ca
 spec:
-  minReplicas: 6
-  maxReplicas: 6
+  minReplicas: 3
+  maxReplicas: 15


### PR DESCRIPTION
## What are you changing?
- [ ] Releasing a new version of Notify
- [x] Changing Kubernetes configuration

## Provide some background on the changes
We have been recently paged during business hours because we don't clear up the email queue fast enough. The last occurrence was [yesterday](https://gcdigital.slack.com/archives/CNWA63606/p1612378640091100).

We processed ~7000 emails/5 minutes with 6 Celery pods, this amounts to 23 emails sent per second. Our limit is at 100 emails sent per second so I'm picking up a 2.5x increase (max replicas from 6 to 15) to clear the queue faster while being under the SES rate limit.

HPA for Celery pods in production is safe compared to HPA with admin/API pods so I'd like to give this a go.

## Checklist if making changes to Kubernetes:
- [x] I know how to get kubectl credentials in case it catches on fire
