### PR TITLE
fix: DB envs on api container not migrate-db

### DIFF
--- a/base/api-deployment.yaml
+++ b/base/api-deployment.yaml
@@ -75,10 +75,6 @@ spec:
               value: '$(SENDGRID_API_KEY)'
             - name: SQLALCHEMY_DATABASE_URI
               value: '$(POSTGRES_SQL)'
-            - name: SQLALCHEMY_DATABASE_READER_URI
-              value: '$(SQLALCHEMY_DATABASE_READER_URI)'
-            - name: SQLALCHEMY_POOL_SIZE
-              value: '$(SQLALCHEMY_POOL_SIZE)'
             - name: STATSD_HOST
               valueFrom:
                 fieldRef:
@@ -164,6 +160,10 @@ spec:
               value: '$(SENDGRID_API_KEY)'
             - name: SQLALCHEMY_DATABASE_URI
               value: '$(POSTGRES_SQL)'
+            - name: SQLALCHEMY_DATABASE_READER_URI
+              value: '$(SQLALCHEMY_DATABASE_READER_URI)'
+            - name: SQLALCHEMY_POOL_SIZE
+              value: '$(SQLALCHEMY_POOL_SIZE)'
             - name: STATSD_HOST
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
## What are you changing?
- [ ] Releasing a new version of Notify
- [x] Changing kubernetes configuration

## Provide some background on the changes
Fixes #226 for the API deployment.

This deployment has 2 containers
- `migrate-db`, on boot in charge of migrating the database if necessary
- `api`, regular API

the env have been added to `migrate-db` instead of `api`, this PR fixes this

## Checklist if making changes to Kubernetes:
- [x] I know how to get kubectl credentials in case it catches on fire