### PR TITLE
feat: do not connect to DB for admin/API liveness probes

### DIFF
--- a/base/admin-deployment.yaml
+++ b/base/admin-deployment.yaml
@@ -112,7 +112,7 @@ spec:
             failureThreshold: 10
           livenessProbe:
             httpGet:
-              path: /_status
+              path: "/_status?simple=true"
               port: 6012
             initialDelaySeconds: 30
             periodSeconds: 3

--- a/base/api-deployment.yaml
+++ b/base/api-deployment.yaml
@@ -204,7 +204,7 @@ spec:
             failureThreshold: 10
           livenessProbe:
             httpGet:
-              path: /_status
+              path: "/_status?simple=true"
               port: 6011
             initialDelaySeconds: 30
             periodSeconds: 3


### PR DESCRIPTION
## What are you changing?
- [ ] Releasing a new version of Notify
- [x] Changing kubernetes configuration

## Provide some background on the changes

Do not do database connection checks on health check endpoints used by `livenessProbes` on admin and API pods. The probe should be responsible for assessing if a single pod is healthy, a slow database connection will make the entire service appear to be unhealthy and will create a cascading failure (all API pods and then all admin pods).

We can pass a `simple` query param to admin and API services to skip the database connection https://github.com/cds-snc/notification-api/blob/10df7c236d431f6653c3a9e1990f93cfc4cdc6aa/app/status/healthcheck.py#L16-L19

Demo:
- https://notification.canada.ca/_status?simple=true
- https://api.notification.canada.ca/_status?simple=true

Trello card: https://trello.com/c/yCDSXWsm/305-do-not-connect-to-db-on-liveness-probes

## Checklist if making changes to Kubernetes:
- [x] I know how to get kubectl credentials in case it catches on fire