### PR TITLE
Set CPU and memory for ipv4 deployment

### DIFF
--- a/base/ipv4-deployment.yaml
+++ b/base/ipv4-deployment.yaml
@@ -22,6 +22,10 @@ spec:
       containers:
         - name: ipv4
           image: public.ecr.aws/cds-snc/notify-ipv4-geolocate-webservice:latest
+          resources:
+            requests:
+              cpu: "50m"
+              memory: "100Mi"
           ports:
             - containerPort: 8080
           readinessProbe:


### PR DESCRIPTION
## What are you changing?
- [ ] Releasing a new version of Notify
- [x] Changing kubernetes configuration

## Provide some background on the changes
Allocate a minimum of CPU and memory to the IP geolookup deployment.

Set to double what it was currently using when I looked at the data

```
kubectl top pod ipv4-8578d99fc-ncblp 
NAME                   CPU(cores)   MEMORY(bytes)   
ipv4-8578d99fc-ncblp   26m          41Mi
```

## Checklist if making changes to Kubernetes:
- [x] I know how to get kubectl credentials in case it catches on fire