### PR TITLE
feat: add env DOCUMENTATION_DOMAIN in admin and API

### DIFF
--- a/base/admin-deployment.yaml
+++ b/base/admin-deployment.yaml
@@ -56,6 +56,8 @@ spec:
               value: '$(CSV_UPLOAD_BUCKET_NAME)'
             - name: DANGEROUS_SALT
               value: '$(DANGEROUS_SALT)'
+            - name: DOCUMENTATION_DOMAIN
+              value: 'documentation.$(BASE_DOMAIN)'
             - name: HC_EN_SERVICE_ID
               value: '$(HC_EN_SERVICE_ID)'
             - name: HC_FR_SERVICE_ID

--- a/base/api-deployment.yaml
+++ b/base/api-deployment.yaml
@@ -51,6 +51,8 @@ spec:
               value: '$(DANGEROUS_SALT)'
             - name: DOCUMENT_DOWNLOAD_API_HOST
               value: 'http://document-download-api.notification-canada-ca.svc.cluster.local:7000'
+            - name: DOCUMENTATION_DOMAIN
+              value: 'documentation.$(BASE_DOMAIN)'
             - name: FIDO2_DOMAIN
               value: '$(BASE_DOMAIN)'
             - name: FLASK_APP


### PR DESCRIPTION
## What are you changing?
- [ ] Releasing a new version of Notify
- [x] Changing kubernetes configuration

## Provide some background on the changes

Stop relying on [the fallback value in `config.py`](https://github.com/cds-snc/notification-admin/blob/f947e0d2053b372d2321670dcf7d0260287dba8d/app/config.py#L32), the fallback mechanism is going away soon. Introduces the env variable on the API side as well, it will be needed in https://github.com/cds-snc/notification-api/pull/1241

## Checklist if making changes to Kubernetes:
- [x] I know how to get kubectl credentials in case it catches on fire