### PR TITLE
Bump production to 0.30.0

### DIFF
--- a/env/production/kustomization.yaml
+++ b/env/production/kustomization.yaml
@@ -1,5 +1,5 @@
 bases:
-  - github.com/cds-snc/notification-manifests//base?ref=v0.28.0
+  - github.com/cds-snc/notification-manifests//base?ref=v0.30.0
 resources:
   - cwagent-fluentd-quickstart.yaml
   - api-target-group.yaml


### PR DESCRIPTION
## What are you changing?
- [ ] Releasing a new version of Notify
- [x] Changing kubernetes configuration

## Provide some background on the changes

Releases:
- 0.29.0 https://github.com/cds-snc/notification-manifests/pull/257
- 0.30.0 https://github.com/cds-snc/notification-manifests/pull/260 (doesn't affect production, tag was only relevant to staging)

## Checklist if making changes to Kubernetes:
- [x] I know how to get kubectl credentials in case it catches on fire
