### PR TITLE
[AUTO-PR] Automatically generated new release 2021-03-03T20:42:24.912Z

### DIFF
--- a/env/production/kustomization.yaml
+++ b/env/production/kustomization.yaml
@@ -9,15 +9,15 @@ resources:
   - documentation-target-group.yaml
 images:
   - name: admin
-    newName: public.ecr.aws/cds-snc/notify-admin:f947e0d
+    newName: public.ecr.aws/cds-snc/notify-admin:d614c30
   - name: api
-    newName: public.ecr.aws/cds-snc/notify-api:2c369fd
+    newName: public.ecr.aws/cds-snc/notify-api:50bebba
   - name: document-download-api
-    newName: public.ecr.aws/cds-snc/notify-document-download-api:fbd36b9
+    newName: public.ecr.aws/cds-snc/notify-document-download-api:e577c8b
   - name: document-download-frontend
-    newName: public.ecr.aws/cds-snc/notify-document-download-frontend:69a23c8
+    newName: public.ecr.aws/cds-snc/notify-document-download-frontend:dde3b65
   - name: documentation
-    newName: public.ecr.aws/cds-snc/notify-documentation:e087113
+    newName: public.ecr.aws/cds-snc/notify-documentation:b4cc499
 configMapGenerator:
   - name: application-config
     env: .env

--- a/env/production/kustomization.yaml
+++ b/env/production/kustomization.yaml
@@ -15,7 +15,7 @@ images:
   - name: document-download-api
     newName: public.ecr.aws/cds-snc/notify-document-download-api:e577c8b
   - name: document-download-frontend
-    newName: public.ecr.aws/cds-snc/notify-document-download-frontend:dde3b65
+    newName: public.ecr.aws/cds-snc/notify-document-download-frontend:a21acdc
   - name: documentation
     newName: public.ecr.aws/cds-snc/notify-documentation:b4cc499
 configMapGenerator:

--- a/env/production/kustomization.yaml
+++ b/env/production/kustomization.yaml
@@ -9,7 +9,7 @@ resources:
   - documentation-target-group.yaml
 images:
   - name: admin
-    newName: public.ecr.aws/cds-snc/notify-admin:d614c30
+    newName: public.ecr.aws/cds-snc/notify-admin:64c8ae5
   - name: api
     newName: public.ecr.aws/cds-snc/notify-api:50bebba
   - name: document-download-api


### PR DESCRIPTION
## What are you changing?
- [x] Releasing a new version of Notify
- [ ] Changing kubernetes configuration

## Provide some background on the changes
⚠️ **The production version of manifests is behind the latest staging version. Consider upgrading to the latest version before merging this pull request.** 

 NOTIFICATION-API

- [Update AWS CLI when building containers (#1242)](https://github.com/cds-snc/notification-api/commit/50bebbae344fc5ba0a9df4599abaac1dd6b08bf6) by Antoine Augusti

NOTIFICATION-ADMIN

- [Rate limit settings (#917)](https://github.com/cds-snc/notification-admin/commit/64c8ae52ec0e221e7b3e9841dadfd07e966e73e4) by Ren-David

NOTIFICATION-DOCUMENT-DOWNLOAD-API

- [Update AWS CLI when building containers (#27)](https://github.com/cds-snc/notification-document-download-api/commit/e577c8b13d089290b21a9f220a5a6cdb178152fd) by Antoine Augusti

NOTIFICATION-DOCUMENT-DOWNLOAD-FRONTEND

- [Increase keepalive between Gunicorn and LB (#35)](https://github.com/cds-snc/notification-document-download-frontend/commit/a21acdc287503018e8b90ffa62fa00d14c129866) by Antoine Augusti

NOTIFICATION-DOCUMENTATION

- [Update AWS CLI v2 when building containers (#66)](https://github.com/cds-snc/notification-documentation/commit/b4cc4995e8c2c0bc6850badea854fd4206957211) by Antoine Augusti

## If you are releasing a new version of notify, what components are you updating
- [x] API
- [x] Admin
- [x] Document API
- [x] Document UI

## Checklist if releasing new version:
- [x] I made sure that both API and Admin changes are present in Notify
- [x] I have checked if the docker images I am referencing exist - ex: https://gallery.ecr.aws/v6b8u5o6/notify-admin

## Checklist if making changes to Kubernetes:
- [ ] I know how to get kubectl credentials in case it catches on fire
