### PR TITLE
Update notify-admin to d614c30

### DIFF
--- a/env/production/kustomization.yaml
+++ b/env/production/kustomization.yaml
@@ -9,7 +9,7 @@ resources:
   - documentation-target-group.yaml
 images:
   - name: admin
-    newName: public.ecr.aws/cds-snc/notify-admin:64c8ae5
+    newName: public.ecr.aws/cds-snc/notify-admin:d614c30
   - name: api
     newName: public.ecr.aws/cds-snc/notify-api:50bebba
   - name: document-download-api


### PR DESCRIPTION
## What are you changing?
- [x] Releasing a new version of Notify
- [ ] Changing kubernetes configuration

## Provide some background on the changes
NOTIFICATION-ADMIN

- [Beta - Navigation overhaul (#904)](https://github.com/cds-snc/notification-admin/commit/d614c30ad22971e3d06ceb32d695e1d84477ffab)

## If you are releasing a new version of notify, what components are you updating
- [ ] API
- [x] Admin
- [ ] Document API
- [ ] Document UI

## Checklist if releasing new version:
- [x] I made sure that both API and Admin changes are present in Notify
- [x] I have checked if the docker images I am referencing exist - ex: https://gallery.ecr.aws/v6b8u5o6/notify-admin

## Checklist if making changes to Kubernetes:
- [ ] I know how to get kubectl credentials in case it catches on fire
