### PR TITLE
[AUTO-PR] Automatically generated new release 2021-03-04T14:48:01.040Z

### DIFF
--- a/env/production/kustomization.yaml
+++ b/env/production/kustomization.yaml
@@ -9,13 +9,13 @@ resources:
   - documentation-target-group.yaml
 images:
   - name: admin
-    newName: public.ecr.aws/cds-snc/notify-admin:64c8ae5
+    newName: public.ecr.aws/cds-snc/notify-admin:e1ef468
   - name: api
-    newName: public.ecr.aws/cds-snc/notify-api:50bebba
+    newName: public.ecr.aws/cds-snc/notify-api:ed3926e
   - name: document-download-api
     newName: public.ecr.aws/cds-snc/notify-document-download-api:e577c8b
   - name: document-download-frontend
-    newName: public.ecr.aws/cds-snc/notify-document-download-frontend:a21acdc
+    newName: public.ecr.aws/cds-snc/notify-document-download-frontend:6979ce6
   - name: documentation
     newName: public.ecr.aws/cds-snc/notify-documentation:b4cc499
 configMapGenerator:


### PR DESCRIPTION
## What are you changing?
- [ ] Releasing a new version of Notify
- [ ] Changing kubernetes configuration

## Provide some background on the changes
⚠️ **The production version of manifests is behind the latest staging version. Consider upgrading to the latest version before merging this pull request.** 

 NOTIFICATION-API

- [fix: removed gov.uk from error message (#1241)](https://github.com/cds-snc/notification-api/commit/ed3926e98598bace6dac04d4ca964d5c6ecf2cbd) by Quan Nguyen

NOTIFICATION-ADMIN

- [fix: hardcoding DOCUMENTATION_DOMAIN, it's now not a derivative (#919)](https://github.com/cds-snc/notification-admin/commit/e1ef468b762c78c6120e50c9d91b610f26baf609) by Quan Nguyen
- [Review and contextualize API integration section (#912)](https://github.com/cds-snc/notification-admin/commit/7a7b9bbdd19e71df46f5fecb7d43d45e21e2c287) by Anik Brazeau
- [Beta - Navigation overhaul (#904)](https://github.com/cds-snc/notification-admin/commit/d614c30ad22971e3d06ceb32d695e1d84477ffab) by dorianjp

NOTIFICATION-DOCUMENT-DOWNLOAD-API



NOTIFICATION-DOCUMENT-DOWNLOAD-FRONTEND

- [Bump node-sass version (#44)](https://github.com/cds-snc/notification-document-download-frontend/commit/6979ce69b232c8ae190f3ef31da6d487421b596b) by Antoine Augusti
- [Update AWS CLI when building container (#43)](https://github.com/cds-snc/notification-document-download-frontend/commit/dde3b6581207098044d9785af213b49c03c9bc37) by Antoine Augusti

NOTIFICATION-DOCUMENTATION



## If you are releasing a new version of notify, what components are you updating
- [ ] API
- [ ] Admin
- [ ] Document API
- [ ] Document UI

## Checklist if releasing new version:
- [ ] I made sure that both API and Admin changes are present in Notify
- [ ] I have checked if the docker images I am referencing exist - ex: https://gallery.ecr.aws/v6b8u5o6/notify-admin

## Checklist if making changes to Kubernetes:
- [ ] I know how to get kubectl credentials in case it catches on fire
