### PR TITLE
Reduce max number of Celery pods in production

### DIFF
--- a/env/production/replica_count.yaml
+++ b/env/production/replica_count.yaml
@@ -63,4 +63,4 @@ metadata:
   namespace: notification-canada-ca
 spec:
   minReplicas: 3
-  maxReplicas: 15
+  maxReplicas: 10


### PR DESCRIPTION
## What are you changing?
- [ ] Releasing a new version of Notify
- [x] Changing kubernetes configuration

## Provide some background on the changes
Lower the number of Celery pods while we work on some other performance issues related to CPU/database connections.

## Checklist if making changes to Kubernetes:
- [x] I know how to get kubectl credentials in case it catches on fire
