### PR TITLE
[AUTO-PR] Automatically generated new release 2021-03-17T13:29:56.602Z

### DIFF
--- a/env/production/kustomization.yaml
+++ b/env/production/kustomization.yaml
@@ -9,15 +9,15 @@ resources:
   - documentation-target-group.yaml
 images:
   - name: admin
-    newName: public.ecr.aws/cds-snc/notify-admin:fb726f6
+    newName: public.ecr.aws/cds-snc/notify-admin:943e2d5
   - name: api
-    newName: public.ecr.aws/cds-snc/notify-api:68e7059
+    newName: public.ecr.aws/cds-snc/notify-api:b5139d4
   - name: document-download-api
-    newName: public.ecr.aws/cds-snc/notify-document-download-api:e577c8b
+    newName: public.ecr.aws/cds-snc/notify-document-download-api:44888d9
   - name: document-download-frontend
-    newName: public.ecr.aws/cds-snc/notify-document-download-frontend:6979ce6
+    newName: public.ecr.aws/cds-snc/notify-document-download-frontend:3a650d0
   - name: documentation
-    newName: public.ecr.aws/cds-snc/notify-documentation:b4cc499
+    newName: public.ecr.aws/cds-snc/notify-documentation:c44410f
 configMapGenerator:
   - name: application-config
     env: .env

--- a/env/production/kustomization.yaml
+++ b/env/production/kustomization.yaml
@@ -9,15 +9,15 @@ resources:
   - documentation-target-group.yaml
 images:
   - name: admin
-    newName: public.ecr.aws/cds-snc/notify-admin:943e2d5
+    newName: public.ecr.aws/cds-snc/notify-admin:ebcad0f
   - name: api
-    newName: public.ecr.aws/cds-snc/notify-api:b5139d4
+    newName: public.ecr.aws/cds-snc/notify-api:68e7059
   - name: document-download-api
-    newName: public.ecr.aws/cds-snc/notify-document-download-api:44888d9
+    newName: public.ecr.aws/cds-snc/notify-document-download-api:e577c8b
   - name: document-download-frontend
-    newName: public.ecr.aws/cds-snc/notify-document-download-frontend:3a650d0
+    newName: public.ecr.aws/cds-snc/notify-document-download-frontend:6979ce6
   - name: documentation
-    newName: public.ecr.aws/cds-snc/notify-documentation:c44410f
+    newName: public.ecr.aws/cds-snc/notify-documentation:24cd5d1
 configMapGenerator:
   - name: application-config
     env: .env


### PR DESCRIPTION
## What are you changing?
- [x] Releasing a new version of Notify
- [ ] Changing kubernetes configuration

## Provide some background on the changes
⚠️ **The production version of the Terraform infrastructure is behind the latest staging version. Consider upgrading to the latest version before merging this pull request.** 

 ⚠️ **The production version of manifests is behind the latest staging version. Consider upgrading to the latest version before merging this pull request.** 

NOTIFICATION-ADMIN

- [fix: translate a section title on Why Notify (#955)](https://github.com/cds-snc/notification-admin/commit/ebcad0fbe47d444a0a46eab3cb5a3d99180e310e) by Antoine Augusti
- [Make 'trial mode' more concise when used as a descriptor (#952)](https://github.com/cds-snc/notification-admin/commit/904761007949fbf66301d1b5efe1dbd1b37a8a89) by Anik Brazeau
- [fix: Added aria-expanded attribute on menu buttons (#948)](https://github.com/cds-snc/notification-admin/commit/412659e3ae147c7c313ef315b10bfa3edf94ba33) by Jimmy Royer
- [clarify teams singular (#950)](https://github.com/cds-snc/notification-admin/commit/418ab942a63f468d5b547c8a7577c3c93b03e6e8) by Anik Brazeau
- [Missing French strings on User profile section (#951)](https://github.com/cds-snc/notification-admin/commit/0dcf0bba2f8207f56f7b3a6a78365bf247386838) by Anik Brazeau
- [Mobile menu transformed into an overlay menu (#944)](https://github.com/cds-snc/notification-admin/commit/c8ee5cc9a089db11665be7840bea198fb54dc403) by Jimmy Royer
- [fix: Removed auto focus on menu opening (#942)](https://github.com/cds-snc/notification-admin/commit/4dde70ae87f948e820c4a77ca4fb3b9ec67c60dd) by Jimmy Royer
- [Making tweaks to improve content (#945)](https://github.com/cds-snc/notification-admin/commit/a87dc791f52dbbfc0e55fbfe78991bcadbce2ab4) by Anik Brazeau
- [fix add swap img to switch services link anchor tag (#933)](https://github.com/cds-snc/notification-admin/commit/41e2098669c9b70778f7a48864a2bea78dd48cfe) by dorianjp
- [feat: redirect to your services as a platform admin (#941)](https://github.com/cds-snc/notification-admin/commit/e613385a905fcfa4e57c748dfa37c57881d18ade) by Antoine Augusti
- [fix menu button padding bleeding background color past containing div (#936)](https://github.com/cds-snc/notification-admin/commit/3d96ce8b9944abc49328a35ca13b5b006ac1d062) by dorianjp

NOTIFICATION-DOCUMENTATION

- [Point to where to request to go live in documentation (#67)](https://github.com/cds-snc/notification-documentation/commit/24cd5d155ea67e97db3bca31c0e2c642b9daef4b) by Anik Brazeau

## If you are releasing a new version of notify, what components are you updating
- [x] API
- [x] Admin
- [ ] Document API
- [ ] Document UI

## Checklist if releasing new version:
- [x] I made sure that both API and Admin changes are present in Notify
- [x] I have checked if the docker images I am referencing exist - ex: https://gallery.ecr.aws/v6b8u5o6/notify-admin

## Checklist if making changes to Kubernetes:
- [ ] I know how to get kubectl credentials in case it catches on fire
