### PR TITLE
feat: improve document download deployments

### DIFF
--- a/base/document-download-api-deployment.yaml
+++ b/base/document-download-api-deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   labels:
     app: document-download-api
-  name:  document-download-api
+  name: document-download-api
   namespace: notification-canada-ca
 spec:
   replicas: 1
@@ -11,6 +11,11 @@ spec:
   selector:
     matchLabels:
       app: document-download-api
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
   template:
     metadata:
       labels:
@@ -51,7 +56,24 @@ spec:
               value: '$(NEW_RELIC_MONITOR_MODE)'
             - name: NOTIFY_ENVIRONMENT
               value: '$(ENVIRONMENT)'
-          resources: {}
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "400Mi"
+            limits:
+              cpu: "400m"
+              memory: "800Mi"
+          ports:
+            - containerPort: 7000
+          readinessProbe:
+            httpGet:
+              path: /_status
+              port: 7000
+            initialDelaySeconds: 1
+            periodSeconds: 3
+            timeoutSeconds: 1
+            successThreshold: 3
+            failureThreshold: 10
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler

--- a/base/document-download-frontend-deployment.yaml
+++ b/base/document-download-frontend-deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   labels:
     app: document-download-frontend
-  name:  document-download-frontend
+  name: document-download-frontend
   namespace: notification-canada-ca
 spec:
   replicas: 1
@@ -54,7 +54,24 @@ spec:
               value: '$(NEW_RELIC_MONITOR_MODE)'
             - name: NOTIFY_ENVIRONMENT
               value: '$(ENVIRONMENT)'
-          resources: {}
+          resources:
+            requests:
+              cpu: "50m"
+              memory: "400Mi"
+            limits:
+              cpu: "400m"
+              memory: "800Mi"
+          ports:
+            - containerPort: 7001
+          readinessProbe:
+            httpGet:
+              path: /_status
+              port: 7001
+            initialDelaySeconds: 1
+            periodSeconds: 3
+            timeoutSeconds: 1
+            successThreshold: 3
+            failureThreshold: 10
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler


### PR DESCRIPTION
## What are you changing?
- [ ] Releasing a new version of Notify
- [x] Changing kubernetes configuration

## Provide some background on the changes

Now that we are going to start sending more attachments, make sure that those deployments are more robust:

- `RollingUpdate` strategy for deployments, for 0 downtime deployments
- Define CPU + memory `requests` and `limits` to give pods a minimum amount of resources to run
- Add `readinessProbe`s to make sure new pods are not serving trafic when the Docker container is not ready yet

## Checklist if making changes to Kubernetes:
- [x] I know how to get kubectl credentials in case it catches on fire

Trello card: https://trello.com/c/OSYe4SV2/386-make-document-download-k8s-deployments-more-robust