### PR TITLE
fix: adding ASSET_DOMAIN to the api container

### DIFF
--- a/base/api-deployment.yaml
+++ b/base/api-deployment.yaml
@@ -112,6 +112,8 @@ spec:
               value: 'http://api.notification-canada-ca.svc.cluster.local:6011'
             - name: ASSET_UPLOAD_BUCKET_NAME
               value: '$(ASSET_UPLOAD_BUCKET_NAME)'
+            - name: ASSET_DOMAIN
+              value: '$(ASSET_DOMAIN)'
             - name: AWS_PINPOINT_REGION
               value: '$(AWS_PINPOINT_REGION)'
             - name: AWS_REGION

--- a/base/api-deployment.yaml
+++ b/base/api-deployment.yaml
@@ -33,6 +33,8 @@ spec:
               value: '$(ADMIN_CLIENT_SECRET)'
             - name: ASSET_UPLOAD_BUCKET_NAME
               value: '$(ASSET_UPLOAD_BUCKET_NAME)'
+            - name: ASSET_DOMAIN
+              value: '$(ASSET_DOMAIN)'
             - name: AWS_ROUTE53_ZONE
               value: '$(AWS_ROUTE53_ZONE)'
             - name: AWS_SES_REGION


### PR DESCRIPTION
## What are you changing?
- [ ] Releasing a new version of Notify
- [x] Changing kubernetes configuration

## Provide some background on the changes
Adding ASSET_DOMAIN which is not defined within notification-api container. 
ASSET_DOMAIN within the code defaults to the production address

## If you are releasing a new version of notify, what components are you updating
- [x] API
- [ ] Admin
- [ ] Document API
- [ ] Document UI

## Checklist if releasing new version:
- [ ] I made sure that both API and Admin changes are present in Notify
- [ ] I have checked if the docker images I am referencing exist - ex: https://gallery.ecr.aws/v6b8u5o6/notify-admin

## Checklist if making changes to Kubernetes:
- [ ] I know how to get kubectl credentials in case it catches on fire
