### PR TITLE
[AUTO-PR] Automatically generated new release 2021-04-01T19:04:31.335Z

### DIFF
--- a/env/production/kustomization.yaml
+++ b/env/production/kustomization.yaml
@@ -9,15 +9,15 @@ resources:
   - documentation-target-group.yaml
 images:
   - name: admin
-    newName: public.ecr.aws/cds-snc/notify-admin:7013191
+    newName: public.ecr.aws/cds-snc/notify-admin:5a53697
   - name: api
-    newName: public.ecr.aws/cds-snc/notify-api:be5ba9f
+    newName: public.ecr.aws/cds-snc/notify-api:3db95eb
   - name: document-download-api
     newName: public.ecr.aws/cds-snc/notify-document-download-api:44888d9
   - name: document-download-frontend
     newName: public.ecr.aws/cds-snc/notify-document-download-frontend:3a650d0
   - name: documentation
-    newName: public.ecr.aws/cds-snc/notify-documentation:f65cc15
+    newName: public.ecr.aws/cds-snc/notify-documentation:d21ce0e
 configMapGenerator:
   - name: application-config
     env: .env


### PR DESCRIPTION
## What are you changing?
- [ ] Releasing a new version of Notify
- [ ] Changing kubernetes configuration

## Provide some background on the changes
NOTIFICATION-API

- [fix: handle hand crafted Notify user agents (#1257)](https://github.com/cds-snc/notification-api/commit/3db95eb950de58faeecefe0818c95c7872863d1f) by Antoine Augusti

NOTIFICATION-ADMIN

- [Live Banner / Pending live status (#975)](https://github.com/cds-snc/notification-admin/commit/5a53697585769a5d46b55ddc92687c326794f02f) by Jimmy Royer
- [Added trial status banner for service in trial mode (#962)](https://github.com/cds-snc/notification-admin/commit/c75a53cc4557e45df979139b6ec6a9400746ab1c) by Jimmy Royer

NOTIFICATION-DOCUMENT-DOWNLOAD-API



NOTIFICATION-DOCUMENT-DOWNLOAD-FRONTEND



NOTIFICATION-DOCUMENTATION

- [Document sending_method argument for files (#70)](https://github.com/cds-snc/notification-documentation/commit/d21ce0e8fd00ee8c41dcbab65e55a2ff13aa9525) by Antoine Augusti

## If you are releasing a new version of notify, what components are you updating
- [ ] API
- [ ] Admin
- [ ] Document API
- [ ] Document UI

## Checklist if releasing new version:
- [ ] I made sure that both API and Admin changes are present in Notify
- [ ] I have checked if the docker images I am referencing exist - ex: https://gallery.ecr.aws/v6b8u5o6/notify-admin

## Checklist if making changes to Kubernetes:
- [ ] I know how to get kubectl credentials in case it catches on fire
