### PR TITLE
[AUTO-PR] Automatically generated new release 2021-04-09T22:00:30.174Z

### DIFF
--- a/env/production/kustomization.yaml
+++ b/env/production/kustomization.yaml
@@ -9,7 +9,7 @@ resources:
   - documentation-target-group.yaml
 images:
   - name: admin
-    newName: public.ecr.aws/cds-snc/notify-admin:946e1af
+    newName: public.ecr.aws/cds-snc/notify-admin:8788f66
   - name: api
     newName: public.ecr.aws/cds-snc/notify-api:701a2f8
   - name: document-download-api
@@ -17,7 +17,7 @@ images:
   - name: document-download-frontend
     newName: public.ecr.aws/cds-snc/notify-document-download-frontend:7f4f8dc
   - name: documentation
-    newName: public.ecr.aws/cds-snc/notify-documentation:89abb9e
+    newName: public.ecr.aws/cds-snc/notify-documentation:d43f2b8
 configMapGenerator:
   - name: application-config
     env: .env


### PR DESCRIPTION
## What are you changing?
- [ ] Releasing a new version of Notify
- [ ] Changing kubernetes configuration

## Provide some background on the changes
NOTIFICATION-API



NOTIFICATION-ADMIN

- [Request to go live pages display messages based on request status (#976)](https://github.com/cds-snc/notification-admin/commit/8788f660de9e8b3d38b8f8ec225732d1a3e6e707) by Jimmy Royer
- [feat: remove guidance on how to send files on templates page (#980)](https://github.com/cds-snc/notification-admin/commit/db203cf885a8846a7c3222350cc53d49eb5f727e) by Antoine Augusti
- [feat: allow - and _ in Notify email addresses (#978)](https://github.com/cds-snc/notification-admin/commit/2c2df4525129ad34d9af2d08f228e956c7590405) by Antoine Augusti

NOTIFICATION-DOCUMENT-DOWNLOAD-API



NOTIFICATION-DOCUMENT-DOWNLOAD-FRONTEND



NOTIFICATION-DOCUMENTATION

- [Update docs to reflect file toggle in settings (#74)](https://github.com/cds-snc/notification-documentation/commit/d43f2b8123ca5ceddcfd8a4d72c6cae762332c27) by Anik Brazeau

## If you are releasing a new version of notify, what components are you updating
- [ ] API
- [ ] Admin
- [ ] Document API
- [ ] Document UI

## Checklist if releasing new version:
- [ ] I made sure that both API and Admin changes are present in Notify
- [ ] I have checked if the docker images I am referencing exist - ex: https://gallery.ecr.aws/v6b8u5o6/notify-admin

## Checklist if making changes to Kubernetes:
- [ ] I know how to get kubectl credentials in case it catches on fire
