### PR TITLE
feat: collect StatsD metrics more often

### DIFF
--- a/env/staging/cwagent-fluentd-quickstart.yaml
+++ b/env/staging/cwagent-fluentd-quickstart.yaml
@@ -79,8 +79,8 @@ data:
           "metrics_collected":{
             "statsd":{
                 "service_address":":8125",
-                "metrics_collection_interval":60,
-                "metrics_aggregation_interval":300
+                "metrics_collection_interval":15,
+                "metrics_aggregation_interval":60
             }
           }
       }
@@ -89,7 +89,7 @@ kind: ConfigMap
 metadata:
   name: cwagentconfig
   namespace: amazon-cloudwatch
-  
+
 ---
 
 # deploy cwagent as daemonset


### PR DESCRIPTION
## What are you changing?
- [ ] Releasing a new version of Notify
- [x] Changing kubernetes configuration

## Provide some background on the changes

Publish StatsD metrics to CW every minute instead of every 5 minutes.

Agents run on each nodes, they are collected every `metrics_collection_interval` to a single agent and aggregated/sent to CW every `metrics_aggregation_interval`.

AWS doc: https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Agent-custom-metrics-statsd.html

## Checklist if making changes to Kubernetes:
- [x] I know how to get kubectl credentials in case it catches on fire