### PR TITLE
testing cpu limit increase

### DIFF
--- a/base/celery-deployment.yaml
+++ b/base/celery-deployment.yaml
@@ -105,7 +105,7 @@ spec:
               cpu: "100m"
               memory: "500Mi"
             limits:
-              cpu: "550m"
+              cpu: "610m"
               memory: "600Mi"
       dnsPolicy: ClusterFirst
       restartPolicy: Always


### PR DESCRIPTION
## What are you changing?
- [ ] Releasing a new version of Notify
- [ x ] Changing kubernetes configuration

## Provide some background on the changes
For large email sending scenarios we see pod cpu spikes up to 98-100% for the main celery pod, which equates to 85-86% CPU capacity for the EC2 instance. Bumping up CPU pod limits to near EC2 capacity to test out email latency scenario

## If you are releasing a new version of notify, what components are you updating
- [ x ] API
- [ ] Admin
- [ ] Document API
- [ ] Document UI

## Checklist if releasing new version:
- [ ] I made sure that both API and Admin changes are present in Notify
- [ ] I have checked if the docker images I am referencing exist - ex: https://gallery.ecr.aws/v6b8u5o6/notify-admin

## Checklist if making changes to Kubernetes:
- [ x ] I know how to get kubectl credentials in case it catches on fire
