### PR TITLE
Revert to previous version of admin with a working build

### DIFF
--- a/env/production/kustomization.yaml
+++ b/env/production/kustomization.yaml
@@ -9,7 +9,7 @@ resources:
   - documentation-target-group.yaml
 images:
   - name: admin
-    newName: public.ecr.aws/cds-snc/notify-admin:d6ce98b
+    newName: public.ecr.aws/cds-snc/notify-admin:615a332
   - name: api
     newName: public.ecr.aws/cds-snc/notify-api:c5319ff
   - name: document-download-api


### PR DESCRIPTION
## What are you changing?

Latest image of admin does not work. Reverting to last image of notification-admin that built OK at this commit:
https://github.com/cds-snc/notification-admin/commit/615a33274e0f6af9c5152ad9a7d8cb39c09f72c5

This should remove these commits from the notification-admin built image:
* [update docker.yaml workflow to use setup node action (#1079)](https://github.com/cds-snc/notification-admin/commit/d6ce98bcffa611d19d5f23464f32a3dce9318f6a) by Omar Nasr
* [Add more help for installing python (#1077)](https://github.com/cds-snc/notification-admin/commit/6592449133b8bf3baaf63d0ef25aed90166a9486) by Steve Astels

## If you are releasing a new version of notify, what components are you updating
- [ ] API
- [x] Admin
- [ ] Documentation
- [ ] Document API
- [ ] Document UI

## Checklist if releasing new version:
- [ ] I made sure that both API and Admin changes are present in Notify
- [ ] I have checked if the docker images I am referencing exist - ex: https://gallery.ecr.aws/v6b8u5o6/notify-admin

## Checklist if making changes to Kubernetes:
- [ ] I know how to get kubectl credentials in case it catches on fire
