### PR TITLE
Bump production to 0.37.3

### DIFF
--- a/env/production/kustomization.yaml
+++ b/env/production/kustomization.yaml
@@ -1,5 +1,5 @@
 bases:
-  - github.com/cds-snc/notification-manifests//base?ref=v0.37.0
+  - github.com/cds-snc/notification-manifests//base?ref=v0.37.3
 resources:
   - cwagent-fluentd-quickstart.yaml
   - api-target-group.yaml


### PR DESCRIPTION
## Provide some background on the changes

The bump includes these changes:

* https://github.com/cds-snc/notification-manifests/pull/494
* https://github.com/cds-snc/notification-manifests/pull/535
* https://github.com/cds-snc/notification-manifests/pull/568

Most of these changes were applied directly to both staging and production, as these were mostly environment variables manipulation. These are not versioned under `kubectl` bases, which includes a revision. So this is mostly a symbolic upgrade.

## If you are releasing a new version of notify, what components are you updating
- [ ] API
- [ ] Admin
- [ ] Documentation
- [ ] Document API
- [ ] Document UI

## Checklist if releasing new version:
- [ ] I made sure that both API and Admin changes are present in Notify
- [ ] I have checked if the docker images I am referencing exist - ex: https://gallery.ecr.aws/v6b8u5o6/notify-admin

## Checklist if making changes to Kubernetes:
- [ ] I know how to get kubectl credentials in case it catches on fire
