### PR TITLE
Revert previous deployment of API

### DIFF
--- a/env/production/kustomization.yaml
+++ b/env/production/kustomization.yaml
@@ -11,7 +11,7 @@ images:
   - name: admin
     newName: public.ecr.aws/cds-snc/notify-admin:5dac7d3
   - name: api
-    newName: public.ecr.aws/cds-snc/notify-api:55a35f1
+    newName: public.ecr.aws/cds-snc/notify-api:ce27097
   - name: document-download-api
     newName: public.ecr.aws/cds-snc/notify-document-download-api:e6800c9
   - name: document-download-frontend


### PR DESCRIPTION
We are having tons of celery error at the moment. Reverting previous release.

## What are you changing?
- [ ] Releasing a new version of Notify
- [ ] Changing kubernetes configuration

## Provide some background on the changes
> Give details ex. Security patching, content update, more API pods etc

## If you are releasing a new version of notify, what components are you updating
- [ ] API
- [ ] Admin
- [ ] Documentation
- [ ] Document API
- [ ] Document UI

## Checklist if releasing new version:
- [ ] I made sure that both API and Admin changes are present in Notify
- [ ] I have checked if the docker images I am referencing exist - ex: https://gallery.ecr.aws/v6b8u5o6/notify-admin

## Checklist if making changes to Kubernetes:
- [ ] I know how to get kubectl credentials in case it catches on fire
