### PR TITLE
fix: adding variable to application container

### DIFF
--- a/base/api-deployment.yaml
+++ b/base/api-deployment.yaml
@@ -204,6 +204,8 @@ spec:
               value: 'https://api.getbase.com'
             - name: ZENDESK_SELL_API_KEY
               value: '$(ZENDESK_SELL_API_KEY)'
+            - name: FF_NOTIFICATION_CELERY_PERSISTENCE
+              value: '$(FF_NOTIFICATION_CELERY_PERSISTENCE)'
           resources:
             requests:
               cpu: "400m"


### PR DESCRIPTION
## What are you changing?
- [ ] Releasing a new version of Notify
- [ ] Changing kubernetes configuration

## Provide some background on the changes
I made an oopsie and realised I added the variable to the init container but not the application one. So I fixed that

## If you are releasing a new version of notify, what components are you updating
- [ ] API
- [ ] Admin
- [ ] Documentation
- [ ] Document API
- [ ] Document UI

## Checklist if releasing new version:
- [ ] I made sure that both API and Admin changes are present in Notify
- [ ] I have checked if the docker images I am referencing exist - ex: https://gallery.ecr.aws/v6b8u5o6/notify-admin

## Checklist if making changes to Kubernetes:
- [ ] I know how to get kubectl credentials in case it catches on fire
