### PR TITLE
feat: Detach the database check from the k8s readiness probe

### DIFF
--- a/base/admin-deployment.yaml
+++ b/base/admin-deployment.yaml
@@ -105,7 +105,7 @@ spec:
             - containerPort: 6012
           readinessProbe:
             httpGet:
-              path: /_status
+              path: /_status?simple=true
               port: 6012
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/base/api-deployment.yaml
+++ b/base/api-deployment.yaml
@@ -217,7 +217,7 @@ spec:
             - containerPort: 6011
           readinessProbe:
             httpGet:
-              path: /_status
+              path: /_status?simple=true
               port: 6011
             initialDelaySeconds: 10
             periodSeconds: 3


### PR DESCRIPTION
## What are you changing?

Tweaking the readiness probe for both admin and API components to remove the database check. For now, removing it will prevent these to go down if the database is slowed to a point that the components can't reply in a timely manner. The API component especially should not go down and stop processing because the database is in `autovacuum` processing.

More details in the [ADR for the database bottleneck](https://github.com/cds-snc/notification-adr/pull/1).

## Provide some background on the changes
> Give details ex. Security patching, content update, more API pods etc

## If you are releasing a new version of notify, what components are you updating
- [ ] API
- [ ] Admin
- [ ] Documentation
- [ ] Document API
- [ ] Document UI

## Checklist if releasing new version:
- [ ] I made sure that both API and Admin changes are present in Notify
- [ ] I have checked if the docker images I am referencing exist - ex: https://gallery.ecr.aws/v6b8u5o6/notify-admin

## Checklist if making changes to Kubernetes:
- [ ] I know how to get kubectl credentials in case it catches on fire
