### PR TITLE
Bumping manifest version

### DIFF
--- a/env/production/kustomization.yaml
+++ b/env/production/kustomization.yaml
@@ -1,5 +1,5 @@
 bases:
-  - github.com/cds-snc/notification-manifests//base?ref=v0.37.3
+  - github.com/cds-snc/notification-manifests//base?ref=v0.39.1
 resources:
   - cwagent-fluentd-quickstart.yaml
   - api-target-group.yaml


### PR DESCRIPTION
Includes following changes:

* [feat: enable feature flag for notification persistence in celery for staging environment](https://github.com/cds-snc/notification-manifests/pull/569)
* [fix: notification persistence feature flag typo](https://github.com/cds-snc/notification-manifests/pull/578)
* [fix: adding variable to application container](https://github.com/cds-snc/notification-manifests/pull/586)
* [feat: Detach the database check from the k8s readiness probe](https://github.com/cds-snc/notification-manifests/pull/602)
* [fix cannot have missing env variables](https://github.com/cds-snc/notification-manifests/pull/606)
