### PR TITLE
Revert "lower max celery workers (#634)"

### DIFF
--- a/env/staging/replica_count.yaml
+++ b/env/staging/replica_count.yaml
@@ -63,7 +63,7 @@ metadata:
   namespace: notification-canada-ca
 spec:
   minReplicas: 3
-  maxReplicas: 5
+  maxReplicas: 10
 ---
 apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler


### PR DESCRIPTION
## What are you changing?

This reverts commit d8f25e0069addd11b64373126f158eb054d10321.

Part of Omar's testing in staging involved seeing if reducing the number of celery workers would reduce database reads and transitively reduce the read loads experienced in staging. We should eventually revert this test to re-align with what we have in production, unless we decide to change the latter as well.

## Checklist if releasing new version:
- [ ] I made sure that both API and Admin changes are present in Notify
- [ ] I have checked if the docker images I am referencing exist - ex: https://gallery.ecr.aws/v6b8u5o6/notify-admin

## Checklist if making changes to Kubernetes:
- [ ] I know how to get kubectl credentials in case it catches on fire
