### PR TITLE
Revert to previous API release #2f0eb99

### DIFF
--- a/env/production/kustomization.yaml
+++ b/env/production/kustomization.yaml
@@ -11,7 +11,7 @@ images:
   - name: admin
     newName: public.ecr.aws/cds-snc/notify-admin:58239a3
   - name: api
-    newName: public.ecr.aws/cds-snc/notify-api:0a3e873
+    newName: public.ecr.aws/cds-snc/notify-api:2f0eb99
   - name: document-download-api
     newName: public.ecr.aws/cds-snc/notify-document-download-api:95d88f3
   - name: document-download-frontend


### PR DESCRIPTION
## What are you changing?

Reverting to previous release of 2f0eb99 for the notification API after we observe that a queue is blocked. It seems a `None` value slips through for the queue to use. We are still investigating why but we are proceeding to the revert to unblock SMS sent through CSV uploads in production. 


## If you are releasing a new version of notify, what components are you updating
- [ ] API
- [ ] Admin
- [ ] Documentation
- [ ] Document API
- [ ] Document UI

## Checklist if releasing new version:
- [ ] I made sure that both API and Admin changes are present in Notify
- [ ] I have checked if the docker images I am referencing exist - ex: https://gallery.ecr.aws/v6b8u5o6/notify-admin

## Checklist if making changes to Kubernetes:
- [ ] I know how to get kubectl credentials in case it catches on fire
