### PR TITLE
Release api lambda

### DIFF
--- a/.github/workflows/merge_to_main_production.yaml
+++ b/.github/workflows/merge_to_main_production.yaml
@@ -8,6 +8,9 @@ on:
       - ".github/workflows/merge_to_main_production.yaml"
       - "env/production/**"
 
+env:
+  REGISTRY: ${{ secrets.AWS_ACCOUNT }}.dkr.ecr.ca-central-1.amazonaws.com/notify
+
 defaults:
   run:
     shell: bash
@@ -48,11 +51,11 @@ jobs:
         run: |
           kubectl apply -k env/production --kubeconfig=/home/runner/.kube/config
 
-      - name: Copy api-lambda image from public ECR
-
-      - name: tag api-lambda image and push to private ECR
-
-      - name: Deploy api-lambda function with new image
+      - name: Deploy lambda
+        run: |
+          aws lambda update-function-code \
+            --function-name api-lambda \
+            --image-uri $REGISTRY/api-lambda:release
 
       - name: Add deployment to New Relic
         run: |

--- a/.github/workflows/merge_to_main_production.yaml
+++ b/.github/workflows/merge_to_main_production.yaml
@@ -48,6 +48,12 @@ jobs:
         run: |
           kubectl apply -k env/production --kubeconfig=/home/runner/.kube/config
 
+      - name: Copy api-lambda image from public ECR
+
+      - name: tag api-lambda image and push to private ECR
+
+      - name: Deploy api-lambda function with new image
+
       - name: Add deployment to New Relic
         run: |
           for application_id in 283469061 283468826 283468685; do

--- a/.github/workflows/merge_to_main_production.yaml
+++ b/.github/workflows/merge_to_main_production.yaml
@@ -9,7 +9,8 @@ on:
       - "env/production/**"
 
 env:
-  REGISTRY: ${{ secrets.PRODUCTION_AWS_ACCOUNT }}.dkr.ecr.ca-central-1.amazonaws.com/notify
+  PRIVATE_ECR: ${{ secrets.PRODUCTION_AWS_ACCOUNT }}.dkr.ecr.ca-central-1.amazonaws.com/notify
+  API_LAMBDA_IMAGE: api-lambda:d2e091e
 
 defaults:
   run:
@@ -55,7 +56,7 @@ jobs:
         run: |
           aws lambda update-function-code \
             --function-name api-lambda \
-            --image-uri $REGISTRY/api-lambda:d2e091e
+            --image-uri $PRIVATE_ECR/$API_LAMBDA_IMAGE
 
       - name: Add deployment to New Relic
         run: |

--- a/.github/workflows/merge_to_main_production.yaml
+++ b/.github/workflows/merge_to_main_production.yaml
@@ -9,7 +9,7 @@ on:
       - "env/production/**"
 
 env:
-  REGISTRY: ${{ secrets.AWS_ACCOUNT }}.dkr.ecr.ca-central-1.amazonaws.com/notify
+  REGISTRY: ${{ secrets.PRODUCTION_AWS_ACCOUNT }}.dkr.ecr.ca-central-1.amazonaws.com/notify
 
 defaults:
   run:

--- a/.github/workflows/merge_to_main_production.yaml
+++ b/.github/workflows/merge_to_main_production.yaml
@@ -55,7 +55,7 @@ jobs:
         run: |
           aws lambda update-function-code \
             --function-name api-lambda \
-            --image-uri $REGISTRY/api-lambda:release
+            --image-uri $REGISTRY/api-lambda:d2e091e
 
       - name: Add deployment to New Relic
         run: |


### PR DESCRIPTION
## What are you changing?
Change action to deploy api lambda to production

## Provide some background on the changes
Action changes needed for the new api lambda

## If you are releasing a new version of notify, what components are you updating
- [ ] API
- [ ] Admin
- [ ] Documentation
- [ ] Document API
- [ ] Document UI
- [x] API Lambda

## Checklist if releasing new version:
- [ ] I made sure that both API and Admin changes are present in Notify
- [x] I have checked if the docker images I am referencing exist - ex: https://gallery.ecr.aws/v6b8u5o6/notify-admin

## Checklist if making changes to Kubernetes:
- [ ] I know how to get kubectl credentials in case it catches on fire
