### PR TITLE
SJA TEST [AUTO-PR] Automatically generated new release 2021-11-17T18:58:06.441Z

### DIFF
--- a/.github/workflows/merge_to_main_production.yaml
+++ b/.github/workflows/merge_to_main_production.yaml
@@ -10,7 +10,7 @@ on:
 
 env:
   PRIVATE_ECR: ${{ secrets.PRODUCTION_AWS_ACCOUNT }}.dkr.ecr.ca-central-1.amazonaws.com/notify
-  API_LAMBDA_IMAGE: api-lambda:d2e091e
+  API_LAMBDA_IMAGE: api-lambda:8b33d6e
 
 defaults:
   run:

--- a/env/production/kustomization.yaml
+++ b/env/production/kustomization.yaml
@@ -9,9 +9,9 @@ resources:
   - documentation-target-group.yaml
 images:
   - name: admin
-    newName: public.ecr.aws/cds-snc/notify-admin:894b52e
+    newName: public.ecr.aws/cds-snc/notify-admin:22462ca
   - name: api
-    newName: public.ecr.aws/cds-snc/notify-api:fe4ea28
+    newName: public.ecr.aws/cds-snc/notify-api:8b33d6e
   - name: document-download-api
     newName: public.ecr.aws/cds-snc/notify-document-download-api:e79edf7
   - name: document-download-frontend


### PR DESCRIPTION
## What are you changing?
- [ ] Releasing a new version of Notify
- [ ] Changing kubernetes configuration

## Provide some background on the changes
⚠️ **The production version of the Terraform infrastructure is behind the latest staging version. Consider upgrading to the latest version before merging this pull request.** 

 ⚠️ **The production version of manifests is behind the latest staging version. Consider upgrading to the latest version before merging this pull request.** 

 NOTIFICATION-API

- [Just use start of gitsha for the lambda image tags (#1399)](https://github.com/cds-snc/notification-api/commit/8b33d6ec6a54525086d37f942295d05b4b624e1f) by Steve Astels

NOTIFICATION-ADMIN

- [Accessible names for template bulk selection checkboxes (#1196)](https://github.com/cds-snc/notification-admin/commit/22462ca75572397c60d31de55d6a76acc7fa084c) by Philippe Caron
- [descriptive link text for service settings (#1185)](https://github.com/cds-snc/notification-admin/commit/78e371c621a1cf36a4783bec5daa74a54fe37aab) by Philippe Caron
- [Contact us. More helpful error messages (#1198)](https://github.com/cds-snc/notification-admin/commit/e6f593cd94ddddb1f4427b831af6bc99347d9032) by Philippe Caron

NOTIFICATION-DOCUMENT-DOWNLOAD-API



NOTIFICATION-DOCUMENT-DOWNLOAD-FRONTEND



NOTIFICATION-DOCUMENTATION



## If you are releasing a new version of notify, what components are you updating
- [ ] API
- [ ] Admin
- [ ] Documentation
- [ ] Document API
- [ ] Document UI

## Checklist if releasing new version:
- [ ] I made sure that both API and Admin changes are present in Notify
- [ ] I have checked if the docker images I am referencing exist - ex: https://gallery.ecr.aws/v6b8u5o6/notify-admin

## Checklist if making changes to Kubernetes:
- [ ] I know how to get kubectl credentials in case it catches on fire
