### PR TITLE
Removed redirection to /dev/null for kubectl kustomize command.

### DIFF
--- a/.github/workflows/syntax_check.yaml
+++ b/.github/workflows/syntax_check.yaml
@@ -14,4 +14,4 @@ jobs:
 
       - name: Run manifest build
         run: |
-          make staging-debug > /dev/null 2>&1
+          make staging-debug


### PR DESCRIPTION
## What are you changing?

Removed redirection to /dev/null for kubectl customize command.

## Provide some background on the changes

We could not quickly assess the reason for the failed build following the `kubectl kustomize`  command from that build. We would like to have all the output for now even if that is a long output. Better than silence.

## If you are releasing a new version of notify, what components are you updating
- [ ] API
- [ ] Admin
- [ ] Documentation
- [ ] Document API
- [ ] Document UI

## Checklist if releasing new version:
- [ ] I made sure that both API and Admin changes are present in Notify
- [ ] I have checked if the docker images I am referencing exist - ex: https://gallery.ecr.aws/v6b8u5o6/notify-admin

## Checklist if making changes to Kubernetes:
- [ ] I know how to get kubectl credentials in case it catches on fire
