### PR TITLE
[AUTO-PR] Automatically generated new release 2022-01-12T15:50:22.088Z

### DIFF
--- a/.github/workflows/merge_to_main_production.yaml
+++ b/.github/workflows/merge_to_main_production.yaml
@@ -10,7 +10,7 @@ on:
 
 env:
   PRIVATE_ECR: ${{ secrets.PRODUCTION_AWS_ACCOUNT }}.dkr.ecr.ca-central-1.amazonaws.com/notify
-  API_LAMBDA_IMAGE: api-lambda:60774a2
+  API_LAMBDA_IMAGE: api-lambda:578c65b
 
 defaults:
   run:

--- a/env/production/kustomization.yaml
+++ b/env/production/kustomization.yaml
@@ -9,13 +9,13 @@ resources:
   - documentation-target-group.yaml
 images:
   - name: admin
-    newName: public.ecr.aws/cds-snc/notify-admin:03ec05a
+    newName: public.ecr.aws/cds-snc/notify-admin:ca390c1
   - name: api
-    newName: public.ecr.aws/cds-snc/notify-api:b1c1064
+    newName: public.ecr.aws/cds-snc/notify-api:578c65b
   - name: document-download-api
-    newName: public.ecr.aws/cds-snc/notify-document-download-api:bdff763
+    newName: public.ecr.aws/cds-snc/notify-document-download-api:71932ff
   - name: document-download-frontend
-    newName: public.ecr.aws/cds-snc/notify-document-download-frontend:04e5355
+    newName: public.ecr.aws/cds-snc/notify-document-download-frontend:9a26e73
   - name: documentation
     newName: public.ecr.aws/cds-snc/notify-documentation:adb6372
 configMapGenerator:


### PR DESCRIPTION
## What are you changing?
- [ ] Releasing a new version of Notify
- [ ] Changing kubernetes configuration

## Provide some background on the changes
⚠️ **The production version of the Terraform infrastructure is behind the latest staging version. Consider upgrading to the latest version before merging this pull request.** 

 ⚠️ **The production version of manifests is behind the latest staging version. Consider upgrading to the latest version before merging this pull request.** 

 NOTIFICATION-API

- [Increased log around notifications to get used queue (#1429)](https://github.com/cds-snc/notification-api/commit/578c65b98b6e6b2c755ac75abcf5ca5992fbb2e2) by Jimmy Royer

NOTIFICATION-ADMIN

- [Add feature to pull page content and navigation from GC Articles (#1210)](https://github.com/cds-snc/notification-admin/commit/ca390c1bc21ff367629b36ed044e56523b619a12) by Tim Arney

NOTIFICATION-DOCUMENT-DOWNLOAD-API

- [Removed previous pr bot secrets and usage (#55)](https://github.com/cds-snc/notification-document-download-api/commit/71932ff69f0348f69b033d94a570a98e49a66dfa) by Jimmy Royer
- [Added waffle step in push workflow (#51)](https://github.com/cds-snc/notification-document-download-api/commit/23e8fecc80046522c92b88968caf7b534d1c1d42) by Jimmy Royer

NOTIFICATION-DOCUMENT-DOWNLOAD-FRONTEND

- [Removed previous pr bot secrets and usage (#78)](https://github.com/cds-snc/notification-document-download-frontend/commit/9a26e7327f873f03b2a83736f314572d5d69ad18) by Jimmy Royer

NOTIFICATION-DOCUMENTATION



## If you are releasing a new version of Notify, what components are you updating
- [ ] API
- [ ] Admin
- [ ] Documentation
- [ ] Document download API
- [ ] Document download frontend

## Checklist if releasing new version:
- [ ] I made sure that the changes are as expected in [Notify staging](https://staging.notification.cdssandbox.xyz/)
- [ ] I have checked if the docker images I am referencing exist
    - [ ] [api lambda](https://ca-central-1.console.aws.amazon.com/ecr/repositories/private/296255494825/notify/api-lambda?region=ca-central-1) (requires Notification-Production / AdministratorAccess login)
    - [ ] [api k8s](https://gallery.ecr.aws/v6b8u5o6/notify-api)
    - [ ] [admin](https://gallery.ecr.aws/v6b8u5o6/notify-admin)
    - [ ] [documentation](https://gallery.ecr.aws/v6b8u5o6/notify-documentation)
    - [ ] [document download API](https://gallery.ecr.aws/v6b8u5o6/notify-document-download-api)
    - [ ] [document download frontend](https://gallery.ecr.aws/v6b8u5o6/notify-document-download-frontend)

## Checklist if making changes to Kubernetes:
- [ ] I know how to get kubectl credentials in case it catches on fire

## After merging this PR
- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.