### PR TITLE
Reset the API HPA to previous values, 4min/8max scalability

### DIFF
--- a/env/production/replica_count.yaml
+++ b/env/production/replica_count.yaml
@@ -45,7 +45,7 @@ metadata:
   namespace: notification-canada-ca
 spec:
   minReplicas: 2
-  maxReplicas: 2
+  maxReplicas: 3
 ---
 apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
@@ -54,7 +54,7 @@ metadata:
   namespace: notification-canada-ca
 spec:
   minReplicas: 4
-  maxReplicas: 4
+  maxReplicas: 8
 ---
 apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
@@ -72,4 +72,4 @@ metadata:
   namespace: notification-canada-ca
 spec:
   minReplicas: 1
-  maxReplicas: 1
+  maxReplicas: 2


### PR DESCRIPTION
## What are you changing?
- [ ] Releasing a new version of Notify
- [x] Changing kubernetes configuration

## Provide some background on the changes

We went through an incident this week where two clients hit the API hard for a short amount of time, possibly the root cause of bringing the API Kubernetes pod instances into an out of memory state. This caused restarts and a few messages to be dropped (around 20-25 observed in AWS CloudWatch / Logs Insights).

![image](https://user-images.githubusercontent.com/805567/152414766-980f0386-15b7-4842-90c1-edf6b1c62c8d.png)

![image](https://user-images.githubusercontent.com/805567/152414662-ad8f1ade-cabc-41eb-9e3e-3beb48de4312.png)

## If you are releasing a new version of Notify, what components are you updating
- [x] API
- [x] Admin
- [ ] Documentation
- [ ] Document download API
- [ ] Document download frontend

## Checklist if releasing new version:
- [ ] I made sure that the changes are as expected in [Notify staging](https://staging.notification.cdssandbox.xyz/)
- [ ] I have checked if the docker images I am referencing exist
    - [ ] [api lambda](https://ca-central-1.console.aws.amazon.com/ecr/repositories/private/296255494825/notify/api-lambda?region=ca-central-1) (requires Notification-Production / AdministratorAccess login)
    - [ ] [api k8s](https://gallery.ecr.aws/v6b8u5o6/notify-api)
    - [ ] [admin](https://gallery.ecr.aws/v6b8u5o6/notify-admin)
    - [ ] [documentation](https://gallery.ecr.aws/v6b8u5o6/notify-documentation)
    - [ ] [document download API](https://gallery.ecr.aws/v6b8u5o6/notify-document-download-api)
    - [ ] [document download frontend](https://gallery.ecr.aws/v6b8u5o6/notify-document-download-frontend)

## Checklist if making changes to Kubernetes:
- [ ] I know how to get kubectl credentials in case it catches on fire

## After merging this PR
- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.