### PR TITLE
[AUTO-PR] Automatically generated new release 2022-02-16T00:07:38.654Z

### DIFF
--- a/.github/workflows/merge_to_main_production.yaml
+++ b/.github/workflows/merge_to_main_production.yaml
@@ -10,7 +10,7 @@ on:
 
 env:
   PRIVATE_ECR: ${{ secrets.PRODUCTION_AWS_ACCOUNT }}.dkr.ecr.ca-central-1.amazonaws.com/notify
-  API_LAMBDA_IMAGE: api-lambda:b7a8ae8
+  API_LAMBDA_IMAGE: api-lambda:a84a71d
 
 defaults:
   run:

--- a/env/production/kustomization.yaml
+++ b/env/production/kustomization.yaml
@@ -9,9 +9,9 @@ resources:
   - documentation-target-group.yaml
 images:
   - name: admin
-    newName: public.ecr.aws/cds-snc/notify-admin:9fef358
+    newName: public.ecr.aws/cds-snc/notify-admin:8ebdd18
   - name: api
-    newName: public.ecr.aws/cds-snc/notify-api:b7a8ae8
+    newName: public.ecr.aws/cds-snc/notify-api:a84a71d
   - name: document-download-api
     newName: public.ecr.aws/cds-snc/notify-document-download-api:7cc62c8
   - name: document-download-frontend


### PR DESCRIPTION
## What are you changing?
- [ ] Releasing a new version of Notify
- [ ] Changing kubernetes configuration

## Provide some background on the changes
⚠️ **The production version of manifests is behind the latest staging version. Consider upgrading to the latest version before merging this pull request.** 

 NOTIFICATION-API

- [Increased cache TTL for daily service limit to 2h (#1464)](https://github.com/cds-snc/notification-api/commit/a84a71ddd3309abefdcbdeb13d9f199211941ec2) by Jimmy Royer
- [Periodic Transition of expired In-Flight SMS/Email (#1456)](https://github.com/cds-snc/notification-api/commit/ba7212a91d484e1face2e4ffbbb9a02731f3340f) by Ikenna
- [Fix the database slow loading of total notifications for a service (#1462)](https://github.com/cds-snc/notification-api/commit/5d3d8b602a1ad4b91cfb35105f48372bbe3e08a8) by Jimmy Royer
- [Move old queue inflights back to the inbox (#1457)](https://github.com/cds-snc/notification-api/commit/ac73b4fb169bc0448ac2d1d76f76ca1b366d516a) by Steve Astels
- [feat: switch to /bin/zsh in devcontainer (#1463)](https://github.com/cds-snc/notification-api/commit/bc0be9042e67abae73fbd7eece711fcdf17cdeb1) by Pat Heard
- [feat: add kubectl to devcontainer (#1461)](https://github.com/cds-snc/notification-api/commit/088788d3e8a109d78b95a675e00c2bf839cf1b9c) by Pat Heard
- [fix: update how devcontainer is initialized (#1460)](https://github.com/cds-snc/notification-api/commit/e3749b469d7f9044ccb6ebceeda92fa1841fefcb) by Pat Heard
- [fix: devcontainer and pytest updates to allow tests to run successfully (#1459)](https://github.com/cds-snc/notification-api/commit/60a040e26febb3b28fd37cf77a26e3be4ebee201) by Mohamed Nur
- [fix: setup of devcontainer (#1455)](https://github.com/cds-snc/notification-api/commit/f1a16295a9565529c9ed2c8f7b31369be0c125cd) by Pat Heard
- [Refactored dao_fetch_service_by_id without tuple return (#1452)](https://github.com/cds-snc/notification-api/commit/980a0bed18a0ad79f56b53edf03122bcb863f410) by Jimmy Royer
- [Add suffix to inflight list (#1451)](https://github.com/cds-snc/notification-api/commit/38e158fb2f37a5fa7b88e05ae56ca5ceb5bd166b) by Jumana B
- [Renaming encryption to signer (#1449)](https://github.com/cds-snc/notification-api/commit/9461b26f9582bdea6fe7c68b3d360597e5eab9ba) by Jimmy Royer
- [don't overwrite notification id (#1450)](https://github.com/cds-snc/notification-api/commit/91d3eae52116b808b2bcf28f324456ff61c423b0) by Steve Astels
- [bug/check for tuple in service (#1448)](https://github.com/cds-snc/notification-api/commit/1250e6a4755591485158e6cabc7745e0b2807a44) by Steve Astels
- [fix the things (#1447)](https://github.com/cds-snc/notification-api/commit/dca8cd5865fdfe5e1f8833d1415f5854bdcf6ca4) by Steve Astels
- [Add the heartbeat code for the queues - email/sms (#1445)](https://github.com/cds-snc/notification-api/commit/c843d7903a2d9f29af5a6d545496f6d2d9146526) by Jumana B
- [Batch saving: Redis inflight worker (#1444)](https://github.com/cds-snc/notification-api/commit/b3b8e8c4ac7102b89196b9f89762ca269f12d0d3) by Steve Astels
- [Batch saving: push to redis queue in post (#1440)](https://github.com/cds-snc/notification-api/commit/c8e860fed5691785b749a6ee87e9eca68cb966b6) by Steve Astels
- [Queue implementation for batch saving (#1442)](https://github.com/cds-snc/notification-api/commit/b64a243af769c79c3463dc78a57e49747d3295f3) by Jimmy Royer
- [Serial exec for tests (#1446)](https://github.com/cds-snc/notification-api/commit/8eaa8b8421ee08c5145c4fd77b8fa225e85b5a6a) by Jimmy Royer

NOTIFICATION-ADMIN

- [added dynamic section at the end of homepage only (#1228)](https://github.com/cds-snc/notification-admin/commit/8ebdd186f45bdefea491aa8e982b7a79b41f2c42) by Philippe Caron
- [Try again if API slug returns 404 (#1227)](https://github.com/cds-snc/notification-admin/commit/608cd9024532628ef8d68016989c78c122d7af1a) by Paul Craig
- [Homepage styles and editor experience (#1223)](https://github.com/cds-snc/notification-admin/commit/003262dcbc148baaf43b066f44c7616587fbfe00) by Philippe Caron
- [Language switcher for pages being returned from the API (#1225)](https://github.com/cds-snc/notification-admin/commit/757545a16148fe2899b44d434caf75eb3405e23a) by Paul Craig

NOTIFICATION-DOCUMENT-DOWNLOAD-API



NOTIFICATION-DOCUMENT-DOWNLOAD-FRONTEND



NOTIFICATION-DOCUMENTATION



## If you are releasing a new version of Notify, what components are you updating
- [ ] API
- [ ] Admin
- [ ] Documentation
- [ ] Document download API
- [ ] Document download frontend

## Checklist if releasing new version:
- [ ] I made sure that the changes are as expected in [Notify staging](https://staging.notification.cdssandbox.xyz/)
- [ ] I have checked if the docker images I am referencing exist
    - [ ] [api lambda](https://ca-central-1.console.aws.amazon.com/ecr/repositories/private/296255494825/notify/api-lambda?region=ca-central-1) (requires Notification-Production / AdministratorAccess login)
    - [ ] [api k8s](https://gallery.ecr.aws/v6b8u5o6/notify-api)
    - [ ] [admin](https://gallery.ecr.aws/v6b8u5o6/notify-admin)
    - [ ] [documentation](https://gallery.ecr.aws/v6b8u5o6/notify-documentation)
    - [ ] [document download API](https://gallery.ecr.aws/v6b8u5o6/notify-document-download-api)
    - [ ] [document download frontend](https://gallery.ecr.aws/v6b8u5o6/notify-document-download-frontend)

## Checklist if making changes to Kubernetes:
- [ ] I know how to get kubectl credentials in case it catches on fire

## After merging this PR
- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.