### PR TITLE
feat: new cloudwatch agent emf service address

### DIFF
--- a/env/staging/cwagent-fluentd-quickstart.yaml
+++ b/env/staging/cwagent-fluentd-quickstart.yaml
@@ -82,7 +82,9 @@ data:
                 "metrics_collection_interval":15,
                 "metrics_aggregation_interval":60
             },
-            "emf": { }
+            "emf": {
+                "service_address":":25888",
+            }
           }
       }
     }

--- a/env/staging/cwagent-fluentd-quickstart.yaml
+++ b/env/staging/cwagent-fluentd-quickstart.yaml
@@ -83,7 +83,7 @@ data:
                 "metrics_aggregation_interval":60
             },
             "emf": {
-                "service_address":":25888",
+                "service_address":":8135",
             }
           }
       }


### PR DESCRIPTION
## What are you changing?
- [ ] Releasing a new version of Notify
- [X] Changing kubernetes configuration

## Provide some background on the changes
> Currently CloudWatch emf is using the same port as the STATSD. This is causing parsing errors since the CloudWatch agent cannot automatically distinguish between emf and statsd logs. The CloudWatch agent will now listen for emf logs on port `8135`

## If you are releasing a new version of Notify, what components are you updating
- [ ] API
- [ ] Admin
- [ ] Documentation
- [ ] Document download API
- [ ] Document download frontend

## Checklist if releasing new version:
- [ ] I made sure that the changes are as expected in [Notify staging](https://staging.notification.cdssandbox.xyz/)
- [ ] I have checked if the docker images I am referencing exist
    - [ ] [api lambda](https://ca-central-1.console.aws.amazon.com/ecr/repositories/private/296255494825/notify/api-lambda?region=ca-central-1) (requires Notification-Production / AdministratorAccess login)
    - [ ] [api k8s](https://gallery.ecr.aws/v6b8u5o6/notify-api)
    - [ ] [admin](https://gallery.ecr.aws/v6b8u5o6/notify-admin)
    - [ ] [documentation](https://gallery.ecr.aws/v6b8u5o6/notify-documentation)
    - [ ] [document download API](https://gallery.ecr.aws/v6b8u5o6/notify-document-download-api)
    - [ ] [document download frontend](https://gallery.ecr.aws/v6b8u5o6/notify-document-download-frontend)

## Checklist if making changes to Kubernetes:
- [ ] I know how to get kubectl credentials in case it catches on fire

## After merging this PR
- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.