### PR TITLE
feat: cloudwatch agent listen for emf (prod)

### DIFF
--- a/env/production/cwagent-fluentd-quickstart.yaml
+++ b/env/production/cwagent-fluentd-quickstart.yaml
@@ -81,7 +81,8 @@ data:
                 "service_address":":8125",
                 "metrics_collection_interval":15,
                 "metrics_aggregation_interval":60
-            }
+            },
+            "emf": { }
           }
       }
     }


### PR DESCRIPTION
## What are you changing?
- [ ] Releasing a new version of Notify
- [X] Changing kubernetes configuration

## Provide some background on the changes
> Enable CloudWatch embedded listener service in production.

## If you are releasing a new version of Notify, what components are you updating
- [ ] API
- [ ] Admin
- [ ] Documentation
- [ ] Document download API
- [ ] Document download frontend

## Checklist if releasing new version:
- [ ] I made sure that the changes are as expected in [Notify staging](https://staging.notification.cdssandbox.xyz/)
- [ ] I have checked if the docker images I am referencing exist
    - [ ] [api lambda](https://ca-central-1.console.aws.amazon.com/ecr/repositories/private/296255494825/notify/api-lambda?region=ca-central-1) (requires Notification-Production / AdministratorAccess login)
    - [ ] [api k8s](https://gallery.ecr.aws/v6b8u5o6/notify-api)
    - [ ] [admin](https://gallery.ecr.aws/v6b8u5o6/notify-admin)
    - [ ] [documentation](https://gallery.ecr.aws/v6b8u5o6/notify-documentation)
    - [ ] [document download API](https://gallery.ecr.aws/v6b8u5o6/notify-document-download-api)
    - [ ] [document download frontend](https://gallery.ecr.aws/v6b8u5o6/notify-document-download-frontend)

## Checklist if making changes to Kubernetes:
- [ ] I know how to get kubectl credentials in case it catches on fire

## After merging this PR
- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.