### PR TITLE
fix: move emf config back to logs

### DIFF
--- a/env/production/cwagent-fluentd-quickstart.yaml
+++ b/env/production/cwagent-fluentd-quickstart.yaml
@@ -70,7 +70,8 @@ data:
             "kubernetes":{
                 "cluster_name":"notification-canada-ca-production-eks-cluster",
                 "metrics_collection_interval":60
-            }
+            },
+            "emf": { }
           },
           "force_flush_interval":5
       },
@@ -81,8 +82,7 @@ data:
                 "service_address":":8125",
                 "metrics_collection_interval":15,
                 "metrics_aggregation_interval":60
-            },
-            "emf": { }
+            }
           }
       }
     }

--- a/env/staging/cwagent-fluentd-quickstart.yaml
+++ b/env/staging/cwagent-fluentd-quickstart.yaml
@@ -70,7 +70,8 @@ data:
             "kubernetes":{
                 "cluster_name":"notification-canada-ca-staging-eks-cluster",
                 "metrics_collection_interval":60
-            }
+            },
+            "emf": { }
           },
           "force_flush_interval":5
       },
@@ -81,8 +82,7 @@ data:
                 "service_address":":8125",
                 "metrics_collection_interval":15,
                 "metrics_aggregation_interval":60
-            },
-            "emf": { }
+            }
           }
       }
     }


### PR DESCRIPTION
## What are you changing?
- [ ] Releasing a new version of Notify
- [X] Changing kubernetes configuration

## Provide some background on the changes
> The name `metrics` is misleading in the config. After reviewing the docs again, the original configuration was correct. This misconfiguration was detected when reviewing the cloudwatch agent logs and it throwing a `Configuration validation first phase failed` error when it detected an unexpected value under the `metric` block.

![image](https://user-images.githubusercontent.com/85885638/155379035-0f91ad97-4c5d-4b0e-92b4-d0e03c11485c.png)


## If you are releasing a new version of Notify, what components are you updating
- [ ] API
- [ ] Admin
- [ ] Documentation
- [ ] Document download API
- [ ] Document download frontend

## Checklist if releasing new version:
- [ ] I made sure that the changes are as expected in [Notify staging](https://staging.notification.cdssandbox.xyz/)
- [ ] I have checked if the docker images I am referencing exist
    - [ ] [api lambda](https://ca-central-1.console.aws.amazon.com/ecr/repositories/private/296255494825/notify/api-lambda?region=ca-central-1) (requires Notification-Production / AdministratorAccess login)
    - [ ] [api k8s](https://gallery.ecr.aws/v6b8u5o6/notify-api)
    - [ ] [admin](https://gallery.ecr.aws/v6b8u5o6/notify-admin)
    - [ ] [documentation](https://gallery.ecr.aws/v6b8u5o6/notify-documentation)
    - [ ] [document download API](https://gallery.ecr.aws/v6b8u5o6/notify-document-download-api)
    - [ ] [document download frontend](https://gallery.ecr.aws/v6b8u5o6/notify-document-download-frontend)

## Checklist if making changes to Kubernetes:
- [ ] I know how to get kubectl credentials in case it catches on fire

## After merging this PR
- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.