### PR TITLE
fix: update the devcontainer with k8s tools

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,11 +1,45 @@
-# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.187.0/containers/alpine/.devcontainer/base.Dockerfile
+FROM mcr.microsoft.com/vscode/devcontainers/base:0-debian
 
-# [Choice] Alpine version: 3.13, 3.12, 3.11, 3.10
-ARG VARIANT="3.13"
-FROM mcr.microsoft.com/vscode/devcontainers/base:0-alpine-${VARIANT}
+RUN apt-get update \
+    && apt-get -y install --no-install-recommends apt-utils 2>&1 \
+    && apt-get -y install \
+        build-essential \
+        curl \
+        fd-find \
+        emacs \
+        exa \
+        git \
+        iproute2 \
+        less \
+        libsodium-dev \
+        lsb-release \
+        man-db \
+        manpages \
+        openssh-client \
+        postgresql-client \
+        procps \
+        net-tools \
+        sudo \
+        tldr \
+        unzip \
+        vim \
+        zsh \
+    && apt-get autoremove -y \
+    && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/*
 
-# ** [Optional] Uncomment this section to install additional packages. **
-RUN apk update \
-    && apk add --no-cache postgresql-client openssh-client less iproute2 procps curl unzip net-tools emacs exa mandoc make aws-cli
+# Install kubens
+RUN git clone -b v0.9.4 --single-branch https://github.com/ahmetb/kubectx /opt/kubectx \
+    && ln -s /opt/kubectx/kubectx /usr/local/bin/kubectx \
+    && ln -s /opt/kubectx/kubens /usr/local/bin/kubens
 
-COPY scripts/notify-dev-entrypoint.sh /usr/local/bin/
+# Install AWS cli
+RUN curl -sL https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip -o awscliv2.zip \
+    && unzip awscliv2.zip \
+    && aws/install \
+    && rm -rf \
+        awscliv2.zip \
+        aws \
+        /usr/local/aws-cli/v2/*/dist/awscli/examples
+    
+COPY .devcontainer/scripts/notify-dev-entrypoint.sh /usr/local/bin/

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,20 +1,22 @@
-// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
-// https://github.com/microsoft/vscode-dev-containers/tree/v0.187.0/containers/alpine
 {
-	"name": "Alpine",
+	"name": "notification-manifests",
 	"build": {
 		"dockerfile": "Dockerfile",
-		// Update 'VARIANT' to pick an Alpine version: 3.10, 3.11, 3.12, 3.13
-		"args": {
-			"VARIANT": "3.13"
+		"context": "..",
+	},
+
+	"features": {
+		"kubectl-helm-minikube": {
+			"version": "latest",
+			"helm": "latest",
+			"minikube": "none"
 		}
 	},
-	// Set *default* container specific settings.json values on container create. 
-	"settings": {
-		"terminal.integrated.shell.linux": "/bin/bash"
+
+	"containerEnv": {
+		"SHELL": "/bin/zsh"
 	},
-	// Add the IDs of extensions you want installed when the container is created.
-	// Note that some extensions may not work in Alpine Linux. See https://aka.ms/vscode-remote/linux.
+
 	"extensions": [
 		"alefragnani.bookmarks",
 		"christian-kohler.path-intellisense",
@@ -33,16 +35,11 @@
 		"tabnine.tabnine-vscode",
 		"usernamehw.errorlens",
 		"visualstudioexptteam.vscodeintellicode",
-		"yzhang.markdown-all-in-one"
+		"yzhang.markdown-all-in-one",
+		"github.copilot"
 	],
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	// "forwardPorts": [],
+
+	"postCreateCommand": "notify-dev-entrypoint.sh",
 	
-	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "/usr/local/bin/notify-dev-entrypoint.sh",
-	
-	 // Uncomment when using a ptrace-based debugger like C++, Go, and Rust
-	// "runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined" ],
-	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "vscode"
 }

--- a/.devcontainer/scripts/notify-dev-entrypoint.sh
+++ b/.devcontainer/scripts/notify-dev-entrypoint.sh
@@ -1,20 +1,32 @@
 #!/bin/bash
-set -ex 
+set -ex
 
 ###################################################################
-# This script will get executed *once* the Docker container has 
+# This script will get executed *once* the Docker container has
 # been built. Commands that need to be executed with all available
-# tools and the filesystem mount enabled should be located here. 
+# tools and the filesystem mount enabled should be located here.
 ###################################################################
 
 # Define aliases
-echo -e "\n\n# User's Aliases" >> ~/.profile
-echo -e "alias fd=fdfind" >> ~/.profile
-echo -e "alias l='ls -al --color'" >> ~/.profile
-echo -e "alias ls='exa'" >> ~/.profile
-echo -e "alias l='exa -alh'" >> ~/.profile
-echo -e "alias ll='exa -alh@ --git'" >> ~/.profile
-echo -e "alias lt='exa -al -T -L 2'" >> ~/.profile
+echo -e "\n\n# User's Aliases" >> ~/.zshrc
+echo -e "alias fd=fdfind" >> ~/.zshrc
+echo -e "alias l='ls -al --color'" >> ~/.zshrc
+echo -e "alias ls='exa'" >> ~/.zshrc
+echo -e "alias l='exa -alh'" >> ~/.zshrc
+echo -e "alias ll='exa -alh@ --git'" >> ~/.zshrc
+echo -e "alias lt='exa -al -T -L 2'" >> ~/.zshrc
 
-# Warm up git index 
+# AWS cli autocomplete and aliases
+echo -e "complete -C /usr/local/bin/aws_completer aws" >> ~/.zshrc
+
+# Kubectl aliases and command autocomplete
+echo -e "alias k='kubectl'" >> ~/.zshrc
+echo -e "alias k-staging='aws eks --region ca-central-1 update-kubeconfig --name notification-canada-ca-staging-eks-cluster'" >> ~/.zshrc
+echo -e "alias k-prod='aws eks --region ca-central-1 update-kubeconfig --name notification-canada-ca-production-eks-cluster'" >> ~/.zshrc
+echo -e "source <(kubectl completion zsh)" >> ~/.zshrc
+echo -e "complete -F __start_kubectl k" >> ~/.zshrc
+
+cd /workspaces/notification-manifests
+
+# Warm up git index prior to display status in prompt
 git status


### PR DESCRIPTION
# Summary
Add kubectl, kubens, AWS cli and aliases to make manifest
support and development easier.

# ⚠️  Note
This includes `k-staging` and `k-prod` aliases that will make it easier to configure our kubeconfig file.

# Related
* Closes cds-snc/notification-planning#426

# What are you changing?
- [ ] Releasing a new version of Notify
- [ ] Changing kubernetes configuration
