### PR TITLE
feat: enable sending metrics via udp

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,8 @@
 FROM mcr.microsoft.com/vscode/devcontainers/base:0-debian
 
+ARG KUBENS_VERSION
+ARG OCTANT_VERSION
+
 RUN apt-get update \
     && apt-get -y install --no-install-recommends apt-utils 2>&1 \
     && apt-get -y install \
@@ -29,9 +32,15 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install kubens
-RUN git clone -b v0.9.4 --single-branch https://github.com/ahmetb/kubectx /opt/kubectx \
+RUN git clone -b v${KUBENS_VERSION} --single-branch https://github.com/ahmetb/kubectx /opt/kubectx \
     && ln -s /opt/kubectx/kubectx /usr/local/bin/kubectx \
     && ln -s /opt/kubectx/kubens /usr/local/bin/kubens
+
+# Install Octant
+RUN curl -Lo octant.tar.gz https://github.com/vmware-tanzu/octant/releases/download/v${OCTANT_VERSION}/octant_${OCTANT_VERSION}_Linux-64bit.tar.gz \
+    && tar -xvf octant.tar.gz \
+    && mv octant_${OCTANT_VERSION}_Linux-64bit/octant /usr/local/bin/ \
+    && rm -rf octant_${OCTANT_VERSION}_Linux-64bit
 
 # Install AWS cli
 RUN curl -sL https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip -o awscliv2.zip \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,6 +3,10 @@
 	"build": {
 		"dockerfile": "Dockerfile",
 		"context": "..",
+		"args": {
+			"KUBENS_VERSION": "0.9.4",
+			"OCTANT_VERSION": "0.25.1"
+		},
 	},
 
 	"features": {

--- a/base/api-deployment.yaml
+++ b/base/api-deployment.yaml
@@ -228,6 +228,8 @@ spec:
               value: '$(FF_BATCH_INSERTION)'
             - name: FF_REDIS_BATCH_SAVING
               value: '$(FF_REDIS_BATCH_SAVING)'
+            - name: CLOUDWATCH_METRICS_ENABLED
+              value: 'False'
 
           resources:
             requests:

--- a/base/api-deployment.yaml
+++ b/base/api-deployment.yaml
@@ -229,7 +229,7 @@ spec:
             - name: FF_REDIS_BATCH_SAVING
               value: '$(FF_REDIS_BATCH_SAVING)'
             - name: CLOUDWATCH_METRICS_ENABLED
-              value: 'False'
+              value: 'True'
 
           resources:
             requests:

--- a/base/api-deployment.yaml
+++ b/base/api-deployment.yaml
@@ -228,7 +228,7 @@ spec:
               value: '$(FF_BATCH_INSERTION)'
             - name: FF_REDIS_BATCH_SAVING
               value: '$(FF_REDIS_BATCH_SAVING)'
-            - name: CLOUDWATCH_METRICS_ENABLED
+            - name: FF_CLOUDWATCH_METRICS_ENABLED
               value: 'True'
 
           resources:

--- a/base/celery-deployment.yaml
+++ b/base/celery-deployment.yaml
@@ -105,7 +105,7 @@ spec:
             - name: FF_BATCH_INSERTION
               value: '$(FF_BATCH_INSERTION)'
             - name: CLOUDWATCH_METRICS_ENABLED
-              value: 'False'
+              value: 'True'
           command: ["/bin/sh"]
           args: ["-c", "sh /app/scripts/run_celery.sh"]
           resources:

--- a/base/celery-deployment.yaml
+++ b/base/celery-deployment.yaml
@@ -104,6 +104,8 @@ spec:
               value: '$(NEW_RELIC_MONITOR_MODE)'
             - name: FF_BATCH_INSERTION
               value: '$(FF_BATCH_INSERTION)'
+            - name: CLOUDWATCH_METRICS_ENABLED
+              value: 'False'
           command: ["/bin/sh"]
           args: ["-c", "sh /app/scripts/run_celery.sh"]
           resources:

--- a/base/celery-deployment.yaml
+++ b/base/celery-deployment.yaml
@@ -104,7 +104,7 @@ spec:
               value: '$(NEW_RELIC_MONITOR_MODE)'
             - name: FF_BATCH_INSERTION
               value: '$(FF_BATCH_INSERTION)'
-            - name: CLOUDWATCH_METRICS_ENABLED
+            - name: FF_CLOUDWATCH_METRICS_ENABLED
               value: 'True'
           command: ["/bin/sh"]
           args: ["-c", "sh /app/scripts/run_celery.sh"]

--- a/env/production/cwagent-fluentd-quickstart.yaml
+++ b/env/production/cwagent-fluentd-quickstart.yaml
@@ -117,7 +117,10 @@ spec:
               protocol: UDP
             - containerPort: 25888
               hostPort: 25888
-              protocol: TCP              
+              protocol: TCP
+            - containerPort: 25888
+              hostPort: 25888
+              protocol: UDP              
           resources:
             limits:
               cpu:  200m

--- a/env/staging/cwagent-fluentd-quickstart.yaml
+++ b/env/staging/cwagent-fluentd-quickstart.yaml
@@ -118,6 +118,9 @@ spec:
             - containerPort: 25888
               hostPort: 25888
               protocol: TCP
+            - containerPort: 25888
+              hostPort: 25888
+              protocol: UDP
           resources:
             limits:
               cpu:  200m

--- a/env/staging/replica_count.yaml
+++ b/env/staging/replica_count.yaml
@@ -72,4 +72,4 @@ metadata:
   namespace: notification-canada-ca
 spec:
   minReplicas: 1
-  maxReplicas: 2
+  maxReplicas: 4


### PR DESCRIPTION
## What are you changing?
- [ ] Releasing a new version of Notify
- [X] Changing kubernetes configuration

## Provide some background on the changes
> Sending metrics via TCP is causing a-lot of open connections. Exposing the agent's UDP port to test performance when metrics are sent via UDP.

## If you are releasing a new version of Notify, what components are you updating
- [ ] API
- [ ] Admin
- [ ] Documentation
- [ ] Document download API
- [ ] Document download frontend

## Checklist if releasing new version:
- [ ] I made sure that the changes are as expected in [Notify staging](https://staging.notification.cdssandbox.xyz/)
- [ ] I have checked if the docker images I am referencing exist
    - [ ] [api lambda](https://ca-central-1.console.aws.amazon.com/ecr/repositories/private/296255494825/notify/api-lambda?region=ca-central-1) (requires Notification-Production / AdministratorAccess login)
    - [ ] [api k8s](https://gallery.ecr.aws/v6b8u5o6/notify-api)
    - [ ] [admin](https://gallery.ecr.aws/v6b8u5o6/notify-admin)
    - [ ] [documentation](https://gallery.ecr.aws/v6b8u5o6/notify-documentation)
    - [ ] [document download API](https://gallery.ecr.aws/v6b8u5o6/notify-document-download-api)
    - [ ] [document download frontend](https://gallery.ecr.aws/v6b8u5o6/notify-document-download-frontend)

## Checklist if making changes to Kubernetes:
- [ ] I know how to get kubectl credentials in case it catches on fire

## After merging this PR
- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.