### PR TITLE
feat: add Octant to devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,8 @@
 FROM mcr.microsoft.com/vscode/devcontainers/base:0-debian
 
+ARG KUBENS_VERSION
+ARG OCTANT_VERSION
+
 RUN apt-get update \
     && apt-get -y install --no-install-recommends apt-utils 2>&1 \
     && apt-get -y install \
@@ -29,9 +32,15 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install kubens
-RUN git clone -b v0.9.4 --single-branch https://github.com/ahmetb/kubectx /opt/kubectx \
+RUN git clone -b v${KUBENS_VERSION} --single-branch https://github.com/ahmetb/kubectx /opt/kubectx \
     && ln -s /opt/kubectx/kubectx /usr/local/bin/kubectx \
     && ln -s /opt/kubectx/kubens /usr/local/bin/kubens
+
+# Install Octant
+RUN curl -Lo octant.tar.gz https://github.com/vmware-tanzu/octant/releases/download/v${OCTANT_VERSION}/octant_${OCTANT_VERSION}_Linux-64bit.tar.gz \
+    && tar -xvf octant.tar.gz \
+    && mv octant_${OCTANT_VERSION}_Linux-64bit/octant /usr/local/bin/ \
+    && rm -rf octant_${OCTANT_VERSION}_Linux-64bit
 
 # Install AWS cli
 RUN curl -sL https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip -o awscliv2.zip \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,6 +3,10 @@
 	"build": {
 		"dockerfile": "Dockerfile",
 		"context": "..",
+		"args": {
+			"KUBENS_VERSION": "0.9.4",
+			"OCTANT_VERSION": "0.25.1"
+		},
 	},
 
 	"features": {


### PR DESCRIPTION
# Summary
Octant provides a dashboard that makes it easier to manage
Kubernetes workloads.

# Related
* cds-snc/notification-api#1491

# What are you changing?
- [ ] Releasing a new version of Notify
- [ ] Changing kubernetes configuration