### PR TITLE
feat: add test manifest build action

### DIFF
--- a/.github/actions/test-manifest/action.yaml
+++ b/.github/actions/test-manifest/action.yaml
@@ -4,15 +4,18 @@ inputs:
   build-target:
     description: Name of the manifest build target
     required: true
+  echo-manifest:
+    description: Echo the built manifest to the logs
+    default: "false"
+    required: false
 
 runs:
   using: "composite"
   steps:
     - name: Test manifest build
       shell: bash
-      run: |
-        exec 5>&1        
-        MANIFEST="$(make ${{ inputs.build-target }} | tee /dev/fd/5)"
+      run: |     
+        MANIFEST="$(make ${{ inputs.build-target }})"
         EXIT=0
 
         if echo "$MANIFEST" | grep 'value: $('
@@ -25,6 +28,11 @@ runs:
         then
           echo "❌ Unreplaced environment variable found"
           EXIT=1
+        fi
+
+        if [ "${{ inputs.echo-manifest }}" = "true" ]
+        then
+          echo "$MANIFEST"
         fi
 
         exit $EXIT

--- a/.github/actions/test-manifest/action.yaml
+++ b/.github/actions/test-manifest/action.yaml
@@ -1,0 +1,24 @@
+name: Test manifest build
+description: Test if a Kustomize manifest build works
+inputs:
+  build-target:
+    description: Name of the manifest build target
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Test manifest build
+      shell: bash
+      run: |
+        MANIFEST="$(make ${{ inputs.build-target }})"
+
+        if echo "$MANIFEST" | grep 'value: $('; then;
+          echo "❌ Undefined environment variable found";
+          exit 1;
+        fi
+
+        if echo "$MANIFEST" | grep 'well-defined vars that were never replaced'; then;
+          echo "❌ Unreplaced environment variable found";
+          exit 1;
+        fi

--- a/.github/actions/test-manifest/action.yaml
+++ b/.github/actions/test-manifest/action.yaml
@@ -11,16 +11,19 @@ runs:
     - name: Test manifest build
       shell: bash
       run: |
+        EXIT=0
         MANIFEST="$(make ${{ inputs.build-target }})"
 
         if echo "$MANIFEST" | grep 'value: $('
         then
           echo "❌ Undefined environment variable found"
-          exit 1
+          EXIT=1
         fi
 
         if echo "$MANIFEST" | grep 'well-defined vars that were never replaced'
         then
           echo "❌ Unreplaced environment variable found"
-          exit 1
+          EXIT=1
         fi
+
+        exit $EXIT

--- a/.github/actions/test-manifest/action.yaml
+++ b/.github/actions/test-manifest/action.yaml
@@ -13,12 +13,14 @@ runs:
       run: |
         MANIFEST="$(make ${{ inputs.build-target }})"
 
-        if echo "$MANIFEST" | grep 'value: $('; then;
-          echo "❌ Undefined environment variable found";
-          exit 1;
+        if echo "$MANIFEST" | grep 'value: $('
+        then
+          echo "❌ Undefined environment variable found"
+          exit 1
         fi
 
-        if echo "$MANIFEST" | grep 'well-defined vars that were never replaced'; then;
-          echo "❌ Unreplaced environment variable found";
-          exit 1;
+        if echo "$MANIFEST" | grep 'well-defined vars that were never replaced'
+        then
+          echo "❌ Unreplaced environment variable found"
+          exit 1
         fi

--- a/.github/actions/test-manifest/action.yaml
+++ b/.github/actions/test-manifest/action.yaml
@@ -11,8 +11,9 @@ runs:
     - name: Test manifest build
       shell: bash
       run: |
+        exec 5>&1        
+        MANIFEST="$(make ${{ inputs.build-target }} | tee /dev/fd/5)"
         EXIT=0
-        MANIFEST="$(make ${{ inputs.build-target }})"
 
         if echo "$MANIFEST" | grep 'value: $('
         then

--- a/.github/workflows/syntax_check.yaml
+++ b/.github/workflows/syntax_check.yaml
@@ -21,6 +21,7 @@ jobs:
         if: always()
         with:
           build-target: staging-debug
+          echo-manifest: true
 
       - name: Test production manifest build
         uses: ./.github/actions/test-manifest

--- a/.github/workflows/syntax_check.yaml
+++ b/.github/workflows/syntax_check.yaml
@@ -1,5 +1,8 @@
 name: Testing manifest
-on: [pull_request]
+
+on: 
+  - pull_request
+
 jobs:
   testing_manifest:
     runs-on: ubuntu-latest
@@ -11,7 +14,17 @@ jobs:
       - name: Add fake .env
         run: |
           cp env.example env/staging/.env
+          cp env.example env/production/.env
 
-      - name: Run manifest build
-        run: |
-          make staging-debug
+      - name: Test staging manifest build
+        uses: ./.github/actions/test-manifest
+        if: always()
+        with:
+          build-target: staging-debug
+
+      - name: Test production manifest build
+        uses: ./.github/actions/test-manifest
+        if: always()
+        with:
+          build-target: production-debug          
+  


### PR DESCRIPTION
# Summary
Add an action that tests a Kustomize manifest build to check
if it can build successfully and there are no environment
variables that are not used or replaced.

# What are you changing?
- [ ] Releasing a new version of Notify
- [ ] Changing kubernetes configuration
- [x] GitHub workflows

# Related
* cds-snc/notification-planning#421