### PR TITLE
fix: missing environment variables in kustomize build

### DIFF
--- a/env/production/kustomization.yaml
+++ b/env/production/kustomization.yaml
@@ -428,3 +428,17 @@ vars:
       apiVersion: v1
     fieldref:
       fieldpath: data.FF_REDIS_BATCH_SAVING
+  - name: GC_ARTICLES_API_AUTH_USERNAME
+    objref:
+      kind: ConfigMap
+      name: application-config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.GC_ARTICLES_API_AUTH_USERNAME
+  - name: GC_ARTICLES_API_AUTH_PASSWORD
+    objref:
+      kind: ConfigMap
+      name: application-config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.GC_ARTICLES_API_AUTH_PASSWORD      

--- a/env/staging/kustomization.yaml
+++ b/env/staging/kustomization.yaml
@@ -310,6 +310,13 @@ vars:
     apiVersion: v1
   fieldref:
     fieldpath: data.SENDGRID_API_KEY
+- name: SENSITIVE_SERVICES
+  objref:
+    kind: ConfigMap
+    name: application-config
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.SENSITIVE_SERVICES    
 - name: SQLALCHEMY_DATABASE_READER_URI
   objref:
     kind: ConfigMap


### PR DESCRIPTION
# Summary
Add environment variables to the kustomize build that are defined
but not replaced.  The result of this change is that instead of
the manifests containing values of `$(VAR_NAME)`, they will
have the value set in the environment's `.env` file.

- **Staging:** Add `SENSITIVE_SERVICES` variable.
- **Production:** Add `GC_ARTICLES_API_AUTH_*` variables.

In both cases, the current `.env` value is blank `""`. 

## What are you changing?
- [ ] Releasing a new version of Notify
- [x] Changing kubernetes configuration

# Related
* #969 
* cds-snc/notification-planning#421