### PR TITLE
feat: automatically release to production when the auto-pr bot release is merged

### DIFF
--- a/.github/workflows/autopr_merged.yaml
+++ b/.github/workflows/autopr_merged.yaml
@@ -23,10 +23,8 @@ jobs:
           github_token: ${{ env.GITHUB_TOKEN }}
           release_branches: main
 
-      - name: Checkout newly merged pr
+      - name: Checkout main branch
         uses: actions/checkout@v2
-        with:
-          ref: 'refs/pull/${{ github.event.number }}/merge'
 
       - name: Get current Prod Version
         run: |

--- a/.github/workflows/autopr_merged.yaml
+++ b/.github/workflows/autopr_merged.yaml
@@ -7,7 +7,7 @@ on:
 jobs:
   tag-release:
     runs-on: ubuntu-latest
-    if: ${{ github.event.pull_request.base.ref == 'main' && github.event.pull_request.merged && (contains(github.event.pull_request.title, '[AUTO-PR]') || contains(github.event.pull_request.title, '[MANIFEST]')) }}
+    if: github.event.pull_request.base.ref == 'main' && github.event.pull_request.merged && (contains(github.event.pull_request.title, '[AUTO-PR]') || contains(github.event.pull_request.title, '[MANIFEST]'))
     
     steps:
       - name: Obtain a Notify PR Bot GitHub App Installation Access Token
@@ -31,6 +31,18 @@ jobs:
           CURRENT_VERSION=`cat VERSION`
           echo "CURRENT_VERSION=$CURRENT_VERSION" >> $GITHUB_ENV
 
+      - name: Update version file
+        env:
+          NEW_VERSION: ${{ steps.tag_version.outputs.new_tag }}
+          CURRENT_VERSION: ${{ env.CURRENT_VERSION }}
+        run: |
+          echo $NEW_VERSION > VERSION
+
+      - name: setup git config
+        run: |
+          git config user.name "Notify PR Bot"
+          git config user.email "<>"
+
       - name: Branch protection OFF
         uses: octokit/request-action@v2.x
         with:
@@ -46,18 +58,6 @@ jobs:
             null 
         env:
           GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}
-
-      - name: Update version file
-        env:
-          NEW_VERSION: ${{ steps.tag_version.outputs.new_tag }}
-          CURRENT_VERSION: ${{ env.CURRENT_VERSION }}
-        run: |
-          echo $NEW_VERSION > VERSION
-
-      - name: setup git config
-        run: |
-          git config user.name "Notify PR Bot"
-          git config user.email "<>"
           
       - name: commit
         env:

--- a/.github/workflows/autopr_merged.yaml
+++ b/.github/workflows/autopr_merged.yaml
@@ -10,11 +10,17 @@ jobs:
     if: ${{ github.event.pull_request.base.ref == 'main' && github.event.pull_request.merged && (contains(github.event.pull_request.title, '[AUTO-PR]') || contains(github.event.pull_request.title, '[MANIFEST]')) }}
     
     steps:
+      - name: Obtain a Notify PR Bot GitHub App Installation Access Token
+        run: |
+          TOKEN="$(npx obtain-github-app-installation-access-token@1.1.0 ci ${{ secrets.GH_APP_CREDENTIALS_TOKEN }})"
+          echo "::add-mask::$TOKEN"
+          echo "GITHUB_TOKEN=$TOKEN" >> $GITHUB_ENV
+
       - name: Bump version and push tag
         id: tag_version
         uses: mathieudutour/github-tag-action@v6.0
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ env.GITHUB_TOKEN }}
           release_branches: main
 
       - name: Checkout newly merged pr
@@ -39,7 +45,7 @@ jobs:
           restrictions: | 
             null 
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_ACTIONS_REPO_ADMIN_CI_TOKEN }}
+          GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}
 
       - name: Update version file
         env:
@@ -50,7 +56,7 @@ jobs:
 
       - name: setup git config
         run: |
-          git config user.name "GitHub Actions Bot"
+          git config user.name "Notify PR Bot"
           git config user.email "<>"
           
       - name: commit
@@ -59,7 +65,7 @@ jobs:
           CURRENT_VERSION: ${{ env.CURRENT_VERSION }}
         run: |
           git add VERSION
-          git commit -m "Bump Version ${CURRENT_VERSION} -> ${NEW_VERSION}"
+          git commit -m "New release: ${CURRENT_VERSION} -> ${NEW_VERSION}"
           git push origin main
 
       - name: Branch protection ON
@@ -77,4 +83,4 @@ jobs:
           restrictions: | 
             null 
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_ACTIONS_REPO_ADMIN_CI_TOKEN }}
+          GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}

--- a/.github/workflows/autopr_merged.yaml
+++ b/.github/workflows/autopr_merged.yaml
@@ -75,7 +75,11 @@ jobs:
           route: PUT /repos/:repository/branches/main/protection
           repository: ${{ github.repository }}
           required_status_checks: | 
-            null 
+            strict: true
+            checks:
+              - testing_manifest
+          required_linear_history: |
+            true
           enforce_admins: |
             true
           required_pull_request_reviews: |

--- a/.github/workflows/autopr_merged.yaml
+++ b/.github/workflows/autopr_merged.yaml
@@ -25,6 +25,8 @@ jobs:
 
       - name: Checkout newly merged pr
         uses: actions/checkout@v2
+        with:
+          ref: 'refs/pull/${{ github.event.number }}/merge'
 
       - name: Get current Prod Version
         run: |

--- a/.github/workflows/autopr_merged.yaml
+++ b/.github/workflows/autopr_merged.yaml
@@ -1,0 +1,80 @@
+name: "Tag and release to production"
+
+on: 
+  pull_request:
+    types: [closed]
+
+jobs:
+  tag-release:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.base.ref == 'main' && github.event.pull_request.merged && (contains(github.event.pull_request.title, '[AUTO-PR]') || contains(github.event.pull_request.title, '[MANIFEST]')) }}
+    
+    steps:
+      - name: Bump version and push tag
+        id: tag_version
+        uses: mathieudutour/github-tag-action@v6.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          release_branches: main
+
+      - name: Checkout newly merged pr
+        uses: actions/checkout@v2
+
+      - name: Get current Prod Version
+        run: |
+          CURRENT_VERSION=`cat VERSION`
+          echo "CURRENT_VERSION=$CURRENT_VERSION" >> $GITHUB_ENV
+
+      - name: Branch protection OFF
+        uses: octokit/request-action@v2.x
+        with:
+          route: PUT /repos/:repository/branches/main/protection
+          repository: ${{ github.repository }}
+          required_status_checks: |
+            null
+          enforce_admins: |
+            null
+          required_pull_request_reviews: |
+            null
+          restrictions: | 
+            null 
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_ACTIONS_REPO_ADMIN_CI_TOKEN }}
+
+      - name: Update version file
+        env:
+          NEW_VERSION: ${{ steps.tag_version.outputs.new_tag }}
+          CURRENT_VERSION: ${{ env.CURRENT_VERSION }}
+        run: |
+          echo $NEW_VERSION > VERSION
+
+      - name: setup git config
+        run: |
+          git config user.name "GitHub Actions Bot"
+          git config user.email "<>"
+          
+      - name: commit
+        env:
+          NEW_VERSION: ${{ steps.tag_version.outputs.new_tag }}
+          CURRENT_VERSION: ${{ env.CURRENT_VERSION }}
+        run: |
+          git add VERSION
+          git commit -m "Bump Version ${CURRENT_VERSION} -> ${NEW_VERSION}"
+          git push origin main
+
+      - name: Branch protection ON
+        if: always()
+        uses: octokit/request-action@v2.x
+        with:
+          route: PUT /repos/:repository/branches/main/protection
+          repository: ${{ github.repository }}
+          required_status_checks: | 
+            null 
+          enforce_admins: |
+            true
+          required_pull_request_reviews: |
+            required_approving_review_count: 1
+          restrictions: | 
+            null 
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_ACTIONS_REPO_ADMIN_CI_TOKEN }}


### PR DESCRIPTION
This PR introduces automation that will trigger the deployment of new releases automatically when the Notify PR bot auto-generated release is merged.

This is done by tracking merged pull requests containing the title [AUTO-PR]. PR's containing the title of [MANIFEST] will also trigger the same process, so that changes to the Kubernetes config can be automatically deployed using the tag system.

This is done by using a new GitHub workflow to bump the `VERSION` file in the root directory, and to update the main branch with this change. Manual intervention will no longer be required when releasing updates to the apps managed by this repo. To achieve this, this new GitHub worklow will disable branch protection, push the update to the version file, and then re-enable branch protection.

[Demo repo that was used to test this workflow](https://github.com/cds-snc/test_autopr/actions/runs/1958375304)

All changes that require authentication will be using the Notify PR bot token which has access to make changes to this repo.

Workflow
1. `notification-pr-bot` generates a new release candidate PR
2. PR approved and merged
3. New workflow kicks off

```mermaid
flowchart TD
A[PR merged] --> B["PR title contains [AUTO-PR] or [MANIFEST]"]
B -- Yes --> C[Tag the release] --> E[Bump the version file] --> F[Turn off branch protection] --> G[Commit and push updated version file to main] --> H[Turn on branch protection] --> I[New production release starts deploying]
B -- No --> D[No change to production deployment]

```
![image](https://user-images.githubusercontent.com/85885638/157494352-bd319408-58c8-4a4a-a132-9f9b8e7fc096.png)

Related: cds-snc/notification-planning#429