### PR TITLE
fix: tweak checkout step to not prefix

### DIFF
--- a/.github/workflows/autopr_merged.yaml
+++ b/.github/workflows/autopr_merged.yaml
@@ -25,6 +25,8 @@ jobs:
 
       - name: Checkout main branch
         uses: actions/checkout@v2
+        with:
+          ref: $GITHUB_HEAD_REF
 
       - name: Get current Prod Version
         run: |
@@ -76,8 +78,6 @@ jobs:
           repository: ${{ github.repository }}
           required_status_checks: | 
             strict: true
-            checks:
-              - testing_manifest
           required_linear_history: |
             true
           enforce_admins: |

--- a/.github/workflows/merge_to_main_production.yaml
+++ b/.github/workflows/merge_to_main_production.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Checkout target Prod version
         uses: actions/checkout@v2
         with:
-          ref: v${{ env.TARGET_VERSION }}
+          ref: ${{ env.TARGET_VERSION }}
 
       - name: Inject token authentication
         run: |


### PR DESCRIPTION
Workflow tweak to no longer prefix with a `v` and to checkout the base branch