### PR TITLE
chore: provide pr bot token when checking out

### DIFF
--- a/.github/workflows/autopr_merged.yaml
+++ b/.github/workflows/autopr_merged.yaml
@@ -43,7 +43,7 @@ jobs:
       - name: setup git config
         run: |
           git config user.name "Notify PR Bot"
-          git config user.email "<>"
+          git config user.email "action@github.com"
 
       - name: Branch protection OFF
         uses: octokit/request-action@v2.x
@@ -52,8 +52,8 @@ jobs:
           repository: ${{ github.repository }}
           required_status_checks: | 
             strict: true
-            contexts:
-              - testing_manifest 
+            checks:
+              - context: testing_manifest
           required_linear_history: |
             true
           enforce_admins: |
@@ -82,8 +82,8 @@ jobs:
           repository: ${{ github.repository }}
           required_status_checks: | 
             strict: true
-            contexts:
-              - testing_manifest 
+            checks:
+              - context: testing_manifest
           required_linear_history: |
             true
           enforce_admins: |

--- a/.github/workflows/autopr_merged.yaml
+++ b/.github/workflows/autopr_merged.yaml
@@ -26,7 +26,6 @@ jobs:
       - name: Checkout main branch
         uses: actions/checkout@v2
         with:
-          ref: $GITHUB_HEAD_REF
           token: ${{ env.GITHUB_TOKEN }}
 
       - name: Get current Prod Version
@@ -51,12 +50,16 @@ jobs:
         with:
           route: PUT /repos/:repository/branches/main/protection
           repository: ${{ github.repository }}
-          required_status_checks: |
-            null
+          required_status_checks: | 
+            strict: true
+            contexts:
+              - testing_manifest 
+          required_linear_history: |
+            true
           enforce_admins: |
             null
           required_pull_request_reviews: |
-            null
+            required_approving_review_count: 1
           restrictions: | 
             null 
         env:
@@ -79,6 +82,8 @@ jobs:
           repository: ${{ github.repository }}
           required_status_checks: | 
             strict: true
+            contexts:
+              - testing_manifest 
           required_linear_history: |
             true
           enforce_admins: |

--- a/.github/workflows/autopr_merged.yaml
+++ b/.github/workflows/autopr_merged.yaml
@@ -27,6 +27,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           ref: $GITHUB_HEAD_REF
+          token: ${{ env.GITHUB_TOKEN }}
 
       - name: Get current Prod Version
         run: |

--- a/.github/workflows/autopr_merged.yaml
+++ b/.github/workflows/autopr_merged.yaml
@@ -10,6 +10,9 @@ jobs:
     if: github.event.pull_request.base.ref == 'main' && github.event.pull_request.merged && (contains(github.event.pull_request.title, '[AUTO-PR]') || contains(github.event.pull_request.title, '[MANIFEST]'))
     
     steps:
+
+      # Generate a bot token that will be used for all workflow actions.
+      # This is required as the default repo GITHUB_TOKEN does not trigger new workflow runs.
       - name: Obtain a Notify PR Bot GitHub App Installation Access Token
         run: |
           TOKEN="$(npx obtain-github-app-installation-access-token@1.1.0 ci ${{ secrets.GH_APP_CREDENTIALS_TOKEN }})"

--- a/.github/workflows/merge_to_main_production.yaml
+++ b/.github/workflows/merge_to_main_production.yaml
@@ -5,7 +5,6 @@ on:
     branches:
       - main
     paths:
-      - ".github/workflows/merge_to_main_production.yaml"
       - "VERSION"
 
 env:


### PR DESCRIPTION
Update the workflow so that the release automation uses the pr-bot GitHub token to interact with the repo. This is required since GitHub prevents the triggering of workflows when the GitHub action token is in play.

Documented [here](https://docs.github.com/en/enterprise-server@2.22/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow)

PR also removes the "Merge to main (production)" workflow trigger on the workflow file.  This is because we now only want a production deploy to occur once the new `VERSION` file is pushed to `main` by the auto PR workflow.