### PR TITLE
feat: remove new lines and only run on dispatch

### DIFF
--- a/.github/workflows/sync_secrets_staging.yaml
+++ b/.github/workflows/sync_secrets_staging.yaml
@@ -2,11 +2,11 @@ name: "Update SecretsManager (Staging)"
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - main
-    paths:
-      - "env/staging/**.aws"
+  # push:
+  #   branches:
+  #     - main
+  #   paths:
+  #     - "env/staging/**.aws"
 
 defaults:
   run:
@@ -34,7 +34,7 @@ jobs:
       - name: Update secret manager
         working-directory: env/staging
         run: |
-          cat .env | jq -nR --raw-output '[ inputs | gsub("\r$"; "") | split("="; "") | {(.[0]): .[1]}] | add' > env.json
+          sed '/^$/d' .env | jq -nR --raw-output '[ inputs | gsub("\r$"; "") | split("="; "") | {(.[0]): .[1]}] | add' > env.json
           aws secretsmanager update-secret --secret-id environment_variables --secret-string file://env.json
 
       # Generate a bot token that will be used to dispatch the terraform apply

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 .env
 .env.zip
+.env.json
 .previous.env
 .previous.env.zip
 .previous.env.zip.enc.aws


### PR DESCRIPTION
## What are you changing?
- [ ] Releasing a new version of Notify
- [ ] Changing kubernetes configuration

## Provide some background on the changes
> Newlines were causing issues when the .env was being converted to JSON. Also making this only run when manually dispatched until a new terraform workflow is created that is capable of updating all resources.

## If you are releasing a new version of Notify, what components are you updating
- [ ] API
- [ ] Admin
- [ ] Documentation
- [ ] Document download API
- [ ] Document download frontend

## Checklist if releasing new version:
- [ ] I made sure that the changes are as expected in [Notify staging](https://staging.notification.cdssandbox.xyz/)
- [ ] I have checked if the docker images I am referencing exist
    - [ ] [api lambda](https://ca-central-1.console.aws.amazon.com/ecr/repositories/private/296255494825/notify/api-lambda?region=ca-central-1) (requires Notification-Production / AdministratorAccess login)
    - [ ] [api k8s](https://gallery.ecr.aws/v6b8u5o6/notify-api)
    - [ ] [admin](https://gallery.ecr.aws/v6b8u5o6/notify-admin)
    - [ ] [documentation](https://gallery.ecr.aws/v6b8u5o6/notify-documentation)
    - [ ] [document download API](https://gallery.ecr.aws/v6b8u5o6/notify-document-download-api)
    - [ ] [document download frontend](https://gallery.ecr.aws/v6b8u5o6/notify-document-download-frontend)

## Checklist if making changes to Kubernetes:
- [ ] I know how to get kubectl credentials in case it catches on fire

## After merging this PR
- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.