### PR TITLE
feat: sync prod secrets to secretsmanager

### DIFF
--- a/.github/workflows/sync_secrets_production.yaml
+++ b/.github/workflows/sync_secrets_production.yaml
@@ -1,0 +1,60 @@
+name: "Update SecretsManager (Production)"
+
+on:
+  workflow_dispatch:
+  # push workflow will be enabled once the secrets have been confirmed
+  
+  # push:
+  #   branches:
+  #     - main
+  #   paths:
+  #     - "env/production/**.aws"
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  sync-secrets:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.PRODUCTION_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.PRODUCTION_AWS_SECRET_ACCESS_KEY }}
+          aws-region: ca-central-1
+
+      - name: Decrypt staging env
+        run: |
+          make decrypt-production
+
+      - name: Update secret manager
+        working-directory: env/production
+        run: |
+          sed '/^$/d' .env | jq -nR --raw-output '[ inputs | gsub("\r$"; "") | split("="; "") | {(.[0]): .[1]}] | add' > env.json
+          aws secretsmanager update-secret --secret-id environment_variables --secret-string file://env.json
+
+      # Generate a bot token that will be used to dispatch the terraform apply
+      # This is required as the default repo GITHUB_TOKEN does not have access to other repositories.
+      - name: Obtain a Notify PR Bot GitHub App Installation Access Token
+        run: |
+          TOKEN="$(npx obtain-github-app-installation-access-token@1.1.0 ci ${{ secrets.GH_APP_CREDENTIALS_TOKEN }})"
+          echo "::add-mask::$TOKEN"
+          echo "GITHUB_TOKEN=$TOKEN" >> $GITHUB_ENV
+
+      - name: Dispatch Terraform apply
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ env.GITHUB_TOKEN }}
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: 'cds-snc',
+              repo: 'notification-terraform',
+              workflow_id: 'merge_to_main_production.yml',
+              ref: 'main'
+            })

--- a/.github/workflows/sync_secrets_production.yaml
+++ b/.github/workflows/sync_secrets_production.yaml
@@ -3,7 +3,7 @@ name: "Update SecretsManager (Production)"
 on:
   workflow_dispatch:
   # push workflow will be enabled once the secrets have been confirmed
-  
+
   # push:
   #   branches:
   #     - main
@@ -29,7 +29,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.PRODUCTION_AWS_SECRET_ACCESS_KEY }}
           aws-region: ca-central-1
 
-      - name: Decrypt staging env
+      - name: Decrypt production env
         run: |
           make decrypt-production
 


### PR DESCRIPTION
## What are you changing?
- [ ] Releasing a new version of Notify
- [ ] Changing kubernetes configuration

## Provide some background on the changes
> Sync production secrets to secretsmanager so that it's available to lambda functions

## If you are releasing a new version of Notify, what components are you updating
- [ ] API
- [ ] Admin
- [ ] Documentation
- [ ] Document download API
- [ ] Document download frontend

## Checklist if releasing new version:
- [ ] I made sure that the changes are as expected in [Notify staging](https://staging.notification.cdssandbox.xyz/)
- [ ] I have checked if the docker images I am referencing exist
    - [ ] [api lambda](https://ca-central-1.console.aws.amazon.com/ecr/repositories/private/296255494825/notify/api-lambda?region=ca-central-1) (requires Notification-Production / AdministratorAccess login)
    - [ ] [api k8s](https://gallery.ecr.aws/v6b8u5o6/notify-api)
    - [ ] [admin](https://gallery.ecr.aws/v6b8u5o6/notify-admin)
    - [ ] [documentation](https://gallery.ecr.aws/v6b8u5o6/notify-documentation)
    - [ ] [document download API](https://gallery.ecr.aws/v6b8u5o6/notify-document-download-api)
    - [ ] [document download frontend](https://gallery.ecr.aws/v6b8u5o6/notify-document-download-frontend)

## Checklist if making changes to Kubernetes:
- [ ] I know how to get kubectl credentials in case it catches on fire

## After merging this PR
- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.