### PR TITLE
feat: only update envs when values change

### DIFF
--- a/.github/workflows/sync_secrets_production.yaml
+++ b/.github/workflows/sync_secrets_production.yaml
@@ -2,13 +2,10 @@ name: "Update SecretsManager (Production)"
 
 on:
   workflow_dispatch:
-  # push workflow will be enabled once the secrets have been confirmed
-
-  # push:
-  #   branches:
-  #     - main
-  #   paths:
-  #     - "env/production/**.aws"
+  workflow_run:
+    workflows: ["Merge to main (Production)"]
+    types:
+      - completed
 
 defaults:
   run:
@@ -33,21 +30,36 @@ jobs:
         run: |
           make decrypt-production
 
-      - name: Update secret manager
+      - name: Generate secretsmanager JSON payload
         working-directory: env/production
         run: |
-          sed '/^$/d' .env | jq -nR --raw-output '[ inputs | gsub("\r$"; "") | split("="; "") | {(.[0]): .[1]}] | add' > env.json
-          aws secretsmanager update-secret --secret-id environment_variables --secret-string file://env.json
+          sed '/^$/d' .env | jq -nR --raw-output '[ inputs | gsub("\r$"; "") | split("="; "") | {(.[0]): .[1]}] | add' > .env.json
+
+      - name: Check for env changes
+        working-directory: env/production
+        run: |
+          aws secretsmanager get-secret-value --secret-id environment_variables | jq --raw-output '.SecretString' > .current.env.json
+          DIFF="$(diff -B .env.json .current.env.json | wc -l)"
+          echo "::add-mask::$DIFF"
+          echo "ENV_DIFF=$DIFF" >> $GITHUB_ENV
+
+      - name: Update secret manager
+        if: env.ENV_DIFF != '0' # Only update secrets when changes detected
+        working-directory: env/production
+        run: |
+          aws secretsmanager update-secret --secret-id environment_variables --secret-string file://.env.json
 
       # Generate a bot token that will be used to dispatch the terraform apply
       # This is required as the default repo GITHUB_TOKEN does not have access to other repositories.
       - name: Obtain a Notify PR Bot GitHub App Installation Access Token
+        if: env.ENV_DIFF != '0'
         run: |
           TOKEN="$(npx obtain-github-app-installation-access-token@1.1.0 ci ${{ secrets.GH_APP_CREDENTIALS_TOKEN }})"
           echo "::add-mask::$TOKEN"
           echo "GITHUB_TOKEN=$TOKEN" >> $GITHUB_ENV
 
       - name: Dispatch Terraform apply
+        if: env.ENV_DIFF != '0'
         uses: actions/github-script@v6
         with:
           github-token: ${{ env.GITHUB_TOKEN }}

--- a/.github/workflows/sync_secrets_production.yaml
+++ b/.github/workflows/sync_secrets_production.yaml
@@ -30,7 +30,7 @@ jobs:
         run: |
           make decrypt-production
 
-      - name: Generate secretsmanager JSON payload
+      - name: Generate env JSON payload
         working-directory: env/production
         run: |
           sed '/^$/d' .env | jq -nR --raw-output '[ inputs | gsub("\r$"; "") | split("="; "") | {(.[0]): .[1]}] | add' > .env.json

--- a/.github/workflows/sync_secrets_staging.yaml
+++ b/.github/workflows/sync_secrets_staging.yaml
@@ -2,11 +2,10 @@ name: "Update SecretsManager (Staging)"
 
 on:
   workflow_dispatch:
-  # push:
-  #   branches:
-  #     - main
-  #   paths:
-  #     - "env/staging/**.aws"
+  workflow_run:
+    workflows: ["Merge to main (Staging)"]
+    types:
+      - completed
 
 defaults:
   run:
@@ -31,21 +30,36 @@ jobs:
         run: |
           make decrypt-staging
 
-      - name: Update secret manager
+      - name: Generate secretsmanager JSON payload
         working-directory: env/staging
         run: |
-          sed '/^$/d' .env | jq -nR --raw-output '[ inputs | gsub("\r$"; "") | split("="; "") | {(.[0]): .[1]}] | add' > env.json
-          aws secretsmanager update-secret --secret-id environment_variables --secret-string file://env.json
+          sed '/^$/d' .env | jq -nR --raw-output '[ inputs | gsub("\r$"; "") | split("="; "") | {(.[0]): .[1]}] | add' > .env.json
+
+      - name: Check for env changes
+        working-directory: env/staging
+        run: |
+          aws secretsmanager get-secret-value --secret-id environment_variables | jq --raw-output '.SecretString' > .current.env.json
+          DIFF="$(diff -B .env.json .current.env.json | wc -l)"
+          echo "::add-mask::$DIFF"
+          echo "ENV_DIFF=$DIFF" >> $GITHUB_ENV
+
+      - name: Update secret manager
+        if: env.ENV_DIFF != '0' # Only update secrets when changes detected
+        working-directory: env/staging
+        run: |
+          aws secretsmanager update-secret --secret-id environment_variables --secret-string file://.env.json
 
       # Generate a bot token that will be used to dispatch the terraform apply
       # This is required as the default repo GITHUB_TOKEN does not have access to other repositories.
       - name: Obtain a Notify PR Bot GitHub App Installation Access Token
+        if: env.ENV_DIFF != '0'
         run: |
           TOKEN="$(npx obtain-github-app-installation-access-token@1.1.0 ci ${{ secrets.GH_APP_CREDENTIALS_TOKEN }})"
           echo "::add-mask::$TOKEN"
           echo "GITHUB_TOKEN=$TOKEN" >> $GITHUB_ENV
 
       - name: Dispatch Terraform apply
+        if: env.ENV_DIFF != '0'
         uses: actions/github-script@v6
         with:
           github-token: ${{ env.GITHUB_TOKEN }}

--- a/.github/workflows/sync_secrets_staging.yaml
+++ b/.github/workflows/sync_secrets_staging.yaml
@@ -30,7 +30,7 @@ jobs:
         run: |
           make decrypt-staging
 
-      - name: Generate secretsmanager JSON payload
+      - name: Generate env JSON payload
         working-directory: env/staging
         run: |
           sed '/^$/d' .env | jq -nR --raw-output '[ inputs | gsub("\r$"; "") | split("="; "") | {(.[0]): .[1]}] | add' > .env.json

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .env
 .env.zip
 .env.json
+.current.env.json
 .previous.env
 .previous.env.zip
 .previous.env.zip.enc.aws


### PR DESCRIPTION
## What are you changing?
- [ ] Releasing a new version of Notify
- [ ] Changing kubernetes configuration

## Provide some background on the changes
> Sync secrets only when envs change and after the merge workflows complete

## If you are releasing a new version of Notify, what components are you updating
- [ ] API
- [ ] Admin
- [ ] Documentation
- [ ] Document download API
- [ ] Document download frontend

## Checklist if releasing new version:
- [ ] I made sure that the changes are as expected in [Notify staging](https://staging.notification.cdssandbox.xyz/)
- [ ] I have checked if the docker images I am referencing exist
    - [ ] [api lambda](https://ca-central-1.console.aws.amazon.com/ecr/repositories/private/296255494825/notify/api-lambda?region=ca-central-1) (requires Notification-Production / AdministratorAccess login)
    - [ ] [api k8s](https://gallery.ecr.aws/v6b8u5o6/notify-api)
    - [ ] [admin](https://gallery.ecr.aws/v6b8u5o6/notify-admin)
    - [ ] [documentation](https://gallery.ecr.aws/v6b8u5o6/notify-documentation)
    - [ ] [document download API](https://gallery.ecr.aws/v6b8u5o6/notify-document-download-api)
    - [ ] [document download frontend](https://gallery.ecr.aws/v6b8u5o6/notify-document-download-frontend)

## Checklist if making changes to Kubernetes:
- [ ] I know how to get kubectl credentials in case it catches on fire

## After merging this PR
- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.