### PR TITLE
chore: disable SecretsManager sync job

### DIFF
--- a/.github/workflows/sync_secrets_production.yaml
+++ b/.github/workflows/sync_secrets_production.yaml
@@ -2,10 +2,6 @@ name: "Update SecretsManager (Production)"
 
 on:
   workflow_dispatch:
-  workflow_run:
-    workflows: ["Merge to main (Production)"]
-    types:
-      - completed
 
 defaults:
   run:

--- a/.github/workflows/sync_secrets_staging.yaml
+++ b/.github/workflows/sync_secrets_staging.yaml
@@ -2,10 +2,6 @@ name: "Update SecretsManager (Staging)"
 
 on:
   workflow_dispatch:
-  workflow_run:
-    workflows: ["Merge to main (Staging)"]
-    types:
-      - completed
 
 defaults:
   run:


### PR DESCRIPTION
# Summary
Disabling the SecretsManager sync jobs while we investigate
how to deal with the 4kb Lambda env var limit we hit in
cds-snc/notification-terraform#420.

# What are you changing?
- [ ] Releasing a new version of Notify
- [ ] Changing kubernetes configuration
- [x] GitHub Workflow

# Related
* cds-snc/notification-terraform#420
* cds-snc/notification-terraform#421