### PR TITLE
fix: prevent aws lambda cli from displaying output

### DIFF
--- a/.github/workflows/merge_to_main_production.yaml
+++ b/.github/workflows/merge_to_main_production.yaml
@@ -65,7 +65,7 @@ jobs:
         run: |
           aws lambda update-function-code \
             --function-name api-lambda \
-            --image-uri $PRIVATE_ECR/$API_LAMBDA_IMAGE
+            --image-uri $PRIVATE_ECR/$API_LAMBDA_IMAGE > /dev/null 2>&1
 
       - name: Add deployment to New Relic
         run: |

--- a/.github/workflows/sync_secrets_production.yaml
+++ b/.github/workflows/sync_secrets_production.yaml
@@ -49,4 +49,4 @@ jobs:
         run: |
           aws lambda update-function-configuration \
             --function-name api-lambda \
-            --description $(date -u +"%Y-%m-%dT%H:%M:%SZ")
+            --description $(date -u +"%Y-%m-%dT%H:%M:%SZ") > /dev/null 2>&1

--- a/.github/workflows/sync_secrets_staging.yaml
+++ b/.github/workflows/sync_secrets_staging.yaml
@@ -49,4 +49,4 @@ jobs:
         run: |
           aws lambda update-function-configuration \
             --function-name api-lambda \
-            --description $(date -u +"%Y-%m-%dT%H:%M:%SZ")
+            --description $(date -u +"%Y-%m-%dT%H:%M:%SZ") > /dev/null 2>&1


### PR DESCRIPTION
This PR will prevent the lambda cli commands from dumping their outputs to the workflow logs.