### PR TITLE
fix: sync secrets failures when differences

### DIFF
--- a/.github/workflows/sync_secrets_production.yaml
+++ b/.github/workflows/sync_secrets_production.yaml
@@ -34,7 +34,7 @@ jobs:
         working-directory: env/production
         run: |
           aws ssm get-parameters --region ca-central-1 --with-decryption --names ENVIRONMENT_VARIABLES --query 'Parameters[*].Value' --output text > .previous.env
-          DIFF="$(diff -B .env .previous.env | wc -l)"
+          DIFF="$(set +o pipefail && diff -B .env .previous.env | wc -l)"
           echo "::add-mask::$DIFF"
           echo "ENV_DIFF=$DIFF" >> $GITHUB_ENV
 

--- a/.github/workflows/sync_secrets_staging.yaml
+++ b/.github/workflows/sync_secrets_staging.yaml
@@ -34,7 +34,7 @@ jobs:
         working-directory: env/staging
         run: |
           aws ssm get-parameters --region ca-central-1 --with-decryption --names ENVIRONMENT_VARIABLES --query 'Parameters[*].Value' --output text > .previous.env
-          DIFF="$(diff -B .env .previous.env | wc -l)"
+          DIFF="$(set +o pipefail && diff -B .env .previous.env | wc -l)"
           echo "::add-mask::$DIFF"
           echo "ENV_DIFF=$DIFF" >> $GITHUB_ENV
 


### PR DESCRIPTION
# Summary
Update the `Check for env changes` step so that when `diff` finds a
difference, and exits with a non-zero exit code, the step continues
as expected and sets the number of `DIFF` lines.