### PR TITLE
Added GC_ARTICLES_API URL value to env config map

### DIFF
--- a/base/admin-deployment.yaml
+++ b/base/admin-deployment.yaml
@@ -100,6 +100,8 @@ spec:
               value: '$(NEW_RELIC_MONITOR_MODE)'
             - name: IP_GEOLOCATE_SERVICE
               value: '$(IP_GEOLOCATE_SERVICE)'
+            - name: GC_ARTICLES_API
+              value: '$(GC_ARTICLES_API)'
             - name: GC_ARTICLES_API_AUTH_USERNAME
               value: '$(GC_ARTICLES_API_AUTH_USERNAME)'
             - name: GC_ARTICLES_API_AUTH_PASSWORD

--- a/env/production/kustomization.yaml
+++ b/env/production/kustomization.yaml
@@ -428,6 +428,13 @@ vars:
       apiVersion: v1
     fieldref:
       fieldpath: data.FF_REDIS_BATCH_SAVING
+  - name: GC_ARTICLES_API
+    objref:
+      kind: ConfigMap
+      name: application-config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.GC_ARTICLES_API
   - name: GC_ARTICLES_API_AUTH_USERNAME
     objref:
       kind: ConfigMap

--- a/env/staging/kustomization.yaml
+++ b/env/staging/kustomization.yaml
@@ -436,6 +436,13 @@ vars:
     apiVersion: v1
   fieldref:
     fieldpath: data.BATCH_INSERTION_CHUNK_SIZE
+- name: GC_ARTICLES_API
+  objref:
+    kind: ConfigMap
+    name: application-config
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.GC_ARTICLES_API
 - name: GC_ARTICLES_API_AUTH_USERNAME
   objref:
     kind: ConfigMap


### PR DESCRIPTION
## What are you changing?

There is no config map defined for GC_ARTICLES_API in the Kubernetes configuration, hence that one is missing in staging and production. This is following the [bump to v0.50.7](https://github.com/cds-snc/notification-manifests/pull/1038) where we discovered it might not work properly and rather fallback to the config in the Python configuration (where production might fallback to staging value; so nothing broken or at risk but an env mismatch we don't want).

## Provide some background on the changes
> Give details ex. Security patching, content update, more API pods etc

## If you are releasing a new version of Notify, what components are you updating
- [ ] API
- [ ] Admin
- [ ] Documentation
- [ ] Document download API
- [ ] Document download frontend

## Checklist if releasing new version:
- [ ] I made sure that the changes are as expected in [Notify staging](https://staging.notification.cdssandbox.xyz/)
- [ ] I have checked if the docker images I am referencing exist
    - [ ] [api lambda](https://ca-central-1.console.aws.amazon.com/ecr/repositories/private/296255494825/notify/api-lambda?region=ca-central-1) (requires Notification-Production / AdministratorAccess login)
    - [ ] [api k8s](https://gallery.ecr.aws/v6b8u5o6/notify-api)
    - [ ] [admin](https://gallery.ecr.aws/v6b8u5o6/notify-admin)
    - [ ] [documentation](https://gallery.ecr.aws/v6b8u5o6/notify-documentation)
    - [ ] [document download API](https://gallery.ecr.aws/v6b8u5o6/notify-document-download-api)
    - [ ] [document download frontend](https://gallery.ecr.aws/v6b8u5o6/notify-document-download-frontend)

## Checklist if making changes to Kubernetes:
- [ ] I know how to get kubectl credentials in case it catches on fire

## After merging this PR
- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.