### PR TITLE
fix: Makefile target to generate env keys

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,10 +85,10 @@ staging-debug:
 	kubectl kustomize env/staging
 
 env-keys-example:
-	@cat env.example | xargs -L1 | grep "=" | cut -f1 -d"=" | sort | tr "\n" "|"
+	@cat env.example | xargs -0 -L1 | grep "=" | cut -f1 -d"=" | sort | tr "\n" "|"
 
 env-keys-production:
-	@cat env/production/.env | xargs -L1 | grep "=" | cut -f1 -d"=" | sort | tr "\n" "|"
+	@cat env/production/.env | xargs -0 -L1 | grep "=" | cut -f1 -d"=" | sort | tr "\n" "|"
 
 env-keys-staging:
-	@cat env/staging/.env | xargs -L1 | grep "=" | cut -f1 -d"=" | sort | tr "\n" "|"
+	@cat env/staging/.env | xargs -0 -L1 | grep "=" | cut -f1 -d"=" | sort | tr "\n" "|"


### PR DESCRIPTION
# Summary
Update the `env-keys-$ENV_NAME` Makefile targets 
so that they can handle `"` quote characters
in the variable value.

## What are you changing?
- [ ] Releasing a new version of Notify
- [ ] Changing kubernetes configuration

## If you are releasing a new version of Notify, what components are you updating
- [ ] API
- [ ] Admin
- [ ] Documentation
- [ ] Document download API
- [ ] Document download frontend