### PR TITLE
fix: install pinned kubectl without Azure action

### DIFF
--- a/.github/workflows/merge_to_main_production.yaml
+++ b/.github/workflows/merge_to_main_production.yaml
@@ -10,6 +10,7 @@ on:
 env:
   PRIVATE_ECR: ${{ secrets.PRODUCTION_AWS_ACCOUNT }}.dkr.ecr.ca-central-1.amazonaws.com/notify
   API_LAMBDA_IMAGE: api-lambda:b73c412
+  KUBECTL_VERSION: 1.23.6
 
 defaults:
   run:
@@ -44,10 +45,12 @@ jobs:
           aws-secret-access-key: ${{ secrets.PRODUCTION_AWS_SECRET_ACCESS_KEY }}
           aws-region: ca-central-1
 
-      # Pin kubectl until https://github.com/aws/aws-cli/issues/6920 is fixed
-      - uses: azure/setup-kubectl@v2.0
-        with:
-          version: 'v1.23.6'
+      - name: Install kubectl
+        run: |
+          curl -LO https://dl.k8s.io/release/v$KUBECTL_VERSION/bin/linux/amd64/kubectl
+          chmod +x kubectl
+          mv kubectl /usr/local/bin/
+          kubectl version --client
 
       - name: Run manifest build
         run: |

--- a/.github/workflows/merge_to_main_staging.yaml
+++ b/.github/workflows/merge_to_main_staging.yaml
@@ -9,6 +9,9 @@ on:
       - ".github/workflows/merge_to_main_staging.yaml"
       - "env/staging/**"
 
+env:
+  KUBECTL_VERSION: 1.23.6
+
 defaults:
   run:
     shell: bash
@@ -31,10 +34,12 @@ jobs:
           aws-secret-access-key: ${{ secrets.STAGING_AWS_SECRET_ACCESS_KEY }}
           aws-region: ca-central-1
 
-      # Pin kubectl until https://github.com/aws/aws-cli/issues/6920 is fixed
-      - uses: azure/setup-kubectl@v2.0
-        with:
-          version: 'v1.23.6'
+      - name: Install kubectl
+        run: |
+          curl -LO https://dl.k8s.io/release/v$KUBECTL_VERSION/bin/linux/amd64/kubectl
+          chmod +x kubectl
+          mv kubectl /usr/local/bin/
+          kubectl version --client
 
       - name: Decrypt staging env
         run: |

--- a/.github/workflows/syntax_check.yaml
+++ b/.github/workflows/syntax_check.yaml
@@ -3,6 +3,9 @@ name: Testing manifest
 on: 
   - pull_request
 
+env:
+  KUBECTL_VERSION: 1.23.6
+
 jobs:
   testing_manifest:
     runs-on: ubuntu-latest
@@ -10,6 +13,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+
+      - name: Install kubectl
+        run: |
+          curl -LO https://dl.k8s.io/release/v$KUBECTL_VERSION/bin/linux/amd64/kubectl
+          chmod +x kubectl
+          mv kubectl /usr/local/bin/
+          kubectl version --client
 
       - name: Add fake .env
         run: |


### PR DESCRIPTION
# Summary
Update all workflows that use `kubectl` to use a pinned version
installed from the official release.

# Related
* #1086 