### PR TITLE
fix: publish new lambda version and update alias

### DIFF
--- a/.github/actions/update-lambda-function/action.yaml
+++ b/.github/actions/update-lambda-function/action.yaml
@@ -1,0 +1,44 @@
+name: Update lambda function
+description: Updates a lambda function, publishes a new version and updates the function alias
+inputs:
+  alias-name:
+    description: Name of the alias to update
+    required: true
+  function-name:
+    description: Name of the function to update
+    required: true
+  image-uri:
+    description: Image tag to update the function with (if not specified, only the lambda description is updated to trigger a reload)
+    default: ''
+    required: false
+
+runs:
+  using: "composite"
+  steps:
+  
+    - name: Update lambda image
+      if: inputs.image-uri != ''
+      shell: bash
+      run: |
+        aws lambda update-function-code \
+          --function-name ${{ inputs.function-name }} \
+          --image-uri ${{ inputs.image-uri }} > /dev/null 2>&1
+
+    - name: Update lambda description
+      if: inputs.image-uri == ''
+      shell: bash
+      run: |
+        aws lambda update-function-configuration \
+          --function-name ${{ inputs.function-name }} \
+          --description $(date -u +"%Y-%m-%dT%H:%M:%SZ") > /dev/null 2>&1
+
+    - name: Publish version and update alias
+      shell: bash
+      run: |
+        aws lambda wait function-updated --function-name ${{ inputs.function-name }}
+        VERSION="$(aws lambda publish-version --function-name ${{ inputs.function-name }} | jq -r '.Version')"
+
+        aws lambda update-alias \
+          --function-name ${{ inputs.function-name }} \
+          --name ${{ inputs.alias-name }} \
+          --function-version "$VERSION" > /dev/null 2>&1

--- a/.github/workflows/merge_to_main_production.yaml
+++ b/.github/workflows/merge_to_main_production.yaml
@@ -70,10 +70,11 @@ jobs:
           kubectl apply -k env/production --kubeconfig=/home/runner/.kube/config
 
       - name: Deploy lambda
-        run: |
-          aws lambda update-function-code \
-            --function-name api-lambda \
-            --image-uri $PRIVATE_ECR/$API_LAMBDA_IMAGE > /dev/null 2>&1
+        uses: ./.github/actions/update-lambda-function
+        with:
+          alias-name: latest
+          function-name: api-lambda
+          image-uri: $PRIVATE_ECR/$API_LAMBDA_IMAGE
 
       - name: Add deployment to New Relic
         run: |

--- a/.github/workflows/sync_secrets_production.yaml
+++ b/.github/workflows/sync_secrets_production.yaml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Force api-lambda to redeploy on environment changes
         if: env.ENV_DIFF != '0'
-        run: |
-          aws lambda update-function-configuration \
-            --function-name api-lambda \
-            --description $(date -u +"%Y-%m-%dT%H:%M:%SZ") > /dev/null 2>&1
+        uses: ./.github/actions/update-lambda-function
+        with:
+          alias-name: latest
+          function-name: api-lambda

--- a/.github/workflows/sync_secrets_staging.yaml
+++ b/.github/workflows/sync_secrets_staging.yaml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Force api-lambda to redeploy on environment changes
         if: env.ENV_DIFF != '0'
-        run: |
-          aws lambda update-function-configuration \
-            --function-name api-lambda \
-            --description $(date -u +"%Y-%m-%dT%H:%M:%SZ") > /dev/null 2>&1
+        uses: ./.github/actions/update-lambda-function
+        with:
+          alias-name: latest
+          function-name: api-lambda


### PR DESCRIPTION
# Summary
When the workflows update the Lambda API, have them also
publish a new function version and update the function alias
to reference this new version.

This is required to make sure the function's provisioned concurrency
stays in sync with the `$LATEST` version of the function code.

## What are you changing?
- [ ] Releasing a new version of Notify
- [ ] Changing kubernetes configuration

## If you are releasing a new version of Notify, what components are you updating
- [ ] API
- [ ] Admin
- [ ] Documentation
- [ ] Document download API
- [ ] Document download frontend

## Checklist if releasing new version:
- [ ] I made sure that the changes are as expected in [Notify staging](https://staging.notification.cdssandbox.xyz/)
- [ ] I have checked if the docker images I am referencing exist
    - [ ] [api lambda](https://ca-central-1.console.aws.amazon.com/ecr/repositories/private/296255494825/notify/api-lambda?region=ca-central-1) (requires Notification-Production / AdministratorAccess login)
    - [ ] [api k8s](https://gallery.ecr.aws/v6b8u5o6/notify-api)
    - [ ] [admin](https://gallery.ecr.aws/v6b8u5o6/notify-admin)
    - [ ] [documentation](https://gallery.ecr.aws/v6b8u5o6/notify-documentation)
    - [ ] [document download API](https://gallery.ecr.aws/v6b8u5o6/notify-document-download-api)
    - [ ] [document download frontend](https://gallery.ecr.aws/v6b8u5o6/notify-document-download-frontend)

## Checklist if making changes to Kubernetes:
- [ ] I know how to get kubectl credentials in case it catches on fire

## After merging this PR
- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.