### PR TITLE
[AUTO-PR] Automatically generated new release 2022-05-10T14:01:46.308Z

### DIFF
--- a/.github/workflows/merge_to_main_production.yaml
+++ b/.github/workflows/merge_to_main_production.yaml
@@ -9,7 +9,7 @@ on:
 
 env:
   PRIVATE_ECR: ${{ secrets.PRODUCTION_AWS_ACCOUNT }}.dkr.ecr.ca-central-1.amazonaws.com/notify
-  API_LAMBDA_IMAGE: api-lambda:e5f8d5a
+  API_LAMBDA_IMAGE: api-lambda:66fb4a2
   KUBECTL_VERSION: 1.23.6
 
 defaults:

--- a/env/production/kustomization.yaml
+++ b/env/production/kustomization.yaml
@@ -11,7 +11,7 @@ images:
   - name: admin
     newName: public.ecr.aws/cds-snc/notify-admin:45473fb
   - name: api
-    newName: public.ecr.aws/cds-snc/notify-api:e5f8d5a
+    newName: public.ecr.aws/cds-snc/notify-api:66fb4a2
   - name: document-download-api
     newName: public.ecr.aws/cds-snc/notify-document-download-api:ae02031
   - name: document-download-frontend


### PR DESCRIPTION
## What are you changing?
- [ ] Releasing a new version of Notify
- [ ] Changing kubernetes configuration

## Provide some background on the changes
⚠️ **The production version of the Terraform infrastructure is behind the latest staging version. Consider upgrading to the latest version before merging this pull request.** 

 ⚠️ **The production version of manifests is behind the latest staging version. Consider upgrading to the latest version before merging this pull request.** 

 NOTIFICATION-API

- [fix: publish new lambda version and update alias (#1543)](https://github.com/cds-snc/notification-api/commit/66fb4a2a9147ba56d4eb89f2d13ab74dc68d1109) by Pat Heard
- [Priority lanes 629 (#1536)](https://github.com/cds-snc/notification-api/commit/1d6fe5d289487f4d85c3e8e35d6f8ff3954ecbd5) by Andrew
- [Added new relic config (#1540)](https://github.com/cds-snc/notification-api/commit/38152c35a5e477ae6ea5753d2ec4fe4b11949269) by Jimmy Royer
- [Upgraded kubectl version to latest known stable (#1541)](https://github.com/cds-snc/notification-api/commit/e67db7ec8968819191791f31cdf361ec933d7e11) by Jimmy Royer
- [Feat/add priority database queues (#1533)](https://github.com/cds-snc/notification-api/commit/3c59c31269c4fc2d11cb51f67993962ad9aedfa4) by Steve Astels

NOTIFICATION-ADMIN



NOTIFICATION-DOCUMENT-DOWNLOAD-API



NOTIFICATION-DOCUMENT-DOWNLOAD-FRONTEND



NOTIFICATION-DOCUMENTATION



## If you are releasing a new version of Notify, what components are you updating
- [ ] API
- [ ] Admin
- [ ] Documentation
- [ ] Document download API
- [ ] Document download frontend

## Checklist if releasing new version:
- [ ] I made sure that the changes are as expected in [Notify staging](https://staging.notification.cdssandbox.xyz/)
- [ ] I have checked if the docker images I am referencing exist
    - [ ] [api lambda](https://ca-central-1.console.aws.amazon.com/ecr/repositories/private/296255494825/notify/api-lambda?region=ca-central-1) (requires Notification-Production / AdministratorAccess login)
    - [ ] [api k8s](https://gallery.ecr.aws/v6b8u5o6/notify-api)
    - [ ] [admin](https://gallery.ecr.aws/v6b8u5o6/notify-admin)
    - [ ] [documentation](https://gallery.ecr.aws/v6b8u5o6/notify-documentation)
    - [ ] [document download API](https://gallery.ecr.aws/v6b8u5o6/notify-document-download-api)
    - [ ] [document download frontend](https://gallery.ecr.aws/v6b8u5o6/notify-document-download-frontend)

## Checklist if making changes to Kubernetes:
- [ ] I know how to get kubectl credentials in case it catches on fire

## After merging this PR
- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.