### PR TITLE
feat: new BACKEND_HOSTNAME env var for dd-api

### DIFF
--- a/base/document-download-api-deployment.yaml
+++ b/base/document-download-api-deployment.yaml
@@ -36,6 +36,8 @@ spec:
               value: '$(DOCUMENTS_BUCKET)'
             - name: FRONTEND_HOSTNAME
               value: 'document.$(BASE_DOMAIN)'
+            - name: BACKEND_HOSTNAME
+              value: 'api.document.$(BASE_DOMAIN)'
             - name: HTTP_SCHEME
               value: 'https'
             - name: MLWR_USER


### PR DESCRIPTION
## What are you changing?
- [ ] Releasing a new version of Notify
- [x] Changing kubernetes configuration

## Provide some background on the changes

Add a new environment variable to document-download-api to support https://github.com/cds-snc/notification-document-download-api/pull/67

This variable (`BACKEND_HOSTNAME`) is automatically calculated using the `BASE_DOMAIN` environment variables, so does not require changing the encrypted environment variable files.

## If you are releasing a new version of Notify, what components are you updating
- [ ] API
- [ ] Admin
- [ ] Documentation
- [ ] Document download API
- [ ] Document download frontend

## Checklist if releasing new version:
- [ ] I made sure that the changes are as expected in [Notify staging](https://staging.notification.cdssandbox.xyz/)
- [ ] I have checked if the docker images I am referencing exist
    - [ ] [api lambda](https://ca-central-1.console.aws.amazon.com/ecr/repositories/private/296255494825/notify/api-lambda?region=ca-central-1) (requires Notification-Production / AdministratorAccess login)
    - [ ] [api k8s](https://gallery.ecr.aws/v6b8u5o6/notify-api)
    - [ ] [admin](https://gallery.ecr.aws/v6b8u5o6/notify-admin)
    - [ ] [documentation](https://gallery.ecr.aws/v6b8u5o6/notify-documentation)
    - [ ] [document download API](https://gallery.ecr.aws/v6b8u5o6/notify-document-download-api)
    - [ ] [document download frontend](https://gallery.ecr.aws/v6b8u5o6/notify-document-download-frontend)

## Checklist if making changes to Kubernetes:
- [ ] I know how to get kubectl credentials in case it catches on fire

## After merging this PR
- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.