### PR TITLE
Revert "[AUTO-PR] Automatically generated new release 2022-07-26T17:22:33.053Z"

### DIFF
--- a/env/production/kustomization.yaml
+++ b/env/production/kustomization.yaml
@@ -13,7 +13,7 @@ images:
   - name: api
     newName: public.ecr.aws/cds-snc/notify-api:a19d919
   - name: document-download-api
-    newName: public.ecr.aws/cds-snc/notify-document-download-api:383b625
+    newName: public.ecr.aws/cds-snc/notify-document-download-api:1da0d53
   - name: document-download-frontend
     newName: public.ecr.aws/cds-snc/notify-document-download-frontend:b4b9582
   - name: documentation


### PR DESCRIPTION
Reverts cds-snc/notification-manifests#1186

```
document-download-api-7b4cc7d64f-w7bgq      0/1     CrashLoopBackOff   4 (70s ago)   4m24s
```
Also, turns out staging was working because the old pod was still running 😞 