### PR TITLE
[AUTO-PR] Automatically generated new release 2022-10-25T14:40:48.143Z

### DIFF
--- a/.github/workflows/merge_to_main_production.yaml
+++ b/.github/workflows/merge_to_main_production.yaml
@@ -9,7 +9,7 @@ on:
 
 env:
   PRIVATE_ECR: ${{ secrets.PRODUCTION_AWS_ACCOUNT }}.dkr.ecr.ca-central-1.amazonaws.com/notify
-  API_LAMBDA_IMAGE: api-lambda:45630d2
+  API_LAMBDA_IMAGE: api-lambda:a1db924
   KUBECTL_VERSION: 1.23.6
 
 defaults:

--- a/env/production/kustomization.yaml
+++ b/env/production/kustomization.yaml
@@ -8,9 +8,9 @@ resources:
   - documentation-target-group.yaml
 images:
   - name: admin
-    newName: public.ecr.aws/cds-snc/notify-admin:9655fcd
+    newName: public.ecr.aws/cds-snc/notify-admin:0ef054e
   - name: api
-    newName: public.ecr.aws/cds-snc/notify-api:45630d2
+    newName: public.ecr.aws/cds-snc/notify-api:a1db924
   - name: document-download-api
     newName: public.ecr.aws/cds-snc/notify-document-download-api:96b8cd1
   - name: documentation


### PR DESCRIPTION
## What are you changing?
- [x] Releasing a new version of Notify
- [ ] Changing kubernetes configuration

## Provide some background on the changes
⚠️ **The production version of the Terraform infrastructure is behind the latest staging version. Consider upgrading to the latest version before merging this pull request.** 

 ⚠️ **The production version of manifests is behind the latest staging version. Consider upgrading to the latest version before merging this pull request.** 

 NOTIFICATION-API

- [Add missing dependency (#1651)](https://github.com/cds-snc/notification-api/commit/a1db924dc870546d10c8a9352563e615f5d501ef) by Stephen McMurtry
- [Fix for bug where user can schedule and send more SMS than daily limit allows (#1645)](https://github.com/cds-snc/notification-api/commit/ae8b1c831e80b34738084dcb80405e7a8a101c14) by Stephen McMurtry

NOTIFICATION-ADMIN

- [Confusing error message for sms limit reached (#1367)](https://github.com/cds-snc/notification-admin/commit/0ef054ed6164288468a2db43482112d24d21a9ae) by Philippe Caron
- [Update language for platform admin sms fragments setting (#1366)](https://github.com/cds-snc/notification-admin/commit/60c908f74309486337435d9e33b68546b08e5c20) by Stephen McMurtry
- [Consistent labels for create and choose template (#1356)](https://github.com/cds-snc/notification-admin/commit/d49570551f1962db894050a630dc01c3e0b439ea) by Philippe Caron
- [Integration of qualtrics survey in staging only (#1361)](https://github.com/cds-snc/notification-admin/commit/e2756c818f2ef678588c50debc54a59dd890f55d) by Jimmy Royer

NOTIFICATION-DOCUMENT-DOWNLOAD-API



NOTIFICATION-DOCUMENTATION



## If you are releasing a new version of Notify, what components are you updating
- [x] API
- [x] Admin
- [ ] Documentation
- [ ] Document download API

## Checklist if releasing new version:
- [ ] I made sure that the changes are as expected in [Notify staging](https://staging.notification.cdssandbox.xyz/)
- [x] I have checked if the docker images I am referencing exist
    - [x] [api lambda](https://ca-central-1.console.aws.amazon.com/ecr/repositories/private/296255494825/notify/api-lambda?region=ca-central-1) (requires Notification-Production / AdministratorAccess login)
    - [x] [api k8s](https://gallery.ecr.aws/v6b8u5o6/notify-api)
    - [x] [admin](https://gallery.ecr.aws/v6b8u5o6/notify-admin)
    - [ ] [documentation](https://gallery.ecr.aws/v6b8u5o6/notify-documentation)
    - [ ] [document download API](https://gallery.ecr.aws/v6b8u5o6/notify-document-download-api)

## Checklist if making changes to Kubernetes:
- [ ] I know how to get kubectl credentials in case it catches on fire

## After merging this PR
- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.