### PR TITLE
Change make-diff to check again origin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,13 +18,13 @@ decrypt-staging-orig:
 
 decrypt-previous-staging:
 	@cd env/staging &&\
-	git cat-file blob main:env/staging/.env.zip.enc.aws > .previous.env.zip.enc.aws &&\
+	git cat-file blob origin/main:env/staging/.env.zip.enc.aws > .previous.env.zip.enc.aws &&\
 	aws kms decrypt --ciphertext-blob fileb://.previous.env.zip.enc.aws --output text --query Plaintext --region ca-central-1 | base64 --decode > .previous.env.zip &&\
 	unzip -o .previous.env.zip && mv .env .previous.env
 
 decrypt-previous-production:
 	@cd env/production &&\
-	git cat-file blob main:env/production/.env.zip.enc.aws > .previous.env.zip.enc.aws &&\
+	git cat-file blob origin/main:env/production/.env.zip.enc.aws > .previous.env.zip.enc.aws &&\
 	aws kms decrypt --ciphertext-blob fileb://.previous.env.zip.enc.aws --output text --query Plaintext --region ca-central-1 | base64 --decode > .previous.env.zip &&\
 	unzip -o .previous.env.zip && mv .env .previous.env
 
@@ -52,13 +52,13 @@ diff-production: decrypt-previous-production decrypt-production
 
 diff-production-orig: decrypt-production
 	@cd env/production &&\
-	git cat-file blob main:env/production/.env.enc.aws > .previous.env.enc.aws &&\
+	git cat-file blob origin/main:env/production/.env.enc.aws > .previous.env.enc.aws &&\
 	aws kms decrypt --ciphertext-blob fileb://.previous.env.enc.aws --output text --query Plaintext --region ca-central-1 | base64 --decode > .previous.env &&\
 	diff .previous.env .env
 
 diff-staging-orig: decrypt-staging
 	@cd env/staging &&\
-	git cat-file blob main:env/staging/.env.enc.aws > .previous.env.enc.aws &&\
+	git cat-file blob origin/main:env/staging/.env.enc.aws > .previous.env.enc.aws &&\
 	aws kms decrypt --ciphertext-blob fileb://.previous.env.enc.aws --output text --query Plaintext --region ca-central-1 | base64 --decode > .previous.env &&\
 	diff .previous.env .env
 


### PR DESCRIPTION
We want to check diffs against what is in current staging and prod and not local stg/prd

## What happens when your PR merges?

When manifest changes, we need to check the change against origin, not against our local checked out version of main.

## Testing
I tested this by changing main (locally), making a new branch (locally) and running `make diff-staging`
It checks the result against local main. 
With my changes, I see the correct result