### PR TITLE
Fix: Celery resource usage and performance tuning

### DIFF
--- a/base/celery-deployment.yaml
+++ b/base/celery-deployment.yaml
@@ -125,7 +125,7 @@ spec:
               memory: "500Mi"
             limits:
               cpu: "550m"
-              memory: "600Mi"
+              memory: "1024Mi"
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler

--- a/base/celery-hpa.yaml
+++ b/base/celery-hpa.yaml
@@ -17,3 +17,9 @@ spec:
       target:
         type: Utilization
         averageUtilization: 50
+  - type: Resource
+    resource:
+      name: memory
+      target:
+        type: Utilization
+        averageUtilization: 75


### PR DESCRIPTION
Increasing the memory limit on celery pods to 1024Mi. Also configure horizontal auto scaler to scale out based on memory usage


## What are you changing?
- [ ] Releasing a new version of Notify
- [x] Changing kubernetes configuration

## Provide some background on the changes
Celery is running into OOM errors in production due to relatively low memory limits. Additionally, the horizontal pod autoscaler (HPA) is not currently configured to monitor memory usage. 

## Checklist if making changes to Kubernetes:
- [x] I know how to get kubectl credentials in case it catches on fire
