### PR TITLE
chore: use poetry for smoke test

### DIFF
--- a/.github/workflows/smoke_test.yaml
+++ b/.github/workflows/smoke_test.yaml
@@ -21,7 +21,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: 3.9
+        python-version: "3.10"
 
     - name: Upgrade pip
       run: python -m pip install --upgrade pip

--- a/.github/workflows/smoke_test.yaml
+++ b/.github/workflows/smoke_test.yaml
@@ -26,13 +26,13 @@ jobs:
     - name: Upgrade pip
       run: python -m pip install --upgrade pip
 
-    - name: Get requirements from cache
+    - name: Get packages from cache
       uses: actions/cache@v2
       with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
+        path: ~/.local
+        key: poetry-${{ runner.os }}-${{ env.PYTHON_VERSION }}-${{ hashFiles('**/poetry.lock') }}
         restore-keys: |
-          ${{ runner.os }}-pip-
+          poetry-${{ runner.os }}-${{ env.PYTHON_VERSION }}-
 
     - name: Install poetry
       env:

--- a/.github/workflows/smoke_test.yaml
+++ b/.github/workflows/smoke_test.yaml
@@ -33,12 +33,15 @@ jobs:
         key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
         restore-keys: |
           ${{ runner.os }}-pip-
+
     - name: Install poetry
       env:
         POETRY_VERSION: "1.3.2"
       run: pip install poetry==${POETRY_VERSION} && poetry --version
+
     - name: Install requirements
       run: poetry install
+
     - name: Run smoke tests on staging
       env:
         SMOKE_ADMIN_CLIENT_SECRET: ${{ secrets.SMOKE_ADMIN_CLIENT_SECRET}}

--- a/.github/workflows/smoke_test.yaml
+++ b/.github/workflows/smoke_test.yaml
@@ -33,10 +33,12 @@ jobs:
         key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
         restore-keys: |
           ${{ runner.os }}-pip-
-
-    - name: Install python requirements
-      run: pip install -r requirements.txt
-
+    - name: Install poetry
+      env:
+        POETRY_VERSION: "1.3.2"
+      run: pip install poetry==${POETRY_VERSION} && poetry --version
+    - name: Install requirements
+      run: poetry install
     - name: Run smoke tests on staging
       env:
         SMOKE_ADMIN_CLIENT_SECRET: ${{ secrets.SMOKE_ADMIN_CLIENT_SECRET}}
@@ -52,4 +54,4 @@ jobs:
         SMOKE_SMS_TEMPLATE_ID: ${{ secrets.SMOKE_SMS_TEMPLATE_ID}}
         SMOKE_USER_ID: ${{ secrets.SMOKE_USER_ID}}
         SMOKE_POLL_TIMEOUT: ${{ secrets.SMOKE_POLL_TIMEOUT}}
-      run: make smoke-test
+      run: poetry run make smoke-test


### PR DESCRIPTION
## What happens when your PR merges?
    - `chore:` - use for changes to non-app code (ex: GitHub actions)

## What are you changing?
- [ ] Releasing a new version of Notify
- [ ] Changing kubernetes configuration

## Provide some background on the changes
Change smoke test github action to use poetry

Essentially copied from https://github.com/cds-snc/notification-api/blob/main/.github/workflows/test.yaml#L34-L39

Run of the new action: https://github.com/cds-snc/notification-manifests/actions/runs/4501158321/jobs/7921211713?pr=1551
## If you are releasing a new version of Notify, what components are you updating
- [ ] API
- [ ] Admin
- [ ] Documentation
- [ ] Document download API

## Checklist if releasing new version:
- [ ] I made sure that the changes are as expected in [Notify staging](https://staging.notification.cdssandbox.xyz/)
- [ ] I have checked if the docker images I am referencing exist
    - [ ] [api lambda](https://ca-central-1.console.aws.amazon.com/ecr/repositories/private/296255494825/notify/api-lambda?region=ca-central-1) (requires Notification-Production / AdministratorAccess login)
    - [ ] [api k8s](https://gallery.ecr.aws/v6b8u5o6/notify-api)
    - [ ] [admin](https://gallery.ecr.aws/v6b8u5o6/notify-admin)
    - [ ] [documentation](https://gallery.ecr.aws/v6b8u5o6/notify-documentation)
    - [ ] [document download API](https://gallery.ecr.aws/v6b8u5o6/notify-document-download-api)

## Checklist if making changes to Kubernetes:
- [ ] I know how to get kubectl credentials in case it catches on fire

## After merging this PR
- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.