### PR TITLE
chore: delete extra s in smoke test action filter

### DIFF
--- a/.github/workflows/smoke_test.yaml
+++ b/.github/workflows/smoke_test.yaml
@@ -3,7 +3,7 @@ name: "Staging smoke test"
 on:
   push:
     branches:
-      - "releases-*"
+      - "release-*"
 
 defaults:
   run:


### PR DESCRIPTION
## Provide some background on the changes
Had an extra "s" in #1587 . Not that [pr-bot names the branches "release-..."](https://github.com/cds-snc/notification-pr-bot/blob/main/github.js#L46)
