### PR TITLE
AWS-Auth configmap in Kustomize

### DIFF
--- a/env/production/aws-auth-configmap.yaml
+++ b/env/production/aws-auth-configmap.yaml
@@ -14,7 +14,7 @@ data:
       - system:masters
       rolearn: arn:aws:iam::296255494825:role/AWSReservedSSO_AWSAdministratorAccess_dcf2167fdeb47617
       username: AWSAdministratorAccess:{{SessionName}}
-    - rolearn: arn:aws:iam::296255494825:role/notification-admin-apply
-      username: notification-admin-apply
+    - rolearn: arn:aws:iam::296255494825:role/notification-manifests-apply
+      username: notification-manifests-apply
       groups:
         - system:masters

--- a/env/production/aws-auth-configmap.yaml
+++ b/env/production/aws-auth-configmap.yaml
@@ -1,0 +1,20 @@
+kind: ConfigMap
+metadata:
+  name: aws-auth
+  namespace: kube-system
+apiVersion: v1
+data:
+  mapRoles: |
+    - groups:
+      - system:bootstrappers
+      - system:nodes
+      rolearn: arn:aws:iam::296255494825:role/eks-worker-role
+      username: system:node:{{EC2PrivateDNSName}}
+    - groups:
+      - system:masters
+      rolearn: arn:aws:iam::296255494825:role/AWSReservedSSO_AWSAdministratorAccess_dcf2167fdeb47617
+      username: AWSAdministratorAccess:{{SessionName}}
+    - rolearn: arn:aws:iam::296255494825:role/notification-admin-apply
+      username: notification-admin-apply
+      groups:
+        - system:masters

--- a/env/production/kustomization.yaml
+++ b/env/production/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - admin-target-group.yaml
   - document-download-api-target-group.yaml
   - documentation-target-group.yaml
+  - aws-auth-configmap.yaml  
 images:
   - name: admin
     newName: public.ecr.aws/cds-snc/notify-admin:dea9144

--- a/env/staging/aws-auth-configmap.yaml
+++ b/env/staging/aws-auth-configmap.yaml
@@ -1,0 +1,20 @@
+kind: ConfigMap
+metadata:
+  name: aws-auth
+  namespace: kube-system
+apiVersion: v1
+data:
+  mapRoles: |
+    - groups:
+      - system:bootstrappers
+      - system:nodes
+      rolearn: arn:aws:iam::239043911459:role/eks-worker-role
+      username: system:node:{{EC2PrivateDNSName}}
+    - groups:
+      - system:masters
+      rolearn: arn:aws:iam::239043911459:role/AWSReservedSSO_AWSAdministratorAccess_4085b2fdb6f29f43
+      username: AWSAdministratorAccess:{{SessionName}}
+    - rolearn: arn:aws:iam::239043911459:role/notification-admin-apply
+      username: notification-admin-apply
+      groups:
+        - system:masters

--- a/env/staging/aws-auth-configmap.yaml
+++ b/env/staging/aws-auth-configmap.yaml
@@ -18,3 +18,7 @@ data:
       username: notification-admin-apply
       groups:
         - system:masters
+    - rolearn: arn:aws:iam::239043911459:role/notification-manifests-apply
+      username: notification-manifests-apply
+      groups:
+        - system:masters

--- a/env/staging/kustomization.yaml
+++ b/env/staging/kustomization.yaml
@@ -9,7 +9,7 @@ resources:
   - admin-target-group.yaml
   - document-download-api-target-group.yaml
   - documentation-target-group.yaml
-
+  - aws-auth-configmap.yaml
 images:
   - name: admin
     newName: public.ecr.aws/cds-snc/notify-admin:latest


### PR DESCRIPTION
## What happens when your PR merges?
The aws-auth configmap in kube-system will be patched to allow the notification-admin-apply role to authenticate against the cluster

## What are you changing?
- [x] Changing kubernetes configuration

## Provide some background on the changes
We are switching the authenticated user in github actions to an OIDC managed one. This configuration update will provide the necessary permissions.

## Checklist if making changes to Kubernetes:
- [x] I know how to get kubectl credentials in case it catches on fire

## After merging this PR
- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.