### PR TITLE
fix: add more OIDC roles to k8s

### DIFF
--- a/env/staging/aws-auth-configmap.yaml
+++ b/env/staging/aws-auth-configmap.yaml
@@ -18,6 +18,18 @@ data:
       username: notification-admin-apply
       groups:
         - system:masters
+    - rolearn: arn:aws:iam::239043911459:role/notification-api-apply
+      username: notification-api-apply
+      groups:
+        - system:masters
+    - rolearn: arn:aws:iam::239043911459:role/notification-document-download-api-apply
+      username: notification-document-download-api-apply
+      groups:
+        - system:masters
+    - rolearn: arn:aws:iam::239043911459:role/notification-documentation-apply
+      username: notification-documentation-apply
+      groups:
+        - system:masters
     - rolearn: arn:aws:iam::239043911459:role/notification-manifests-apply
       username: notification-manifests-apply
       groups:


### PR DESCRIPTION
## What are you changing?
- [ ] Releasing a new version of Notify
- [x] Changing kubernetes configuration

## Provide some background on the changes

Followup to #1644 , add roles for a few more repos

## If you are releasing a new version of Notify, what components are you updating
- [ ] API
- [ ] Admin
- [ ] Documentation
- [ ] Document download API

## Checklist if releasing new version:
- [ ] I made sure that the changes are as expected in [Notify staging](https://staging.notification.cdssandbox.xyz/)
- [ ] I have checked if the docker images I am referencing exist
    - [ ] [api lambda](https://ca-central-1.console.aws.amazon.com/ecr/repositories/private/296255494825/notify/api-lambda?region=ca-central-1) (requires Notification-Production / AdministratorAccess login)
    - [ ] [api k8s](https://gallery.ecr.aws/v6b8u5o6/notify-api)
    - [ ] [admin](https://gallery.ecr.aws/v6b8u5o6/notify-admin)
    - [ ] [documentation](https://gallery.ecr.aws/v6b8u5o6/notify-documentation)
    - [ ] [document download API](https://gallery.ecr.aws/v6b8u5o6/notify-document-download-api)

## Checklist if making changes to Kubernetes:
- [ ] I know how to get kubectl credentials in case it catches on fire

## After merging this PR
- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.