### PR TITLE
Setting minimum replicas for doc download and documentation to 2

### DIFF
--- a/env/staging/replica_count.yaml
+++ b/env/staging/replica_count.yaml
@@ -36,7 +36,7 @@ metadata:
   name:  documentation
   namespace: notification-canada-ca
 spec:
-  replicas: 1
+  replicas: 2
 ---
 apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
@@ -71,5 +71,5 @@ metadata:
   name: document-download-api-hpa
   namespace: notification-canada-ca
 spec:
-  minReplicas: 1
+  minReplicas: 2
   maxReplicas: 4


### PR DESCRIPTION
## What happens when your PR merges?
Document download and documentation scale up to 2 pods

## What are you changing?
- [X] Changing kubernetes configuration

## Provide some background on the changes
Setting the minimum pods for all deployments to 2 in prep for k8s upgrade.

## If you are releasing a new version of Notify, what components are you updating
- [ ] API
- [ ] Admin
- [X] Documentation
- [X] Document download API

## Checklist if making changes to Kubernetes:
- [X] I know how to get kubectl credentials in case it catches on fire

## After merging this PR
- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.