### PR TITLE
[MANIFEST] Scaling out prod documentation and doc download in prep for k8s upgrade

### DIFF
--- a/env/production/replica_count.yaml
+++ b/env/production/replica_count.yaml
@@ -36,7 +36,7 @@ metadata:
   name:  documentation
   namespace: notification-canada-ca
 spec:
-  replicas: 1
+  replicas: 2
 ---
 apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
@@ -71,5 +71,5 @@ metadata:
   name: document-download-api-hpa
   namespace: notification-canada-ca
 spec:
-  minReplicas: 1
+  minReplicas: 2
   maxReplicas: 4


### PR DESCRIPTION
## What happens when your PR merges?
Documentation and Document Download APIs will scale out to 2 pods minimum. This is in preparation for the K8s upgrade so that there will always be at least one pod running.

## What are you changing?
- [x] Changing kubernetes configuration

## Provide some background on the changes
Required for ensuring no downtime while upgrading k8s to 1.23

## If you are releasing a new version of Notify, what components are you updating
- [X] Documentation
- [X] Document download API

## Checklist if releasing new version:
- [X] I made sure that the changes are as expected in [Notify staging](https://staging.notification.cdssandbox.xyz/)

## Checklist if making changes to Kubernetes:
- [X] I know how to get kubectl credentials in case it catches on fire

## After merging this PR
- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.