### PR TITLE
HPA api version migrated from beta to v2 for k8s 1.24

### DIFF
--- a/base/admin-hpa.yaml
+++ b/base/admin-hpa.yaml
@@ -4,6 +4,7 @@ metadata:
   name: admin-hpa
   namespace: notification-canada-ca
 spec:
+  minReplicas: 1
   maxReplicas: 2
   metrics:
   - resource:
@@ -12,7 +13,6 @@ spec:
         averageUtilization: 50
         type: Utilization
     type: Resource
-  minReplicas: 1
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment

--- a/base/admin-hpa.yaml
+++ b/base/admin-hpa.yaml
@@ -1,19 +1,19 @@
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: admin-hpa
   namespace: notification-canada-ca
 spec:
-  minReplicas: 1
   maxReplicas: 2
+  metrics:
+  - resource:
+      name: cpu
+      target:
+        averageUtilization: 50
+        type: Utilization
+    type: Resource
+  minReplicas: 1
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
     name: admin
-  metrics:
-  - type: Resource
-    resource:
-      name: cpu
-      target:
-        type: Utilization
-        averageUtilization: 50

--- a/base/api-hpa.yaml
+++ b/base/api-hpa.yaml
@@ -1,19 +1,19 @@
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: api-hpa
   namespace: notification-canada-ca
 spec:
-  minReplicas: 1
   maxReplicas: 2
+  metrics:
+  - resource:
+      name: cpu
+      target:
+        averageUtilization: 50
+        type: Utilization
+    type: Resource
+  minReplicas: 1
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
     name: api
-  metrics:
-  - type: Resource
-    resource:
-      name: cpu
-      target:
-        type: Utilization
-        averageUtilization: 50

--- a/base/api-hpa.yaml
+++ b/base/api-hpa.yaml
@@ -4,6 +4,7 @@ metadata:
   name: api-hpa
   namespace: notification-canada-ca
 spec:
+  minReplicas: 1
   maxReplicas: 2
   metrics:
   - resource:
@@ -12,7 +13,6 @@ spec:
         averageUtilization: 50
         type: Utilization
     type: Resource
-  minReplicas: 1
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment

--- a/base/celery-hpa.yaml
+++ b/base/celery-hpa.yaml
@@ -1,25 +1,25 @@
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: celery-hpa
   namespace: notification-canada-ca
 spec:
-  minReplicas: 1
   maxReplicas: 2
+  metrics:
+  - resource:
+      name: cpu
+      target:
+        averageUtilization: 50
+        type: Utilization
+    type: Resource
+  - resource:
+      name: memory
+      target:
+        averageUtilization: 75
+        type: Utilization
+    type: Resource
+  minReplicas: 1
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
     name: celery
-  metrics:
-  - type: Resource
-    resource:
-      name: cpu
-      target:
-        type: Utilization
-        averageUtilization: 50
-  - type: Resource
-    resource:
-      name: memory
-      target:
-        type: Utilization
-        averageUtilization: 75

--- a/base/celery-hpa.yaml
+++ b/base/celery-hpa.yaml
@@ -4,6 +4,7 @@ metadata:
   name: celery-hpa
   namespace: notification-canada-ca
 spec:
+  minReplicas: 1
   maxReplicas: 2
   metrics:
   - resource:
@@ -18,7 +19,6 @@ spec:
         averageUtilization: 75
         type: Utilization
     type: Resource
-  minReplicas: 1
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment

--- a/base/document-download-api-hpa.yaml
+++ b/base/document-download-api-hpa.yaml
@@ -4,6 +4,7 @@ metadata:
   name: document-download-api-hpa
   namespace: notification-canada-ca
 spec:
+  minReplicas: 1
   maxReplicas: 2
   metrics:
   - resource:
@@ -12,7 +13,6 @@ spec:
         averageUtilization: 35
         type: Utilization
     type: Resource
-  minReplicas: 1
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment

--- a/base/document-download-api-hpa.yaml
+++ b/base/document-download-api-hpa.yaml
@@ -1,19 +1,19 @@
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: document-download-api-hpa
   namespace: notification-canada-ca
 spec:
-  minReplicas: 1
   maxReplicas: 2
+  metrics:
+  - resource:
+      name: cpu
+      target:
+        averageUtilization: 35
+        type: Utilization
+    type: Resource
+  minReplicas: 1
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
     name: document-download-api
-  metrics:
-  - type: Resource
-    resource:
-      name: cpu
-      target:
-        type: Utilization
-        averageUtilization: 35

--- a/env/production/replica_count.yaml
+++ b/env/production/replica_count.yaml
@@ -38,7 +38,7 @@ metadata:
 spec:
   replicas: 2
 ---
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: admin-hpa
@@ -47,7 +47,7 @@ spec:
   minReplicas: 2
   maxReplicas: 3
 ---
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: api-hpa
@@ -56,7 +56,7 @@ spec:
   minReplicas: 4
   maxReplicas: 8
 ---
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: celery-hpa
@@ -65,7 +65,7 @@ spec:
   minReplicas: 3
   maxReplicas: 10
 ---
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: document-download-api-hpa

--- a/env/scratch/replica_count.yaml
+++ b/env/scratch/replica_count.yaml
@@ -38,7 +38,7 @@ metadata:
 spec:
   replicas: 2
 ---
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: admin-hpa
@@ -47,7 +47,7 @@ spec:
   minReplicas: 2
   maxReplicas: 2
 ---
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: api-hpa
@@ -56,7 +56,7 @@ spec:
   minReplicas: 4
   maxReplicas: 4
 ---
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: celery-hpa
@@ -65,7 +65,7 @@ spec:
   minReplicas: 3
   maxReplicas: 10
 ---
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: document-download-api-hpa

--- a/env/staging/replica_count.yaml
+++ b/env/staging/replica_count.yaml
@@ -38,7 +38,7 @@ metadata:
 spec:
   replicas: 2
 ---
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: admin-hpa
@@ -47,7 +47,7 @@ spec:
   minReplicas: 2
   maxReplicas: 2
 ---
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: api-hpa
@@ -56,7 +56,7 @@ spec:
   minReplicas: 4
   maxReplicas: 4
 ---
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: celery-hpa
@@ -65,7 +65,7 @@ spec:
   minReplicas: 3
   maxReplicas: 10
 ---
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: document-download-api-hpa


### PR DESCRIPTION
## What happens when your PR merges?
The horizontal pod autoscalers for GC Notify will be converted to the v2 api spec away from the v2beta api spec which is no longer supported as of K8s v1.24

## What are you changing?
- [X] Changing kubernetes configuration

## Provide some background on the changes
K8s v1.24 removes support for autoscaling/v2beta api. I have converted the HPAs for notify to the new v2 api format. Tested working in my scratch account

## Checklist if making changes to Kubernetes:
- [X] I know how to get kubectl credentials in case it catches on fire
