### PR TITLE
Lowering initial CPU requests since we are over requesting

### DIFF
--- a/base/admin-deployment.yaml
+++ b/base/admin-deployment.yaml
@@ -128,7 +128,7 @@ spec:
               value: '$(FF_ABTEST_SERVICE_ID)'
           resources:
             requests:
-              cpu: "250"
+              cpu: "250m"
               memory: "700Mi"
             limits:
               cpu: "1200m"

--- a/base/api-deployment.yaml
+++ b/base/api-deployment.yaml
@@ -260,7 +260,7 @@ spec:
               value: '$(FF_BOUNCE_RATE_BACKEND)'
           resources:
             requests:
-              cpu: "200"
+              cpu: "200m"
               memory: "700Mi"
             limits:
               cpu: "1200m"


### PR DESCRIPTION
## What happens when your PR merges?
The CPU requests for API and Admin pods will be reduced since they are currently requesting a high level of resources but not using them. The limits will stay the same, so the pods will start off with low CPU but will be able to request more as required.

## What are you changing?
- [X] Changing kubernetes configuration

## Provide some background on the changes
We are running into resourcing limits in prod and staging but in reality we are just reserving large blocks of resources without actually using them.

## Checklist if making changes to Kubernetes:
- [X] I know how to get kubectl credentials in case it catches on fire

