### PR TITLE
Changing Celery CPU request to 100m and upping to 20 replicas max (Staging)

### DIFF
--- a/env/staging/replica_count.yaml
+++ b/env/staging/replica_count.yaml
@@ -33,7 +33,7 @@ spec:
       - name: celery
         resources:
           requests:
-            cpu: "300m"
+            cpu: "100m"
             memory: "500Mi"
           limits:
             cpu: "550m"
@@ -74,7 +74,7 @@ metadata:
   namespace: notification-canada-ca
 spec:
   minReplicas: 3
-  maxReplicas: 10
+  maxReplicas: 20
 ---
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler


### PR DESCRIPTION
## What happens when your PR merges?
Celery CPU requests will be reverted to 100m, and the max replicas will be upped to 20

## What are you changing?
- [X] Changing kubernetes configuration

## Provide some background on the changes
Celery performance tuning

## Checklist if making changes to Kubernetes:
- [X] I know how to get kubectl credentials in case it catches on fire
