### PR TITLE
Celery HPA CPU only

### DIFF
--- a/base/celery-hpa.yaml
+++ b/base/celery-hpa.yaml
@@ -6,19 +6,6 @@ metadata:
 spec:
   minReplicas: 1
   maxReplicas: 2
-  metrics:
-  - resource:
-      name: cpu
-      target:
-        averageUtilization: 50
-        type: Utilization
-    type: Resource
-  - resource:
-      name: memory
-      target:
-        averageUtilization: 75
-        type: Utilization
-    type: Resource
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment

--- a/env/production/replica_count.yaml
+++ b/env/production/replica_count.yaml
@@ -64,6 +64,19 @@ metadata:
 spec:
   minReplicas: 3
   maxReplicas: 10
+  metrics:
+  - resource:
+      name: cpu
+      target:
+        averageUtilization: 50
+        type: Utilization
+    type: Resource
+  - resource:
+      name: memory
+      target:
+        averageUtilization: 75
+        type: Utilization
+    type: Resource    
 ---
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler

--- a/env/scratch/replica_count.yaml
+++ b/env/scratch/replica_count.yaml
@@ -75,6 +75,13 @@ metadata:
 spec:
   minReplicas: 3
   maxReplicas: 10
+  metrics:
+  - resource:
+      name: cpu
+      target:
+        averageUtilization: 50
+        type: Utilization
+    type: Resource
 ---
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler

--- a/env/staging/replica_count.yaml
+++ b/env/staging/replica_count.yaml
@@ -75,6 +75,13 @@ metadata:
 spec:
   minReplicas: 3
   maxReplicas: 20
+  metrics:
+  - resource:
+      name: cpu
+      target:
+        averageUtilization: 50
+        type: Utilization
+    type: Resource
 ---
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler


### PR DESCRIPTION
## What happens when your PR merges?
The HPA for celery in scratch and staging will set to scale based off of CPU usage only, since this process seems to be more CPU bound.

## What are you changing?
- [X] Changing kubernetes configuration

## Provide some background on the changes
Part of celery performance tuning

## Checklist if making changes to Kubernetes:
- [X] I know how to get kubectl credentials in case it catches on fire

## After merging this PR
- [x] I have verified that the tests / deployment actions succeeded
- [x] I have verified that any affected pods were restarted successfully
- [x] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [x] I have verified that the smoke tests still pass on production
- [x] I have communicated the release in the #notify Slack channel.