### PR TITLE
Upping celery HPA max to 40

### DIFF
--- a/env/staging/replica_count.yaml
+++ b/env/staging/replica_count.yaml
@@ -74,7 +74,7 @@ metadata:
   namespace: notification-canada-ca
 spec:
   minReplicas: 3
-  maxReplicas: 20
+  maxReplicas: 40
   metrics:
   - resource:
       name: cpu


### PR DESCRIPTION
## What happens when your PR merges?
Maximum number of celery workers will increase to 40 in staging only.

## What are you changing?
- [X] Changing kubernetes configuration

## Provide some background on the changes
Re: Celery performance tuning

## Checklist if making changes to Kubernetes:
- [X] I know how to get kubectl credentials in case it catches on fire
