### PR TITLE
Upping celery to 60 max replicas in staging

### DIFF
--- a/env/staging/replica_count.yaml
+++ b/env/staging/replica_count.yaml
@@ -74,7 +74,7 @@ metadata:
   namespace: notification-canada-ca
 spec:
   minReplicas: 3
-  maxReplicas: 40
+  maxReplicas: 60
   metrics:
   - resource:
       name: cpu


### PR DESCRIPTION
Upping celery to 60 max replicas in staging