### PR TITLE
Setting termination grace period to 60

### DIFF
--- a/base/admin-deployment.yaml
+++ b/base/admin-deployment.yaml
@@ -163,5 +163,5 @@ spec:
       restartPolicy: Always
       schedulerName: default-scheduler
       securityContext: {}
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
 status: {}

--- a/base/api-deployment.yaml
+++ b/base/api-deployment.yaml
@@ -297,5 +297,5 @@ spec:
       restartPolicy: Always
       schedulerName: default-scheduler
       securityContext: {}
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
 status: {}

--- a/base/celery-deployment-fargate.yaml
+++ b/base/celery-deployment-fargate.yaml
@@ -106,5 +106,5 @@ spec:
       securityContext:
         fsGroup: 65534
       serviceAccountName: notification-service-account
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
 status: {}

--- a/base/celery-deployment.yaml
+++ b/base/celery-deployment.yaml
@@ -136,5 +136,5 @@ spec:
       restartPolicy: Always
       schedulerName: default-scheduler
       securityContext: {}
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
 status: {}

--- a/base/celery-sms-deployment.yaml
+++ b/base/celery-sms-deployment.yaml
@@ -122,5 +122,5 @@ spec:
       restartPolicy: Always
       schedulerName: default-scheduler
       securityContext: {}
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
 status: {}

--- a/base/document-download-api-deployment.yaml
+++ b/base/document-download-api-deployment.yaml
@@ -80,5 +80,5 @@ spec:
       restartPolicy: Always
       schedulerName: default-scheduler
       securityContext: {}
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
 status: {}

--- a/base/documentation-deployment.yaml
+++ b/base/documentation-deployment.yaml
@@ -54,4 +54,4 @@ spec:
       restartPolicy: Always
       schedulerName: default-scheduler
       securityContext: {}
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60


### PR DESCRIPTION
## What happens when your PR merges?
Setting termination grace period to 60 on all k8s deployments to allow for proper connection draining

## What are you changing?
- [X] Changing kubernetes configuration

## Provide some background on the changes
This in support of doing node maintenance with k8s cordon and drain.

## Checklist if making changes to Kubernetes:
- [X] I know how to get kubectl credentials in case it catches on fire
