### PR TITLE
80 celery pods on staging

### DIFF
--- a/env/staging/replica_count.yaml
+++ b/env/staging/replica_count.yaml
@@ -74,7 +74,7 @@ metadata:
   namespace: notification-canada-ca
 spec:
   minReplicas: 3
-  maxReplicas: 60
+  maxReplicas: 80
   metrics:
   - resource:
       name: cpu


### PR DESCRIPTION

## What are you changing?
- [ ] Releasing a new version of Notify
- [ ] Changing kubernetes configuration

## Provide some background on the changes
staging celery maxReplicas 60 -> 80
