### PR TITLE
Setting staging HPA tuning to 12 pods per cycle at 45 seconds

### DIFF
--- a/env/staging/performance.yaml
+++ b/env/staging/performance.yaml
@@ -87,8 +87,8 @@ spec:
       stabilizationWindowSeconds: 0
       policies:
       - type: Pods
-        value: 4
-        periodSeconds: 60
+        value: 12
+        periodSeconds: 45
       selectPolicy: Max            
 ---
 apiVersion: autoscaling/v2


### PR DESCRIPTION
## What happens when your PR merges?
Set celery HPA tuning to 12 pods per iteration at 45 seconds per. 

## What are you changing?
- [X] Changing kubernetes configuration

## Provide some background on the changes
Re: Celery perf tuning

## Checklist if making changes to Kubernetes:
- [X] I know how to get kubectl credentials in case it catches on fire
