### PR TITLE
Lowering staging to 10 celery pods

### DIFF
--- a/env/staging/performance.yaml
+++ b/env/staging/performance.yaml
@@ -74,7 +74,7 @@ metadata:
   namespace: notification-canada-ca
 spec:
   minReplicas: 3
-  maxReplicas: 73
+  maxReplicas: 10
   metrics:
   - resource:
       name: cpu


### PR DESCRIPTION
## What happens when your PR merges?
This will lower the number of max celery pods in staging to 10 for @jimleroyer to investigate other performance avenues

## What are you changing?
- [X] Changing kubernetes configuration

## Provide some background on the changes
Re: Notify perf testing

## Checklist if making changes to Kubernetes:
- [X] I know how to get kubectl credentials in case it catches on fire
