### PR TITLE
fix: sms send script name

### DIFF
--- a/env/scratch/celery-sms-send-deployment.yaml
+++ b/env/scratch/celery-sms-send-deployment.yaml
@@ -122,7 +122,7 @@ spec:
                 - -c
                 - /app/scripts/run_celery_exit.sh
           command: ["/bin/sh"]
-          args: ["-c", "sh /app/scripts/run_celery_sms_send.sh"]
+          args: ["-c", "sh /app/scripts/run_celery_send_sms.sh"]
           resources:
             requests:
               cpu: "100m"

--- a/env/staging/celery-sms-send-deployment.yaml
+++ b/env/staging/celery-sms-send-deployment.yaml
@@ -122,7 +122,7 @@ spec:
                 - -c
                 - /app/scripts/run_celery_exit.sh
           command: ["/bin/sh"]
-          args: ["-c", "sh /app/scripts/run_celery_sms_send.sh"]
+          args: ["-c", "sh /app/scripts/run_celery_send_sms.sh"]
           resources:
             requests:
               cpu: "100m"


### PR DESCRIPTION
## What happens when your PR merges?

    - `fix:` - tag `main` as a new patch release

## What are you changing?
- [ ] Releasing a new version of Notify
- [ ] Changing kubernetes configuration

## Provide some background on the changes
fix the name of [the script](https://github.com/cds-snc/notification-api/blob/8caba67c2c9ba58d33738dbf05854e989e92ba8d/scripts/run_celery_send_sms.sh)  
run_celery_sms_send.sh -> run_celery_send_sms.sh


## If you are releasing a new version of Notify, what components are you updating
- [ ] API
- [ ] Admin
- [ ] Documentation
- [ ] Document download API

## Checklist if releasing new version:
- [ ] I made sure that the changes are as expected in [Notify staging](https://staging.notification.cdssandbox.xyz/)
- [ ] I have checked if the docker images I am referencing exist
    - [ ] [api lambda](https://ca-central-1.console.aws.amazon.com/ecr/repositories/private/296255494825/notify/api-lambda?region=ca-central-1) (requires Notification-Production / AdministratorAccess login)
    - [ ] [api k8s](https://gallery.ecr.aws/v6b8u5o6/notify-api)
    - [ ] [admin](https://gallery.ecr.aws/v6b8u5o6/notify-admin)
    - [ ] [documentation](https://gallery.ecr.aws/v6b8u5o6/notify-documentation)
    - [ ] [document download API](https://gallery.ecr.aws/v6b8u5o6/notify-document-download-api)

## Checklist if making changes to Kubernetes:
- [ ] I know how to get kubectl credentials in case it catches on fire

## After merging this PR
- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.