### PR TITLE
Setting staging celery and utils to run on spot instances

### DIFF
--- a/env/staging/celery-deployment.yaml
+++ b/env/staging/celery-deployment.yaml
@@ -23,6 +23,8 @@ spec:
         app: celery
         # profile: fargate
     spec:
+      nodeSelector: 
+        karpenter.sh/provisioner-name: default    
       containers:
         - image: api
           imagePullPolicy: Always

--- a/env/staging/celery-sms-send-deployment.yaml
+++ b/env/staging/celery-sms-send-deployment.yaml
@@ -21,6 +21,8 @@ spec:
       labels:
         app: celery-sms-send
     spec:
+      nodeSelector: 
+        karpenter.sh/provisioner-name: default    
       containers:
         - image: api
           imagePullPolicy: Always

--- a/env/staging/hasura-patch.yaml
+++ b/env/staging/hasura-patch.yaml
@@ -1,0 +1,12 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hasura
+  namespace: notification-canada-ca
+  labels:
+    app: hasura
+spec:
+  template:
+    spec:
+      nodeSelector: 
+        karpenter.sh/provisioner-name: default    

--- a/env/staging/jump-box-patch.yaml
+++ b/env/staging/jump-box-patch.yaml
@@ -1,0 +1,12 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: jump-box
+  namespace: notification-canada-ca
+  labels:
+    app: jump-box
+spec:
+  template:
+    spec:
+      nodeSelector: 
+        karpenter.sh/provisioner-name: default    

--- a/env/staging/kustomization.yaml
+++ b/env/staging/kustomization.yaml
@@ -35,6 +35,8 @@ patches:
   - cwagent-patch.yaml
   - celery-deployment.yaml
   - karpenter.yaml  
+  - hasura-patch.yaml
+  - jump-box-patch.yaml
 
 vars:
 - name: ADMIN_CLIENT_SECRET


### PR DESCRIPTION
## What happens when your PR merges?
Both celery batch sends (email and sms) as well as hasura and the jump box will run on spot instances provisioned by karpenter only. This will allow us to scale back our full time nodes and save some cash!

## What are you changing?
- [X] Changing kubernetes configuration

## Provide some background on the changes
Part of performance tuning

## Checklist if making changes to Kubernetes:
- [X] I know how to get kubectl credentials in case it catches on fire
