### PR TITLE
Celery sms send hpa tuning

### DIFF
--- a/env/staging/performance.yaml
+++ b/env/staging/performance.yaml
@@ -124,7 +124,7 @@ spec:
   - resource:
       name: cpu
       target:
-        averageUtilization: 50
+        averageUtilization: 25
         type: Utilization
     type: Resource
   behavior:

--- a/env/staging/performance.yaml
+++ b/env/staging/performance.yaml
@@ -54,7 +54,7 @@ spec:
       - name: celery-sms-send
         resources:
           requests:
-            cpu: "100m"
+            cpu: "50m"
             memory: "500Mi"
           limits:
             cpu: "550m"
@@ -124,7 +124,7 @@ spec:
   - resource:
       name: cpu
       target:
-        averageUtilization: 25
+        averageUtilization: 50
         type: Utilization
     type: Resource
   behavior:


### PR DESCRIPTION
## What happens when your PR merges?
Instead of lowering the threshold for Celery sms CPU HPA, lets lower the CPU request, which should in theory raise the reported CPU usage on the pods, and thus cause the HPA to kick in.

## What are you changing?
- [X] Changing kubernetes configuration

## Provide some background on the changes
Part of SMS tuning
