### PR TITLE
sms-send back up to 10 pods

### DIFF
--- a/env/staging/performance.yaml
+++ b/env/staging/performance.yaml
@@ -119,7 +119,7 @@ metadata:
   namespace: notification-canada-ca
 spec:
   minReplicas: 3
-  maxReplicas: 5
+  maxReplicas: 10
   metrics:
   - resource:
       name: cpu


### PR DESCRIPTION

## Provide some background on the changes

set sms-send maxReplicas back up to 10. Hopefully now we'll be able to scale up and stay there. 