### PR TITLE
Upping celery sms hpa to 11 max pods

### DIFF
--- a/env/staging/performance.yaml
+++ b/env/staging/performance.yaml
@@ -119,7 +119,7 @@ metadata:
   namespace: notification-canada-ca
 spec:
   minReplicas: 3
-  maxReplicas: 10
+  maxReplicas: 11
   metrics:
   - resource:
       name: cpu


### PR DESCRIPTION
## What happens when your PR merges?
Staging Celery HPA for SMS will max out at 11 pods to try and achieve 600/s

## What are you changing?
- [X] Changing kubernetes configuration

## Provide some background on the changes
Re: SMS Perf Tuning
