### PR TITLE
fix: force 11 sms-send pods

### DIFF
--- a/env/production/performance.yaml
+++ b/env/production/performance.yaml
@@ -108,7 +108,7 @@ metadata:
   name: celery-sms-send-hpa
   namespace: notification-canada-ca
 spec:
-  minReplicas: 3
+  minReplicas: 11
   maxReplicas: 11
   metrics:
   - resource:

--- a/env/staging/performance.yaml
+++ b/env/staging/performance.yaml
@@ -118,7 +118,7 @@ metadata:
   name: celery-sms-send-hpa
   namespace: notification-canada-ca
 spec:
-  minReplicas: 3
+  minReplicas: 11
   maxReplicas: 11
   metrics:
   - resource:


### PR DESCRIPTION
## What happens when your PR merges?
    - `fix:` - tag `main` as a new patch release

## What are you changing?
- [ ] Releasing a new version of Notify
- [ ] Changing kubernetes configuration

## Provide some background on the changes
sms-send pods only scaling to 4, this will set to 11 until we get the scaling up figured out

## If you are releasing a new version of Notify, what components are you updating
- [ ] API
- [ ] Admin
- [ ] Documentation
- [ ] Document download API

## Checklist if releasing new version:
- [ ] I made sure that the changes are as expected in [Notify staging](https://staging.notification.cdssandbox.xyz/)
- [ ] I have checked if the docker images I am referencing exist
    - [ ] [api lambda](https://ca-central-1.console.aws.amazon.com/ecr/repositories/private/296255494825/notify/api-lambda?region=ca-central-1) (requires Notification-Production / AdministratorAccess login)
    - [ ] [api k8s](https://gallery.ecr.aws/v6b8u5o6/notify-api)
    - [ ] [admin](https://gallery.ecr.aws/v6b8u5o6/notify-admin)
    - [ ] [documentation](https://gallery.ecr.aws/v6b8u5o6/notify-documentation)
    - [ ] [document download API](https://gallery.ecr.aws/v6b8u5o6/notify-document-download-api)

## Checklist if making changes to Kubernetes:
- [ ] I know how to get kubectl credentials in case it catches on fire

## After merging this PR
- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.