### PR TITLE
Setting minimum pods to 3 for sms in staging

### DIFF
--- a/env/staging/performance.yaml
+++ b/env/staging/performance.yaml
@@ -118,7 +118,7 @@ metadata:
   name: celery-sms-send-hpa
   namespace: notification-canada-ca
 spec:
-  minReplicas: 11
+  minReplicas: 3
   maxReplicas: 11
   metrics:
   - resource:


### PR DESCRIPTION
## What happens when your PR merges?
SMS Celery in staging will reduce to 3 minimum pods, so that we can verify the scaling issues we're seeing in production

## What are you changing?
- [X] Changing kubernetes configuration

## Provide some background on the changes
Re: Performance tuning
