### PR TITLE
adding pod disruption budget for api

### DIFF
--- a/base/notify-api/api-pod-disruption-budget.yaml
+++ b/base/notify-api/api-pod-disruption-budget.yaml
@@ -1,0 +1,12 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: api
+  namespace: notification-canada-ca
+  labels:
+    app: api
+spec:
+  maxUnavailable: 2
+  selector:
+    matchLabels:
+      app: api

--- a/base/notify-api/kustomization.yaml
+++ b/base/notify-api/kustomization.yaml
@@ -2,5 +2,6 @@ resources:
   - api-deployment.yaml
   - api-service.yaml
   - api-hpa.yaml
+  - api-pod-disruption-budget.yaml
 
   


### PR DESCRIPTION
## What happens when your PR merges?
A pod disruption budget for the api pods in kubernetes will be set. We will not allow more than two pods to be down at once. This will hopefully force karpenter to be patient when shuffling things around.

## What are you changing?
- [X] Changing kubernetes configuration

## Provide some background on the changes
Re: Performance tuning 

