### PR TITLE
Changing the prod workflow to use the retry script for kustomize

### DIFF
--- a/.github/workflows/merge_to_main_production.yaml
+++ b/.github/workflows/merge_to_main_production.yaml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Apply changes
         run: |
-          kubectl apply -k env/production --kubeconfig=/home/runner/.kube/config
+          ./scripts/applyKube.sh env/production --kubeconfig=/home/runner/.kube/config
 
       - name: Check for env changes
         working-directory: env/production


### PR DESCRIPTION
## What happens when your PR merges?
The prod k8s workflow will use the auto-retry script for kustomize apply

## What are you changing?
- [X] Changing kubernetes configuration

## Provide some background on the changes
Re: Performance tuning

