### PR TITLE
Setting production to run celery on karpenter nodes

### DIFF
--- a/env/production/node-selector-patch.yaml
+++ b/env/production/node-selector-patch.yaml
@@ -2,10 +2,6 @@
 
 #### KARPENTER SPOT INSTANCES - EPHEMERAL, STATE NOT REQUIRED
 
-# NONE UNTIL KARPENTER IS IN PROD
-
-### ON DEMAND (PRIMARY) NODES - ALWAYS AVAILABLE
-
 # Celery Email
 apiVersion: apps/v1
 kind: Deployment
@@ -18,7 +14,7 @@ spec:
   template:
     spec:
       nodeSelector:
-        eks.amazonaws.com/capacityType: ON_DEMAND    
+        karpenter.sh/provisioner-name: default
 ---
 # Celery SMS Send
 apiVersion: apps/v1
@@ -32,8 +28,10 @@ spec:
   template:
     spec:
       nodeSelector:
-        eks.amazonaws.com/capacityType: ON_DEMAND    
+        karpenter.sh/provisioner-name: default    
 ---
+### ON DEMAND (PRIMARY) NODES - ALWAYS AVAILABLE
+
 # Notification API K8s
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
## What happens when your PR merges?
When released, celery will use Karpenter nodes again.

We have introduced a cwagent health check script that should fix the intermittent metric send errors.

## What are you changing?
- [X] Changing kubernetes configuration

## Provide some background on the changes
Re: Celery performance tuning and node autoscaling

## Checklist if making changes to Kubernetes:
- [X] I know how to get kubectl credentials in case it catches on fire

