### PR TITLE
Moving API off of karpenter nodes for now while we look into 502s

### DIFF
--- a/env/staging/node-selector-patch.yaml
+++ b/env/staging/node-selector-patch.yaml
@@ -30,6 +30,8 @@ spec:
       nodeSelector:
         karpenter.sh/provisioner-name: default    
 ---
+### ON DEMAND (PRIMARY) NODES - ALWAYS AVAILABLE
+
 # Notification API K8s
 apiVersion: apps/v1
 kind: Deployment
@@ -42,10 +44,8 @@ spec:
   template:
     spec:
       nodeSelector:
-        karpenter.sh/provisioner-name: default
+        eks.amazonaws.com/capacityType: ON_DEMAND    
 ---
-
-### ON DEMAND (PRIMARY) NODES - ALWAYS AVAILABLE
 # Celery Beat
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
## What happens when your PR merges?
In staging, the API will now deploy to standard k8s nodes instead of karpenter spot instances. This is to get rid of the 502 errors we're intermittently seeing. A new card will be opened to debug that.

## What are you changing?
- [X] Changing kubernetes configuration

