### PR TITLE
Setting system logging components to be node cricial priority

### DIFF
--- a/base/k8s-event-logger/deployment.yaml
+++ b/base/k8s-event-logger/deployment.yaml
@@ -22,6 +22,7 @@ spec:
         app.kubernetes.io/instance: k8s-event-logger
     spec:
       serviceAccountName: k8s-event-logger
+      priorityClassName: system-node-critical
       containers:
         - name: app
           image: "maxrocketinternet/k8s-event-logger:2.2"

--- a/base/kube-state-metrics/ksm-deployment.yaml
+++ b/base/kube-state-metrics/ksm-deployment.yaml
@@ -20,6 +20,7 @@ spec:
         app.kubernetes.io/version: 2.8.2
     spec:
       automountServiceAccountToken: true
+      priorityClassName: system-node-critical
       containers:
       - image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.8.2
         livenessProbe:

--- a/base/notify-celery/celery-deployment.yaml
+++ b/base/notify-celery/celery-deployment.yaml
@@ -132,6 +132,20 @@ spec:
             limits:
               cpu: "550m"
               memory: "1024Mi"
+          livenessProbe:
+            exec:
+              command:
+              - cat
+              - /tmp/celery.pid
+            initialDelaySeconds: 5
+            periodSeconds: 5     
+          readinessProbe:
+            exec:
+              command:
+              - cat
+              - /tmp/celery.pid
+            initialDelaySeconds: 5
+            periodSeconds: 5                          
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler

--- a/base/notify-celery/celery-sms-send-deployment.yaml
+++ b/base/notify-celery/celery-sms-send-deployment.yaml
@@ -132,6 +132,20 @@ spec:
             limits:
               cpu: "550m"
               memory: "1024Mi"
+          livenessProbe:
+            exec:
+              command:
+              - cat
+              - /tmp/celery.pid
+            initialDelaySeconds: 5
+            periodSeconds: 5     
+          readinessProbe:
+            exec:
+              command:
+              - cat
+              - /tmp/celery.pid
+            initialDelaySeconds: 5
+            periodSeconds: 5                 
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler

--- a/base/prometheus-cloudwatch/cwagent-deployment.yaml
+++ b/base/prometheus-cloudwatch/cwagent-deployment.yaml
@@ -13,6 +13,7 @@ spec:
       labels:
         app: cwagent-prometheus
     spec:
+      priorityClassName: system-node-critical
       containers:
         - name: cloudwatch-agent
           image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.247358.0b252413


### PR DESCRIPTION
## What happens when your PR merges?
We will set the logging system components to be node critical priority (IE they have the authority to kick off other pods in the event that there aren't enough resources). 

## What are you changing?
- [X] Changing kubernetes configuration

## Provide some background on the changes
Re: Node autoscaling and performance tuning.

