### PR TITLE
reverting probes for celery since they aren't working properly

### DIFF
--- a/base/notify-celery/celery-deployment.yaml
+++ b/base/notify-celery/celery-deployment.yaml
@@ -132,20 +132,6 @@ spec:
             limits:
               cpu: "550m"
               memory: "1024Mi"
-          livenessProbe:
-            exec:
-              command:
-              - cat
-              - /tmp/celery.pid
-            initialDelaySeconds: 5
-            periodSeconds: 5     
-          readinessProbe:
-            exec:
-              command:
-              - cat
-              - /tmp/celery.pid
-            initialDelaySeconds: 5
-            periodSeconds: 5                          
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler

--- a/base/notify-celery/celery-sms-send-deployment.yaml
+++ b/base/notify-celery/celery-sms-send-deployment.yaml
@@ -132,20 +132,6 @@ spec:
             limits:
               cpu: "550m"
               memory: "1024Mi"
-          livenessProbe:
-            exec:
-              command:
-              - cat
-              - /tmp/celery.pid
-            initialDelaySeconds: 5
-            periodSeconds: 5     
-          readinessProbe:
-            exec:
-              command:
-              - cat
-              - /tmp/celery.pid
-            initialDelaySeconds: 5
-            periodSeconds: 5                 
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler


### PR DESCRIPTION
## What happens when your PR merges?
The celery health probes are not working correctly in staging. Reverting them for now so we can do a manifest release. I will create a card to investigate improvements here.

## What are you changing?
- [X] Changing kubernetes configuration

