### PR TITLE
feat: set staging sms minreplicas to 3

### DIFF
--- a/env/staging/performance.yaml
+++ b/env/staging/performance.yaml
@@ -118,7 +118,7 @@ metadata:
   name: celery-sms-send-hpa
   namespace: notification-canada-ca
 spec:
-  minReplicas: 11
+  minReplicas: 3
   maxReplicas: 20
   metrics:
   - resource:


### PR DESCRIPTION
## What happens when your PR merges?
    - `feat:` - tag `main` as a new minor release

## What are you changing?
- [ ] Releasing a new version of Notify
- [x] Changing kubernetes configuration

## Provide some background on the changes

Currently prod has constant 11 sm-send pods. We've fixed the "sms priority queue delay on pod shutdown" issue 🤞 so we can now ramp sms pods up and down without alarms.

We've had staging scale 11 - 20 sms pods for a while, so may as well start with a max of 20.

This PR sets staging to scale 3 - 20. We can kick the tires on this and then set prod to the same.

## Checklist if making changes to Kubernetes:
- [ ] I know how to get kubectl credentials in case it catches on fire

## After merging this PR
- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.