### PR TITLE
Setting celery sms cpu threshold to 25% in staging

### DIFF
--- a/env/staging/performance.yaml
+++ b/env/staging/performance.yaml
@@ -124,7 +124,7 @@ spec:
   - resource:
       name: cpu
       target:
-        averageUtilization: 50
+        averageUtilization: 25
         type: Utilization
     type: Resource
   behavior:


### PR DESCRIPTION
## What happens when your PR merges?
Celery HPA CPU threshold will be set to 25% in staging only. Testing to get more throughput out of SMS

## What are you changing?
- [ ] Releasing a new version of Notify
- [X] Changing kubernetes configuration
