### PR TITLE
[MANIFEST] Setting HPA for celery SMS to 25% CPU. Adjusting pod count

### DIFF
--- a/env/production/performance.yaml
+++ b/env/production/performance.yaml
@@ -108,13 +108,13 @@ metadata:
   name: celery-sms-send-hpa
   namespace: notification-canada-ca
 spec:
-  minReplicas: 11
-  maxReplicas: 11
+  minReplicas: 3
+  maxReplicas: 20
   metrics:
   - resource:
       name: cpu
       target:
-        averageUtilization: 50
+        averageUtilization: 25
         type: Utilization
     type: Resource
   behavior:


### PR DESCRIPTION
## What happens when your PR merges?
Setting HPA for Celery SMS in prod to 25% CPU Threshold and re-enabling autoscaling

## What are you changing?
- [X] Changing kubernetes configuration

