### PR TITLE
R5 only

### DIFF
--- a/env/production/karpenter.yaml
+++ b/env/production/karpenter.yaml
@@ -47,7 +47,7 @@ spec:
       values: ["spot"]
     - key: node.kubernetes.io/instance-type
       operator: In
-      values: ["r5.large"]      
+      values: ["r5.xlarge", "r5.large"]      
   limits:
     resources:
       cpu: 1000

--- a/env/production/karpenter.yaml
+++ b/env/production/karpenter.yaml
@@ -47,7 +47,7 @@ spec:
       values: ["spot"]
     - key: node.kubernetes.io/instance-type
       operator: In
-      values: ["m5.large", "r5.large"]      
+      values: ["r5.large"]      
   limits:
     resources:
       cpu: 1000

--- a/env/staging/karpenter.yaml
+++ b/env/staging/karpenter.yaml
@@ -47,7 +47,7 @@ spec:
       values: ["spot"]
     - key: node.kubernetes.io/instance-type
       operator: In
-      values: ["r5.large"]      
+      values: ["r5.xlarge", "r5.large"]      
   limits:
     resources:
       cpu: 1000

--- a/env/staging/karpenter.yaml
+++ b/env/staging/karpenter.yaml
@@ -47,7 +47,7 @@ spec:
       values: ["spot"]
     - key: node.kubernetes.io/instance-type
       operator: In
-      values: ["m5.large", "r5.large"]      
+      values: ["r5.large"]      
   limits:
     resources:
       cpu: 1000


### PR DESCRIPTION
## What happens when your PR merges?
Celery Karpenter will only use r5.large and r5.xlarge in staging and prod. No more m5's as they don't seem to behave.

## What are you changing?
- [X] Changing kubernetes configuration

## Provide some background on the changes
Node autoscaling

