### PR TITLE
fix: Setting higher memory limits in cwagent

### DIFF
--- a/env/production/cwagent.yaml
+++ b/env/production/cwagent.yaml
@@ -124,7 +124,7 @@ spec:
           resources:
             limits:
               cpu:  200m
-              memory: 200Mi
+              memory: 1000Mi
             requests:
               cpu: 200m
               memory: 200Mi

--- a/env/staging/cwagent.yaml
+++ b/env/staging/cwagent.yaml
@@ -124,7 +124,7 @@ spec:
           resources:
             limits:
               cpu:  200m
-              memory: 200Mi
+              memory: 1000Mi
             requests:
               cpu: 200m
               memory: 200Mi


### PR DESCRIPTION
## What happens when your PR merges?

The memory limit for cwagent in kubernetes will be set to 1gb from 200mb.

## What are you changing?
- [X] Changing kubernetes configuration

## Provide some background on the changes
We are experiencing OOM crashes on cwagent.

## Checklist if making changes to Kubernetes:
- [X] I know how to get kubectl credentials in case it catches on fire

## After merging this PR
- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.