### PR TITLE
Setting prod celery to run on on-demads

### DIFF
--- a/env/production/node-selector-patch.yaml
+++ b/env/production/node-selector-patch.yaml
@@ -14,7 +14,7 @@ spec:
   template:
     spec:
       nodeSelector:
-        karpenter.sh/provisioner-name: default
+        eks.amazonaws.com/capacityType: ON_DEMAND    
 ---
 # Celery SMS Send
 apiVersion: apps/v1
@@ -28,7 +28,7 @@ spec:
   template:
     spec:
       nodeSelector:
-        karpenter.sh/provisioner-name: default    
+        eks.amazonaws.com/capacityType: ON_DEMAND    
 ---
 ### ON DEMAND (PRIMARY) NODES - ALWAYS AVAILABLE
 


### PR DESCRIPTION
## What happens when your PR merges?
Setting the celery pods to run on on-demand instances only while we sort out the imdsv2 issue with spot instances.

## What are you changing?
- [X] Changing kubernetes configuration

## Provide some background on the changes
We are experiencing OOM errors on cwagent when using spot instances. While debugging that, we will move celery to on demand instances.


