### PR TITLE
Setting http tokens to optional which should enable imdsv1 

### DIFF
--- a/env/staging/karpenter.yaml
+++ b/env/staging/karpenter.yaml
@@ -64,3 +64,5 @@ spec:
     karpenter.sh/discovery: notification-canada-ca-staging-eks-cluster
   securityGroupSelector:
     karpenter.sh/discovery: notification-canada-ca-staging-eks-cluster    
+  metadataOptions:
+    httpTokens: optional


### PR DESCRIPTION
## What happens when your PR merges?
IMDSv1 should be enabled for spot instances in staging after a redeploy and recycling of nodes.

## What are you changing?
- [X] Changing kubernetes configuration

## Provide some background on the changes
We are seeing imds errors on fluentbit on spot instances due to a version mismatch.

