### PR TITLE
Staging fluentbit membufflimit 1

### DIFF
--- a/env/staging/fluentbit.yaml
+++ b/env/staging/fluentbit.yaml
@@ -277,7 +277,6 @@ data:
         log_stream_prefix           ${HOST_NAME}.
         auto_create_group           true
         extra_user_agent            container-insights
-        net.max_worker_connections  20
 
   parsers.conf: |
     [PARSER]

--- a/env/staging/fluentbit.yaml
+++ b/env/staging/fluentbit.yaml
@@ -379,7 +379,7 @@ spec:
               value: "k8s/1.3.15"
         resources:
             limits:
-              memory: 200Mi
+              memory: 500Mi
             requests:
               cpu: 100m
               memory: 100Mi

--- a/env/staging/fluentbit.yaml
+++ b/env/staging/fluentbit.yaml
@@ -69,7 +69,7 @@ data:
         storage.path              /var/fluent-bit/state/flb-storage/
         storage.sync              normal
         storage.checksum          off
-        storage.backlog.mem_limit 5M
+        storage.backlog.mem_limit 50M
         
     @INCLUDE celery-log.conf
     @INCLUDE notify-log.conf
@@ -146,7 +146,7 @@ data:
         Path                /var/log/containers/celery*
         multiline.parser    docker, cri
         DB                  /var/fluent-bit/state/celery.db
-        Mem_Buf_Limit       50MB
+        Mem_Buf_Limit       150MB
         Skip_Long_Lines     Off
         Refresh_Interval    10
         Rotate_Wait         30
@@ -270,13 +270,14 @@ data:
         imds_version        v1
 
     [OUTPUT]
-        Name                cloudwatch_logs
-        Match               host.*
-        region              ${AWS_REGION}
-        log_group_name      /aws/containerinsights/${CLUSTER_NAME}/host
-        log_stream_prefix   ${HOST_NAME}.
-        auto_create_group   true
-        extra_user_agent    container-insights
+        Name                        cloudwatch_logs
+        Match                       host.*
+        region                      ${AWS_REGION}
+        log_group_name              /aws/containerinsights/${CLUSTER_NAME}/host
+        log_stream_prefix           ${HOST_NAME}.
+        auto_create_group           true
+        extra_user_agent            container-insights
+        net.max_worker_connections  20
 
   parsers.conf: |
     [PARSER]


### PR DESCRIPTION
## What happens when your PR merges?

Tripling membuff limit on staging celery fluentbit in order to alleviate emitter paused errors under load.
Increasing maximum memory usage for the daemonset to accommodate.

## What are you changing?
- [X] Changing kubernetes configuration

## Provide some background on the changes
Errors in fluentbit when under load
