### PR TITLE
Fluenbit Pipeline Aliases and Celery MLP emitter Mem Buff Limit

### DIFF
--- a/env/staging/fluentbit.yaml
+++ b/env/staging/fluentbit.yaml
@@ -81,6 +81,7 @@ data:
   notify-log.conf: |
     [INPUT]
         Name                tail
+        Alias               notify-app-input-tail 
         Tag                 application.*
         Exclude_Path        /var/log/containers/cloudwatch-agent*, /var/log/containers/fluent-bit*, /var/log/containers/aws-node*, /var/log/containers/kube-proxy*, /var/log/containers/celery*
         Path                /var/log/containers/*.log
@@ -95,6 +96,7 @@ data:
 
     [INPUT]
         Name                tail
+        Alias               notify-app-fluentbit
         Tag                 application.*
         Path                /var/log/containers/fluent-bit*
         multiline.parser    docker, cri
@@ -106,6 +108,7 @@ data:
 
     [INPUT]
         Name                tail
+        Alias               notify-app-cwagent
         Tag                 application.*
         Path                /var/log/containers/cloudwatch-agent*
         multiline.parser    docker, cri
@@ -117,6 +120,7 @@ data:
 
     [FILTER]
         Name                kubernetes
+        Alias               notify-app-k8s-filter
         Match               application.*
         Kube_URL            https://kubernetes.default.svc:443
         Kube_Tag_Prefix     application.var.log.containers.
@@ -132,6 +136,7 @@ data:
 
     [OUTPUT]
         Name                cloudwatch
+        Alias               notify-app-cw-output
         Match               application.*
         region              ${AWS_REGION}
         log_group_name      /aws/containerinsights/${CLUSTER_NAME}/application
@@ -142,6 +147,7 @@ data:
   celery-log.conf: |
     [INPUT]
         Name                tail
+        Alias               notify-celery-input-tail
         Tag                 celery.*
         Path                /var/log/containers/celery*
         multiline.parser    docker, cri
@@ -155,28 +161,32 @@ data:
 
 
     [FILTER]
-        Name                kubernetes
-        Match               celery.*
-        Kube_URL            https://kubernetes.default.svc:443
-        Kube_Tag_Prefix     celery.var.log.containers.
-        Merge_Log           On
-        Merge_Log_Key       log_processed
-        K8S-Logging.Parser  On
-        K8S-Logging.Exclude Off
-        Labels              Off
-        Annotations         Off
-        Use_Kubelet         On
-        Kubelet_Port        10250
-        Buffer_Size         0
+        Name                  kubernetes
+        Alias                 notify-celery-k8s-filter
+        Match                 celery.*
+        Kube_URL              https://kubernetes.default.svc:443
+        Kube_Tag_Prefix       celery.var.log.containers.
+        Merge_Log             On
+        Merge_Log_Key         log_processed
+        K8S-Logging.Parser    On
+        K8S-Logging.Exclude   Off
+        Labels                Off
+        Annotations           Off
+        Use_Kubelet           On
+        Kubelet_Port          10250
+        Buffer_Size           0
+        emitter_mem_buf_limit 150MB
 
     [FILTER]
         name                  multiline
+        Alias                 notify-celery-multiline-filter
         match                 celery.*
         multiline.key_content log
         multiline.parser      multiline-notify-python
 
     [OUTPUT]
         Name                cloudwatch
+        Alias               notify-celery-cw-output
         Match               celery.*
         region              ${AWS_REGION}
         log_group_name      /aws/containerinsights/${CLUSTER_NAME}/application
@@ -187,6 +197,7 @@ data:
   dataplane-log.conf: |
     [INPUT]
         Name                systemd
+        Alias               k8s-dataplane-systemd-input
         Tag                 dataplane.systemd.*
         Systemd_Filter      _SYSTEMD_UNIT=docker.service
         Systemd_Filter      _SYSTEMD_UNIT=containerd.service
@@ -197,6 +208,7 @@ data:
 
     [INPUT]
         Name                tail
+        Alias               k8s-dataplane-tail-input
         Tag                 dataplane.tail.*
         Path                /var/log/containers/aws-node*, /var/log/containers/kube-proxy*
         multiline.parser    docker, cri
@@ -210,6 +222,7 @@ data:
 
     [FILTER]
         Name                modify
+        Alias               k8s-dataplane-modify-filter
         Match               dataplane.systemd.*
         Rename              _HOSTNAME                   hostname
         Rename              _SYSTEMD_UNIT               systemd_unit
@@ -218,11 +231,13 @@ data:
 
     [FILTER]
         Name                aws
+        Alias               k8s-dataplane-aws-filter
         Match               dataplane.*
         imds_version        v1
 
     [OUTPUT]
         Name                cloudwatch_logs
+        Alias               k8s-dataplane-cw-output
         Match               dataplane.*
         region              ${AWS_REGION}
         log_group_name      /aws/containerinsights/${CLUSTER_NAME}/dataplane
@@ -233,6 +248,7 @@ data:
   host-log.conf: |
     [INPUT]
         Name                tail
+        Alias               k8s-host-tail-dmesg-input
         Tag                 host.dmesg
         Path                /var/log/dmesg
         Key                 message
@@ -244,6 +260,7 @@ data:
 
     [INPUT]
         Name                tail
+        Alias               k8s-host-tail-log-messages-input
         Tag                 host.messages
         Path                /var/log/messages
         Parser              syslog
@@ -255,6 +272,7 @@ data:
 
     [INPUT]
         Name                tail
+        Alias               k8s-host-tail-log-secure-input
         Tag                 host.secure
         Path                /var/log/secure
         Parser              syslog
@@ -266,11 +284,13 @@ data:
 
     [FILTER]
         Name                aws
+        Alias               k8s-host-aws-filter
         Match               host.*
         imds_version        v1
 
     [OUTPUT]
         Name                        cloudwatch_logs
+        Alias                       k8s-host-cw-output
         Match                       host.*
         region                      ${AWS_REGION}
         log_group_name              /aws/containerinsights/${CLUSTER_NAME}/host


### PR DESCRIPTION
## What happens when your PR merges?
Celery in staging will have aliases assigned to the pipeline stages to better troubleshoot issues.

Celery MLP emitter will have an increased membuff limit to avoid lost chunks under load.