### PR TITLE
Fluent Bit Startup Delay

### DIFF
--- a/env/staging/fluentbit.yaml
+++ b/env/staging/fluentbit.yaml
@@ -351,6 +351,10 @@ spec:
         version: v1
         kubernetes.io/cluster-service: "true"
     spec:
+      initContainers:
+      - name: waitForInit
+        image: busybox:1.28
+        command: ['sh', '-c', 'echo "Waiting for 10 seconds for node to sort itself out" && sleep 10']
       containers:
       - name: fluent-bit
         image: public.ecr.aws/aws-observability/aws-for-fluent-bit:stable


### PR DESCRIPTION
## What happens when your PR merges?

In staging Fluent bit will sleep for 10 seconds before starting up. This is to test if there is a race condition between the node and fluent bit.

## What are you changing?
- [X] Changing kubernetes configuration

## Provide some background on the changes
Troubleshooting fluentbit stuff