### PR TITLE
Forcing Karpenter to use large nodes for fluent bit testing

### DIFF
--- a/env/staging/karpenter.yaml
+++ b/env/staging/karpenter.yaml
@@ -47,7 +47,7 @@ spec:
       values: ["spot"]
     - key: node.kubernetes.io/instance-type
       operator: In
-      values: ["r5.xlarge", "r5.large"]      
+      values: ["r5.xlarge"]      
   limits:
     resources:
       cpu: 1000


### PR DESCRIPTION
## What happens when your PR merges?
Karpenter will have to use xlarge nodes to consolidate celery onto a single node for fluent bit emitter testing.

## What are you changing?
- [X] Changing kubernetes configuration

