### PR TITLE
karpenter set to on demand in staging for testing

### DIFF
--- a/env/staging/karpenter.yaml
+++ b/env/staging/karpenter.yaml
@@ -44,7 +44,7 @@ spec:
   requirements:
     - key: karpenter.sh/capacity-type
       operator: In
-      values: ["spot"]
+      values: ["on-demand"]
     - key: node.kubernetes.io/instance-type
       operator: In
       values: ["r5.xlarge"]      


### PR DESCRIPTION
## What happens when your PR merges?
Setting staging to use on demand instances for karpenter for testing
