### PR TITLE
Setting prod fluent bit buffers and init

### DIFF
--- a/env/production/fluentbit.yaml
+++ b/env/production/fluentbit.yaml
@@ -146,7 +146,7 @@ data:
         Path                /var/log/containers/celery*
         multiline.parser    docker, cri
         DB                  /var/fluent-bit/state/celery.db
-        Mem_Buf_Limit       50MB
+        Mem_Buf_Limit       150MB
         Skip_Long_Lines     Off
         Refresh_Interval    10
         Rotate_Wait         30
@@ -174,6 +174,7 @@ data:
         match                 celery.*
         multiline.key_content log
         multiline.parser      multiline-notify-python
+        emitter_mem_buf_limit 150MB
 
     [OUTPUT]
         Name                cloudwatch
@@ -331,6 +332,10 @@ spec:
         kubernetes.io/cluster-service: "true"
     spec:
       containers:
+      initContainers:
+      - name: wait-for-init
+        image: busybox:1.28
+        command: ['sh', '-c', 'echo "Waiting for 2 seconds for node to sort itself out" && sleep 2']      
       - name: fluent-bit
         image: public.ecr.aws/aws-observability/aws-for-fluent-bit:stable
         imagePullPolicy: Always

--- a/env/staging/fluentbit.yaml
+++ b/env/staging/fluentbit.yaml
@@ -355,7 +355,7 @@ spec:
       initContainers:
       - name: wait-for-init
         image: busybox:1.28
-        command: ['sh', '-c', 'echo "Waiting for 10 seconds for node to sort itself out" && sleep 10']
+        command: ['sh', '-c', 'echo "Waiting for 2 seconds for node to sort itself out" && sleep 2']
       containers:
       - name: fluent-bit
         image: public.ecr.aws/aws-observability/aws-for-fluent-bit:stable


### PR DESCRIPTION
## What happens when your PR merges?
Fluent bit celery pipelines will have increased memory buffers in production. Fluent bit will also wait 2 seconds before spinning up to avoid TLS errors on new node startup.

## What are you changing?
- [X] Changing kubernetes configuration

## Provide some background on the changes
Fluent Bit TLS errors and mem buffer errors

