### PR TITLE
[MANIFEST] Setting the minimum pods for celery core to 3

### DIFF
--- a/env/production/performance.yaml
+++ b/env/production/performance.yaml
@@ -104,7 +104,7 @@ metadata:
   name: celery-hpa
   namespace: notification-canada-ca
 spec:
-  minReplicas: 30
+  minReplicas: 3
   maxReplicas: 30
   metrics:
   - resource:


### PR DESCRIPTION
## What happens when your PR merges?
The base celery (core) HPA will be re-enabled and set to 3 minimum pods scaling up to 30 as needed.

## What are you changing?
- [X] Changing kubernetes configuration

## Provide some background on the changes
Celery performance tuning
