### PR TITLE
[MANIFEST] prod: switch celery back to ON_DEMAND for now

### DIFF
--- a/env/production/node-selector-patch.yaml
+++ b/env/production/node-selector-patch.yaml
@@ -2,7 +2,7 @@
 
 #### KARPENTER SPOT INSTANCES - EPHEMERAL, STATE NOT REQUIRED
 
-# Celery Email
+# Celery
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -14,7 +14,7 @@ spec:
   template:
     spec:
       nodeSelector:
-        karpenter.sh/provisioner-name: default
+        eks.amazonaws.com/capacityType: ON_DEMAND    
 ---
 # Celery SMS Send
 apiVersion: apps/v1
@@ -28,7 +28,7 @@ spec:
   template:
     spec:
       nodeSelector:
-        karpenter.sh/provisioner-name: default    
+        eks.amazonaws.com/capacityType: ON_DEMAND    
 ---
 # Celery Email Send
 apiVersion: apps/v1
@@ -42,7 +42,7 @@ spec:
   template:
     spec:
       nodeSelector:
-        karpenter.sh/provisioner-name: default
+        eks.amazonaws.com/capacityType: ON_DEMAND    
 ---
 
 ### ON DEMAND (PRIMARY) NODES - ALWAYS AVAILABLE

--- a/env/production/node-selector-patch.yaml
+++ b/env/production/node-selector-patch.yaml
@@ -14,7 +14,7 @@ spec:
   template:
     spec:
       nodeSelector:
-        eks.amazonaws.com/capacityType: ON_DEMAND    
+        eks.amazonaws.com/capacityType: ON_DEMAND
 ---
 # Celery SMS Send
 apiVersion: apps/v1
@@ -28,7 +28,7 @@ spec:
   template:
     spec:
       nodeSelector:
-        eks.amazonaws.com/capacityType: ON_DEMAND    
+        eks.amazonaws.com/capacityType: ON_DEMAND
 ---
 # Celery Email Send
 apiVersion: apps/v1
@@ -42,7 +42,7 @@ spec:
   template:
     spec:
       nodeSelector:
-        eks.amazonaws.com/capacityType: ON_DEMAND    
+        eks.amazonaws.com/capacityType: ON_DEMAND
 ---
 
 ### ON DEMAND (PRIMARY) NODES - ALWAYS AVAILABLE
@@ -59,7 +59,7 @@ spec:
   template:
     spec:
       nodeSelector:
-        eks.amazonaws.com/capacityType: ON_DEMAND    
+        eks.amazonaws.com/capacityType: ON_DEMAND
 ---
 
 # Celery Beat
@@ -74,7 +74,7 @@ spec:
   template:
     spec:
       nodeSelector:
-        eks.amazonaws.com/capacityType: ON_DEMAND    
+        eks.amazonaws.com/capacityType: ON_DEMAND
 ---
 # Celery SMS
 apiVersion: apps/v1
@@ -117,7 +117,7 @@ spec:
   template:
     spec:
       nodeSelector:
-        eks.amazonaws.com/capacityType: ON_DEMAND    
+        eks.amazonaws.com/capacityType: ON_DEMAND
 ---
 # Documentation
 apiVersion: apps/v1
@@ -131,4 +131,4 @@ spec:
   template:
     spec:
       nodeSelector:
-        eks.amazonaws.com/capacityType: ON_DEMAND   
+        eks.amazonaws.com/capacityType: ON_DEMAND


### PR DESCRIPTION
## What happens when your PR merges?
    - `[MANIFEST]` - tag `main` as a new patch release and deploy to production

## What are you changing?
- [x] Changing kubernetes configuration

## Provide some background on the changes
having issues with celery pods dropping to zero. will switch to on demand for the weekend. and fix / verify next week


## After merging this PR
- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.