### PR TITLE
[MANIFEST] Release 2023-11-20T14:05:26.382Z

### DIFF
--- a/.github/workflows/merge_to_main_production.yaml
+++ b/.github/workflows/merge_to_main_production.yaml
@@ -9,7 +9,7 @@ on:
 
 env:
   PRIVATE_ECR: ${{ secrets.PRODUCTION_AWS_ACCOUNT }}.dkr.ecr.ca-central-1.amazonaws.com/notify
-  API_LAMBDA_IMAGE: api-lambda:7b81e42
+  API_LAMBDA_IMAGE: api-lambda:a7b6726
   KUBECTL_VERSION: 1.23.6
 
 defaults:

--- a/env/production/kustomization.yaml
+++ b/env/production/kustomization.yaml
@@ -31,9 +31,9 @@ patches:
 
 images:
   - name: admin
-    newName: public.ecr.aws/cds-snc/notify-admin:43c6b7a
+    newName: public.ecr.aws/cds-snc/notify-admin:d06c713
   - name: api
-    newName: public.ecr.aws/cds-snc/notify-api:7b81e42
+    newName: public.ecr.aws/cds-snc/notify-api:a7b6726
   - name: document-download-api
     newName: public.ecr.aws/cds-snc/notify-document-download-api:31d6347
   - name: documentation


### PR DESCRIPTION
## What happens when your PR merges?
- Prefix the title of your PR:
    - `fix:` - tag `main` as a new patch release
    - `feat:` - tag `main` as a new minor release
    - `BREAKING CHANGE:` - tag `main` as a new major release
    - `[MANIFEST]` - tag `main` as a new patch release and deploy to production
    - `chore:` - use for changes to non-app code (ex: GitHub actions)
- Alternatively, change the [VERSION file](https://github.com/cds-snc/notification-manifests/blob/main/VERSION) - this will not create a new tag, but rather will release the tag in `VERSION` to production.

## What are you changing?
- [x] Releasing a new version of Notify
- [ ] Changing kubernetes configuration

## Provide some background on the changes
⚠️ **The production version of manifests is behind the latest staging version. Consider upgrading to the latest version before merging this pull request.** 

 NOTIFICATION-API

- [Moving cwagent check outside of run celery (#2027)](https://github.com/cds-snc/notification-api/commit/a7b67264be0d866bb5f42d98e3768db3cc853a64) by Ben Larabie
- [Fix startup scripts to POSIX standards / add timeout for cwagent waiting (#2016)](https://github.com/cds-snc/notification-api/commit/203307f69724cdb863e9eab83e80c581443a98d3) by Jimmy Royer
- [10m -> 20m perf test (#2025)](https://github.com/cds-snc/notification-api/commit/07f2ed5c8ec8fdbbfb25507415b67afc63baeb22) by Steve Astels

NOTIFICATION-ADMIN

- [Added bam.nr-data.net to connect-src exception for NewRelic (#1726)](https://github.com/cds-snc/notification-admin/commit/d06c713ca01b16818e97b8924b1a1c8030fef6d3) by Jimmy Royer
- [Added an exception for CompDocError (#1723)](https://github.com/cds-snc/notification-admin/commit/1d66cec7ed53c490ffa0c23351dccc26bd2e9920) by Jumana B
- [Moved NewRelic config file to project root folder (#1725)](https://github.com/cds-snc/notification-admin/commit/71f134f187e7228d76930ca3468a55593829694a) by Jimmy Royer
- [Set the auto RUM insertion at global config level instead (#1722)](https://github.com/cds-snc/notification-admin/commit/7dab86a90e821fb1a126e1140cfa662e80a7a96e) by Jimmy Royer

NOTIFICATION-DOCUMENT-DOWNLOAD-API



NOTIFICATION-DOCUMENTATION



## If you are releasing a new version of Notify, what components are you updating
- [x] API
- [x] Admin
- [ ] Documentation
- [ ] Document download API

## Checklist if releasing new version:
- [x] I made sure that the changes are as expected in [Notify staging](https://staging.notification.cdssandbox.xyz/)
- [x] I have checked if the docker images I am referencing exist
    - [x] [api lambda](https://ca-central-1.console.aws.amazon.com/ecr/repositories/private/296255494825/notify/api-lambda?region=ca-central-1) (requires Notification-Production / AdministratorAccess login)
    - [x] [api k8s](https://gallery.ecr.aws/v6b8u5o6/notify-api)
    - [x] [admin](https://gallery.ecr.aws/v6b8u5o6/notify-admin)
    - [ ] [documentation](https://gallery.ecr.aws/v6b8u5o6/notify-documentation)
    - [ ] [document download API](https://gallery.ecr.aws/v6b8u5o6/notify-document-download-api)

## Checklist if making changes to Kubernetes:
- [ ] I know how to get kubectl credentials in case it catches on fire

## After merging this PR
- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.