### PR TITLE
[MANIFEST] Turning off TLS verification on kubernetes filter

### DIFF
--- a/env/dev/fluentbit.yaml
+++ b/env/dev/fluentbit.yaml
@@ -129,6 +129,7 @@ data:
         Use_Kubelet         On
         Kubelet_Port        10250
         Buffer_Size         0
+        tls.verify          Off
 
     [OUTPUT]
         Name                cloudwatch
@@ -168,6 +169,8 @@ data:
         Use_Kubelet         On
         Kubelet_Port        10250
         Buffer_Size         0
+        tls.verify          Off
+
 
     [FILTER]
         name                  multiline
@@ -330,6 +333,7 @@ spec:
         version: v1
         kubernetes.io/cluster-service: "true"
     spec:
+      priorityClassName: system-node-critical       
       containers:
       - name: fluent-bit
         image: public.ecr.aws/aws-observability/aws-for-fluent-bit:stable

--- a/env/production/fluentbit.yaml
+++ b/env/production/fluentbit.yaml
@@ -331,10 +331,7 @@ spec:
         version: v1
         kubernetes.io/cluster-service: "true"
     spec:
-      initContainers:
-      - name: wait-for-init
-        image: busybox:1.28
-        command: ['sh', '-c', 'echo "Waiting for 2 seconds for node to sort itself out" && sleep 2']      
+      priorityClassName: system-node-critical
       containers:
       - name: fluent-bit
         image: public.ecr.aws/aws-observability/aws-for-fluent-bit:stable

--- a/env/production/fluentbit.yaml
+++ b/env/production/fluentbit.yaml
@@ -331,7 +331,11 @@ spec:
         version: v1
         kubernetes.io/cluster-service: "true"
     spec:
-      priorityClassName: system-node-critical
+      priorityClassName: system-node-critical        
+      initContainers:
+      - name: wait-for-init
+        image: busybox:1.28
+        command: ['sh', '-c', 'echo "Waiting for 10 seconds for node to sort itself out" && sleep 10']      
       containers:
       - name: fluent-bit
         image: public.ecr.aws/aws-observability/aws-for-fluent-bit:stable

--- a/env/scratch/fluentbit.yaml
+++ b/env/scratch/fluentbit.yaml
@@ -129,6 +129,7 @@ data:
         Use_Kubelet         On
         Kubelet_Port        10250
         Buffer_Size         0
+        tls.verify          Off
 
     [OUTPUT]
         Name                cloudwatch
@@ -168,6 +169,7 @@ data:
         Use_Kubelet         On
         Kubelet_Port        10250
         Buffer_Size         0
+        tls.verify          Off
 
     [FILTER]
         name                  multiline
@@ -330,6 +332,7 @@ spec:
         version: v1
         kubernetes.io/cluster-service: "true"
     spec:
+      priorityClassName: system-node-critical        
       containers:
       - name: fluent-bit
         image: public.ecr.aws/aws-observability/aws-for-fluent-bit:stable

--- a/env/staging/fluentbit.yaml
+++ b/env/staging/fluentbit.yaml
@@ -133,6 +133,7 @@ data:
         Use_Kubelet         On
         Kubelet_Port        10250
         Buffer_Size         0
+        tls.verify          Off
 
     [OUTPUT]
         Name                cloudwatch
@@ -175,6 +176,7 @@ data:
         Use_Kubelet           On
         Kubelet_Port          10250
         Buffer_Size           0
+        tls.verify            Off
 
     [FILTER]
         name                  multiline
@@ -352,10 +354,7 @@ spec:
         version: v1
         kubernetes.io/cluster-service: "true"
     spec:
-      initContainers:
-      - name: wait-for-init
-        image: busybox:1.28
-        command: ['sh', '-c', 'echo "Waiting for 2 seconds for node to sort itself out" && sleep 2']
+      priorityClassName: system-node-critical       
       containers:
       - name: fluent-bit
         image: public.ecr.aws/aws-observability/aws-for-fluent-bit:stable


### PR DESCRIPTION
## What happens when your PR merges?
The Fluent Bit kubernetes filter will have TLS verification disabled when talking to the kubelet. TLS is still enforced, but we do not verify the certificate... This is to test the TLS verification error we are receiving on fluent bit startup.

## What are you changing?
- [X] Changing kubernetes configuration

## Provide some background on the changes
Re: TLS errors in fluent bit.

