### PR TITLE
Setting min available for celery pdb to 2

### DIFF
--- a/base/notify-celery-email-send/celery-email-send-pdb.yaml
+++ b/base/notify-celery-email-send/celery-email-send-pdb.yaml
@@ -4,7 +4,7 @@ metadata:
   name: celery-email-hpa
   namespace: notification-canada-ca
 spec:
-  minAvailable: 3
+  minAvailable: 2
   selector:
     matchLabels:
       app: celery-email-send

--- a/base/notify-celery-main/celery-main-pdb.yaml
+++ b/base/notify-celery-main/celery-main-pdb.yaml
@@ -4,7 +4,7 @@ metadata:
   name: celery-main-hpa
   namespace: notification-canada-ca
 spec:
-  minAvailable: 3
+  minAvailable: 2
   selector:
     matchLabels:
       app: celery

--- a/base/notify-celery-sms-send/celery-sms-send-pdb.yaml
+++ b/base/notify-celery-sms-send/celery-sms-send-pdb.yaml
@@ -4,7 +4,7 @@ metadata:
   name: celery-sms-send-hpa
   namespace: notification-canada-ca
 spec:
-  minAvailable: 3
+  minAvailable: 2
   selector:
     matchLabels:
       app: celery-sms-send


### PR DESCRIPTION
## What happens when your PR merges?
Celery pod disruption budget will be set to two, so that there will always be at least one allowed disruption when evicting pods.

## What are you changing?
- [X] Changing kubernetes configuration

## Provide some background on the changes
Re: Action item from failed TF worker upgrade.
