### PR TITLE
Staging - Document Download Pod Skew

### DIFF
--- a/env/staging/node-selector-patch.yaml
+++ b/env/staging/node-selector-patch.yaml
@@ -89,6 +89,34 @@ spec:
                 values:
                 - spot      
 ---
+# Document Download API
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: document-download-api
+  name: document-download-api
+  namespace: notification-canada-ca
+spec:
+  template:
+    spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 90
+            preference:
+              matchExpressions:
+              - key: eks.amazonaws.com/capacityType
+                operator: In
+                values:
+                - ON_DEMAND
+          - weight: 10
+            preference:
+              matchExpressions:
+              - key: karpenter.sh/capacity-type
+                operator: In
+                values:
+---
 
 ### ON DEMAND (PRIMARY) NODES - ALWAYS AVAILABLE
 
@@ -148,20 +176,6 @@ spec:
     spec:
       nodeSelector:
         eks.amazonaws.com/capacityType: ON_DEMAND
----
-# Document Download API
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  labels:
-    app: document-download-api
-  name: document-download-api
-  namespace: notification-canada-ca
-spec:
-  template:
-    spec:
-      nodeSelector:
-        eks.amazonaws.com/capacityType: ON_DEMAND    
 ---
 # Documentation
 apiVersion: apps/v1


### PR DESCRIPTION
## What happens when your PR merges?
In Staging, document download api pods will prefer 9:1 on demand nodes, but in the event that on demand nodes are not available, will allow pods to spin up on spot instances. This is to ensure that the DD Api HPA will be able to scale accordingly.

## What are you changing?
- [X] Changing kubernetes configuration

## Provide some background on the changes
Notify Performance tuning and autoscaling
