### PR TITLE
[MANIFEST] Adding pod disruption budget for admin

### DIFF
--- a/base/notify-admin/admin-pdb.yaml
+++ b/base/notify-admin/admin-pdb.yaml
@@ -1,0 +1,10 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: admin-pdb
+  namespace: notification-canada-ca
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: celery-email-send

--- a/base/notify-admin/admin-pdb.yaml
+++ b/base/notify-admin/admin-pdb.yaml
@@ -7,4 +7,4 @@ spec:
   minAvailable: 1
   selector:
     matchLabels:
-      app: celery-email-send
+      app: admin  

--- a/base/notify-admin/kustomization.yaml
+++ b/base/notify-admin/kustomization.yaml
@@ -2,3 +2,4 @@ resources:
   - admin-deployment.yaml
   - admin-service.yaml
   - admin-hpa.yaml
+  - admin-pdb.yaml


### PR DESCRIPTION
## What happens when your PR merges?
A pod disruption budget will be added for admin so that at least one pod is always available

## What are you changing?
- [X] Changing kubernetes configuration

## Provide some background on the changes
Downscaling nodes in prod caused admin to temporarily go down while k8s did it's thing.
