### PR TITLE
Modifying scaling behaviour for celeries

### DIFF
--- a/env/dev/performance.yaml
+++ b/env/dev/performance.yaml
@@ -153,7 +153,7 @@ spec:
       stabilizationWindowSeconds: 0
       policies:
       - type: Pods
-        value: 12
+        value: 6
         periodSeconds: 45
       selectPolicy: Max
 ---
@@ -177,6 +177,6 @@ spec:
       stabilizationWindowSeconds: 0
       policies:
       - type: Pods
-        value: 12
+        value: 6
         periodSeconds: 45
       selectPolicy: Max

--- a/env/production/performance.yaml
+++ b/env/production/performance.yaml
@@ -113,6 +113,14 @@ spec:
         averageUtilization: 50
         type: Utilization
     type: Resource
+  behavior:
+    scaleUp:
+      stabilizationWindowSeconds: 0
+      policies:
+      - type: Pods
+        value: 6
+        periodSeconds: 45
+      selectPolicy: Max    
 ---
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
@@ -143,7 +151,7 @@ spec:
       stabilizationWindowSeconds: 0
       policies:
       - type: Pods
-        value: 12
+        value: 6
         periodSeconds: 45
       selectPolicy: Max
 ---
@@ -159,7 +167,7 @@ spec:
   - resource:
       name: cpu
       target:
-        averageUtilization: 25
+        averageUtilization: 50
         type: Utilization
     type: Resource
   behavior:
@@ -167,6 +175,6 @@ spec:
       stabilizationWindowSeconds: 0
       policies:
       - type: Pods
-        value: 12
+        value: 6
         periodSeconds: 45
       selectPolicy: Max            

--- a/env/production/performance.yaml
+++ b/env/production/performance.yaml
@@ -113,14 +113,6 @@ spec:
         averageUtilization: 50
         type: Utilization
     type: Resource
-  behavior:
-    scaleUp:
-      stabilizationWindowSeconds: 0
-      policies:
-      - type: Pods
-        value: 6
-        periodSeconds: 45
-      selectPolicy: Max    
 ---
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
@@ -151,7 +143,7 @@ spec:
       stabilizationWindowSeconds: 0
       policies:
       - type: Pods
-        value: 6
+        value: 12
         periodSeconds: 45
       selectPolicy: Max
 ---
@@ -167,7 +159,7 @@ spec:
   - resource:
       name: cpu
       target:
-        averageUtilization: 50
+        averageUtilization: 25
         type: Utilization
     type: Resource
   behavior:
@@ -175,6 +167,6 @@ spec:
       stabilizationWindowSeconds: 0
       policies:
       - type: Pods
-        value: 6
+        value: 12
         periodSeconds: 45
       selectPolicy: Max            

--- a/env/staging/performance.yaml
+++ b/env/staging/performance.yaml
@@ -129,7 +129,7 @@ spec:
       stabilizationWindowSeconds: 0
       policies:
       - type: Pods
-        value: 12
+        value: 6
         periodSeconds: 45
       selectPolicy: Max            
 ---
@@ -153,7 +153,7 @@ spec:
       stabilizationWindowSeconds: 0
       policies:
       - type: Pods
-        value: 12
+        value: 6
         periodSeconds: 45
       selectPolicy: Max            
 ---
@@ -169,7 +169,7 @@ spec:
   - resource:
       name: cpu
       target:
-        averageUtilization: 25
+        averageUtilization: 50
         type: Utilization
     type: Resource
   behavior:
@@ -177,7 +177,7 @@ spec:
       stabilizationWindowSeconds: 0
       policies:
       - type: Pods
-        value: 12
+        value: 6
         periodSeconds: 45
       selectPolicy: Max            
 ---


### PR DESCRIPTION
## What happens when your PR merges?
Changing the scale up chunks for the celeries to scale up slower, and not overload the system.

Also adjusted celery email CPU usage target back to 50 because we are seeing 30 pods even when there is low load on the system.

To be tested in staging.

## What are you changing?
- [X] Changing kubernetes configuration

## Provide some background on the changes
Celery and node autoscaling

