### PR TITLE
[MANIFEST] Production Primary and Scalable Celeries

### DIFF
--- a/env/production/kustomization.yaml
+++ b/env/production/kustomization.yaml
@@ -6,9 +6,13 @@ bases:
   - ../../base/utils
   - ../../base/notify-admin
   - ../../base/notify-api
-  - ../../base/notify-celery-main
-  - ../../base/notify-celery-sms-send
-  - ../../base/notify-celery-email-send
+  - ../../base/notify-celery-other
+  - ../../base/notify-celery-main-primary
+  - ../../base/notify-celery-sms-send-primary
+  - ../../base/notify-celery-email-send-primary
+  - ../../base/notify-celery-main-scalable
+  - ../../base/notify-celery-sms-send-scalable
+  - ../../base/notify-celery-email-send-scalable
   - ../../base/notify-document-download
   - ../../base/notify-documentation
   - ../../base/notify-system

--- a/env/production/node-selector-patch.yaml
+++ b/env/production/node-selector-patch.yaml
@@ -7,89 +7,47 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: celery
-  name:  celery
+    app: celery-scalable
+  name:  celery-scalable
   namespace: notification-canada-ca
 spec:
   template:
     spec:
-      affinity:
-        nodeAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 50
-            preference:
-              matchExpressions:
-              - key: eks.amazonaws.com/capacityType
-                operator: In
-                values:
-                - ON_DEMAND
-          - weight: 50
-            preference:
-              matchExpressions:
-              - key: karpenter.sh/capacity-type
-                operator: In
-                values:
-                - spot     
+      nodeSelector:
+        karpenter.sh/capacity-type: spot    
+
 ---
 # Celery SMS Send
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: celery-sms-send
-  name:  celery-sms-send
+    app: celery-sms-send-scalable
+  name:  celery-sms-send-scalable
   namespace: notification-canada-ca
 spec:
   template:
     spec:
-      affinity:
-        nodeAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 50
-            preference:
-              matchExpressions:
-              - key: eks.amazonaws.com/capacityType
-                operator: In
-                values:
-                - ON_DEMAND
-          - weight: 50
-            preference:
-              matchExpressions:
-              - key: karpenter.sh/capacity-type
-                operator: In
-                values:
-                - spot         
+      nodeSelector:
+        karpenter.sh/capacity-type: spot    
+   
 ---
 # Celery Email Send
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: celery-email-send
-  name:  celery-email-send
+    app: celery-email-send-scalable
+  name:  celery-email-send-scalable
   namespace: notification-canada-ca
 spec:
   template:
     spec:
-      affinity:
-        nodeAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 15
-            preference:
-              matchExpressions:
-              - key: eks.amazonaws.com/capacityType
-                operator: In
-                values:
-                - ON_DEMAND
-          - weight: 85
-            preference:
-              matchExpressions:
-              - key: karpenter.sh/capacity-type
-                operator: In
-                values:
-                - spot    
----
+      nodeSelector:
+        karpenter.sh/capacity-type: spot    
 
+
+---
 # Notification API K8s
 apiVersion: apps/v1
 kind: Deployment
@@ -118,10 +76,54 @@ spec:
                 operator: In
                 values:
                 - spot    
+---
+### ON DEMAND (PRIMARY) NODES - ALWAYS AVAILABLE
+
+# Celery
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: celery-primary
+  name:  celery-primary
+  namespace: notification-canada-ca
+spec:
+  template:
+    spec:
+      nodeSelector:
+        eks.amazonaws.com/capacityType: ON_DEMAND    
 
 ---
+# Celery SMS Send
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: celery-sms-send-primary
+  name:  celery-sms-send-primary
+  namespace: notification-canada-ca
+spec:
+  template:
+    spec:
+      nodeSelector:
+        eks.amazonaws.com/capacityType: ON_DEMAND    
+   
+---
+# Celery Email Send
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: celery-email-send-primary
+  name:  celery-email-send-primary
+  namespace: notification-canada-ca
+spec:
+  template:
+    spec:
+      nodeSelector:
+        eks.amazonaws.com/capacityType: ON_DEMAND    
 
-### ON DEMAND (PRIMARY) NODES - ALWAYS AVAILABLE
+---
 
 # Celery Beat
 apiVersion: apps/v1
@@ -135,7 +137,7 @@ spec:
   template:
     spec:
       nodeSelector:
-        eks.amazonaws.com/capacityType: ON_DEMAND
+        eks.amazonaws.com/capacityType: ON_DEMAND    
 ---
 # Celery SMS
 apiVersion: apps/v1
@@ -178,7 +180,7 @@ spec:
   template:
     spec:
       nodeSelector:
-        eks.amazonaws.com/capacityType: ON_DEMAND
+        eks.amazonaws.com/capacityType: ON_DEMAND    
 ---
 # Documentation
 apiVersion: apps/v1
@@ -192,4 +194,4 @@ spec:
   template:
     spec:
       nodeSelector:
-        eks.amazonaws.com/capacityType: ON_DEMAND
+        eks.amazonaws.com/capacityType: ON_DEMAND   

--- a/env/production/performance.yaml
+++ b/env/production/performance.yaml
@@ -1,3 +1,135 @@
+####################################### RESOURCE REQUESTS #######################################
+# PRIMARY CELERIES
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: celery-primary
+  name:  celery-primary
+  namespace: notification-canada-ca
+spec:
+  replicas: 3
+  template:
+    spec:
+      containers:
+      - name: celery-primary
+        resources:
+          requests:
+            cpu: "300m"
+            memory: "500Mi"
+          limits:
+            cpu: "550m"
+            memory: "1024Mi"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: celery-sms-send-primary
+  name:  celery-sms-send-primary
+  namespace: notification-canada-ca
+spec:
+  replicas: 3
+  template:
+    spec:
+      containers:
+      - name: celery-sms-send-primary
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "500Mi"
+          limits:
+            cpu: "550m"
+            memory: "1024Mi"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: celery-email-send-primary
+  name:  celery-email-send-primary
+  namespace: notification-canada-ca
+spec:
+  replicas: 3
+  template:
+    spec:
+      containers:
+      - name: celery-email-send-primary
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "500Mi"
+          limits:
+            cpu: "550m"
+            memory: "1024Mi"
+---
+# SCALABLE CELERIES
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: celery-scalable
+  name:  celery-scalable
+  namespace: notification-canada-ca
+spec:
+  replicas: 3
+  template:
+    spec:
+      containers:
+      - name: celery-scalable
+        resources:
+          requests:
+            cpu: "300m"
+            memory: "500Mi"
+          limits:
+            cpu: "550m"
+            memory: "1024Mi"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: celery-sms-send-scalable
+  name:  celery-sms-send-scalable
+  namespace: notification-canada-ca
+spec:
+  replicas: 3
+  template:
+    spec:
+      containers:
+      - name: celery-sms-send-scalable
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "500Mi"
+          limits:
+            cpu: "550m"
+            memory: "1024Mi"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: celery-email-send-scalable
+  name:  celery-email-send-scalable
+  namespace: notification-canada-ca
+spec:
+  replicas: 3
+  template:
+    spec:
+      containers:
+      - name: celery-email-send-scalable
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "500Mi"
+          limits:
+            cpu: "550m"
+            memory: "1024Mi"
+---
+# OTHER APPS
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -22,58 +154,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: celery
-  name:  celery
-  namespace: notification-canada-ca
-spec:
-  replicas: 3
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  labels:
-    app: celery-sms-send
-  name:  celery-sms-send
-  namespace: notification-canada-ca
-spec:
-  replicas: 3
-  template:
-    spec:
-      containers:
-      - name: celery-sms-send
-        resources:
-          requests:
-            cpu: "50m"
-            memory: "500Mi"
-          limits:
-            cpu: "550m"
-            memory: "1024Mi"
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  labels:
-    app: celery-email-send
-  name:  celery-email-send
-  namespace: notification-canada-ca
-spec:
-  replicas: 3
-  template:
-    spec:
-      containers:
-      - name: celery-email-send
-        resources:
-          requests:
-            cpu: "50m"
-            memory: "500Mi"
-          limits:
-            cpu: "550m"
-            memory: "1024Mi"
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  labels:
     app: documentation
   name:  documentation
   namespace: notification-canada-ca
@@ -83,25 +163,20 @@ spec:
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: admin-hpa
+  name: document-download-api-hpa
   namespace: notification-canada-ca
 spec:
   minReplicas: 2
-  maxReplicas: 3
+  maxReplicas: 4
 ---
+
+####################################### POD AUTOSCALING #######################################
+# AUTOSCALING FOR CELERIES
+
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: api-hpa
-  namespace: notification-canada-ca
-spec:
-  minReplicas: 4
-  maxReplicas: 8
----
-apiVersion: autoscaling/v2
-kind: HorizontalPodAutoscaler
-metadata:
-  name: celery-hpa
+  name: celery-scalable-hpa
   namespace: notification-canada-ca
 spec:
   minReplicas: 3
@@ -113,20 +188,19 @@ spec:
         averageUtilization: 25
         type: Utilization
     type: Resource
+  behavior:
+    scaleUp:
+      stabilizationWindowSeconds: 0
+      policies:
+      - type: Pods
+        value: 6
+        periodSeconds: 45
+      selectPolicy: Max            
 ---
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: document-download-api-hpa
-  namespace: notification-canada-ca
-spec:
-  minReplicas: 2
-  maxReplicas: 4
----
-apiVersion: autoscaling/v2
-kind: HorizontalPodAutoscaler
-metadata:
-  name: celery-sms-send-hpa
+  name: celery-sms-send-scalable-hpa
   namespace: notification-canada-ca
 spec:
   minReplicas: 3
@@ -143,14 +217,14 @@ spec:
       stabilizationWindowSeconds: 0
       policies:
       - type: Pods
-        value: 12
+        value: 6
         periodSeconds: 45
       selectPolicy: Max
 ---
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: celery-email-send-hpa
+  name: celery-email-send-scalable-hpa
   namespace: notification-canada-ca
 spec:
   minReplicas: 3
@@ -167,6 +241,26 @@ spec:
       stabilizationWindowSeconds: 0
       policies:
       - type: Pods
-        value: 12
+        value: 6
         periodSeconds: 45
-      selectPolicy: Max            
+      selectPolicy: Max
+
+---
+# OTHER APPS
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: admin-hpa
+  namespace: notification-canada-ca
+spec:
+  minReplicas: 2
+  maxReplicas: 2
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: api-hpa
+  namespace: notification-canada-ca
+spec:
+  minReplicas: 4
+  maxReplicas: 4

--- a/env/production/performance.yaml
+++ b/env/production/performance.yaml
@@ -110,7 +110,7 @@ spec:
   - resource:
       name: cpu
       target:
-        averageUtilization: 50
+        averageUtilization: 25
         type: Utilization
     type: Resource
 ---

--- a/env/staging/performance.yaml
+++ b/env/staging/performance.yaml
@@ -1,3 +1,135 @@
+####################################### RESOURCE REQUESTS #######################################
+# PRIMARY CELERIES
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: celery-primary
+  name:  celery-primary
+  namespace: notification-canada-ca
+spec:
+  replicas: 3
+  template:
+    spec:
+      containers:
+      - name: celery-primary
+        resources:
+          requests:
+            cpu: "300m"
+            memory: "500Mi"
+          limits:
+            cpu: "550m"
+            memory: "1024Mi"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: celery-sms-send-primary
+  name:  celery-sms-send-primary
+  namespace: notification-canada-ca
+spec:
+  replicas: 3
+  template:
+    spec:
+      containers:
+      - name: celery-sms-send-primary
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "500Mi"
+          limits:
+            cpu: "550m"
+            memory: "1024Mi"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: celery-email-send-primary
+  name:  celery-email-send-primary
+  namespace: notification-canada-ca
+spec:
+  replicas: 3
+  template:
+    spec:
+      containers:
+      - name: celery-email-send-primary
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "500Mi"
+          limits:
+            cpu: "550m"
+            memory: "1024Mi"
+---
+# SCALABLE CELERIES
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: celery-scalable
+  name:  celery-scalable
+  namespace: notification-canada-ca
+spec:
+  replicas: 3
+  template:
+    spec:
+      containers:
+      - name: celery-scalable
+        resources:
+          requests:
+            cpu: "300m"
+            memory: "500Mi"
+          limits:
+            cpu: "550m"
+            memory: "1024Mi"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: celery-sms-send-scalable
+  name:  celery-sms-send-scalable
+  namespace: notification-canada-ca
+spec:
+  replicas: 3
+  template:
+    spec:
+      containers:
+      - name: celery-sms-send-scalable
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "500Mi"
+          limits:
+            cpu: "550m"
+            memory: "1024Mi"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: celery-email-send-scalable
+  name:  celery-email-send-scalable
+  namespace: notification-canada-ca
+spec:
+  replicas: 3
+  template:
+    spec:
+      containers:
+      - name: celery-email-send-scalable
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "500Mi"
+          limits:
+            cpu: "550m"
+            memory: "1024Mi"
+---
+# OTHER APPS
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -22,58 +154,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: celery
-  name:  celery
-  namespace: notification-canada-ca
-spec:
-  replicas: 3
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  labels:
-    app: celery-sms-send
-  name:  celery-sms-send
-  namespace: notification-canada-ca
-spec:
-  replicas: 3
-  template:
-    spec:
-      containers:
-      - name: celery-sms-send
-        resources:
-          requests:
-            cpu: "50m"
-            memory: "500Mi"
-          limits:
-            cpu: "550m"
-            memory: "1024Mi"
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  labels:
-    app: celery-email-send
-  name:  celery-email-send
-  namespace: notification-canada-ca
-spec:
-  replicas: 3
-  template:
-    spec:
-      containers:
-      - name: celery-email-send
-        resources:
-          requests:
-            cpu: "50m"
-            memory: "500Mi"
-          limits:
-            cpu: "550m"
-            memory: "1024Mi"
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  labels:
     app: documentation
   name:  documentation
   namespace: notification-canada-ca
@@ -83,25 +163,20 @@ spec:
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: admin-hpa
+  name: document-download-api-hpa
   namespace: notification-canada-ca
 spec:
   minReplicas: 2
-  maxReplicas: 3
+  maxReplicas: 4
 ---
+
+####################################### POD AUTOSCALING #######################################
+# AUTOSCALING FOR CELERIES
+
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: api-hpa
-  namespace: notification-canada-ca
-spec:
-  minReplicas: 4
-  maxReplicas: 8
----
-apiVersion: autoscaling/v2
-kind: HorizontalPodAutoscaler
-metadata:
-  name: celery-hpa
+  name: celery-scalable-hpa
   namespace: notification-canada-ca
 spec:
   minReplicas: 3
@@ -113,20 +188,19 @@ spec:
         averageUtilization: 25
         type: Utilization
     type: Resource
+  behavior:
+    scaleUp:
+      stabilizationWindowSeconds: 0
+      policies:
+      - type: Pods
+        value: 6
+        periodSeconds: 45
+      selectPolicy: Max            
 ---
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: document-download-api-hpa
-  namespace: notification-canada-ca
-spec:
-  minReplicas: 2
-  maxReplicas: 4
----
-apiVersion: autoscaling/v2
-kind: HorizontalPodAutoscaler
-metadata:
-  name: celery-sms-send-hpa
+  name: celery-sms-send-scalable-hpa
   namespace: notification-canada-ca
 spec:
   minReplicas: 3
@@ -143,14 +217,14 @@ spec:
       stabilizationWindowSeconds: 0
       policies:
       - type: Pods
-        value: 12
+        value: 6
         periodSeconds: 45
       selectPolicy: Max
 ---
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: celery-email-send-hpa
+  name: celery-email-send-scalable-hpa
   namespace: notification-canada-ca
 spec:
   minReplicas: 3
@@ -167,6 +241,26 @@ spec:
       stabilizationWindowSeconds: 0
       policies:
       - type: Pods
-        value: 12
+        value: 6
         periodSeconds: 45
-      selectPolicy: Max            
+      selectPolicy: Max
+
+---
+# OTHER APPS
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: admin-hpa
+  namespace: notification-canada-ca
+spec:
+  minReplicas: 2
+  maxReplicas: 2
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: api-hpa
+  namespace: notification-canada-ca
+spec:
+  minReplicas: 4
+  maxReplicas: 4

--- a/env/staging/performance.yaml
+++ b/env/staging/performance.yaml
@@ -1,135 +1,3 @@
-####################################### RESOURCE REQUESTS #######################################
-# PRIMARY CELERIES
-
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  labels:
-    app: celery-primary
-  name:  celery-primary
-  namespace: notification-canada-ca
-spec:
-  replicas: 3
-  template:
-    spec:
-      containers:
-      - name: celery-primary
-        resources:
-          requests:
-            cpu: "300m"
-            memory: "500Mi"
-          limits:
-            cpu: "550m"
-            memory: "1024Mi"
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  labels:
-    app: celery-sms-send-primary
-  name:  celery-sms-send-primary
-  namespace: notification-canada-ca
-spec:
-  replicas: 3
-  template:
-    spec:
-      containers:
-      - name: celery-sms-send-primary
-        resources:
-          requests:
-            cpu: "100m"
-            memory: "500Mi"
-          limits:
-            cpu: "550m"
-            memory: "1024Mi"
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  labels:
-    app: celery-email-send-primary
-  name:  celery-email-send-primary
-  namespace: notification-canada-ca
-spec:
-  replicas: 3
-  template:
-    spec:
-      containers:
-      - name: celery-email-send-primary
-        resources:
-          requests:
-            cpu: "100m"
-            memory: "500Mi"
-          limits:
-            cpu: "550m"
-            memory: "1024Mi"
----
-# SCALABLE CELERIES
-
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  labels:
-    app: celery-scalable
-  name:  celery-scalable
-  namespace: notification-canada-ca
-spec:
-  replicas: 3
-  template:
-    spec:
-      containers:
-      - name: celery-scalable
-        resources:
-          requests:
-            cpu: "300m"
-            memory: "500Mi"
-          limits:
-            cpu: "550m"
-            memory: "1024Mi"
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  labels:
-    app: celery-sms-send-scalable
-  name:  celery-sms-send-scalable
-  namespace: notification-canada-ca
-spec:
-  replicas: 3
-  template:
-    spec:
-      containers:
-      - name: celery-sms-send-scalable
-        resources:
-          requests:
-            cpu: "100m"
-            memory: "500Mi"
-          limits:
-            cpu: "550m"
-            memory: "1024Mi"
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  labels:
-    app: celery-email-send-scalable
-  name:  celery-email-send-scalable
-  namespace: notification-canada-ca
-spec:
-  replicas: 3
-  template:
-    spec:
-      containers:
-      - name: celery-email-send-scalable
-        resources:
-          requests:
-            cpu: "100m"
-            memory: "500Mi"
-          limits:
-            cpu: "550m"
-            memory: "1024Mi"
----
-# OTHER APPS
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -154,19 +22,86 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
+    app: celery
+  name:  celery
+  namespace: notification-canada-ca
+spec:
+  replicas: 3
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: celery-sms-send
+  name:  celery-sms-send
+  namespace: notification-canada-ca
+spec:
+  replicas: 3
+  template:
+    spec:
+      containers:
+      - name: celery-sms-send
+        resources:
+          requests:
+            cpu: "50m"
+            memory: "500Mi"
+          limits:
+            cpu: "550m"
+            memory: "1024Mi"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: celery-email-send
+  name:  celery-email-send
+  namespace: notification-canada-ca
+spec:
+  replicas: 3
+  template:
+    spec:
+      containers:
+      - name: celery-email-send
+        resources:
+          requests:
+            cpu: "50m"
+            memory: "500Mi"
+          limits:
+            cpu: "550m"
+            memory: "1024Mi"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
     app: documentation
   name:  documentation
   namespace: notification-canada-ca
 spec:
   replicas: 2
 ---
-####################################### POD AUTOSCALING #######################################
-# AUTOSCALING FOR CELERIES
-
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: celery-scalable-hpa
+  name: admin-hpa
+  namespace: notification-canada-ca
+spec:
+  minReplicas: 2
+  maxReplicas: 3
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: api-hpa
+  namespace: notification-canada-ca
+spec:
+  minReplicas: 4
+  maxReplicas: 8
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: celery-hpa
   namespace: notification-canada-ca
 spec:
   minReplicas: 3
@@ -175,22 +110,23 @@ spec:
   - resource:
       name: cpu
       target:
-        averageUtilization: 50
+        averageUtilization: 25
         type: Utilization
     type: Resource
-  behavior:
-    scaleUp:
-      stabilizationWindowSeconds: 0
-      policies:
-      - type: Pods
-        value: 6
-        periodSeconds: 45
-      selectPolicy: Max            
 ---
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: celery-sms-send-scalable-hpa
+  name: document-download-api-hpa
+  namespace: notification-canada-ca
+spec:
+  minReplicas: 2
+  maxReplicas: 4
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: celery-sms-send-hpa
   namespace: notification-canada-ca
 spec:
   minReplicas: 3
@@ -207,14 +143,14 @@ spec:
       stabilizationWindowSeconds: 0
       policies:
       - type: Pods
-        value: 6
+        value: 12
         periodSeconds: 45
       selectPolicy: Max
 ---
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: celery-email-send-scalable-hpa
+  name: celery-email-send-hpa
   namespace: notification-canada-ca
 spec:
   minReplicas: 3
@@ -223,7 +159,7 @@ spec:
   - resource:
       name: cpu
       target:
-        averageUtilization: 50
+        averageUtilization: 25
         type: Utilization
     type: Resource
   behavior:
@@ -231,26 +167,6 @@ spec:
       stabilizationWindowSeconds: 0
       policies:
       - type: Pods
-        value: 6
+        value: 12
         periodSeconds: 45
-      selectPolicy: Max
-
----
-# OTHER APPS
-apiVersion: autoscaling/v2
-kind: HorizontalPodAutoscaler
-metadata:
-  name: admin-hpa
-  namespace: notification-canada-ca
-spec:
-  minReplicas: 2
-  maxReplicas: 2
----
-apiVersion: autoscaling/v2
-kind: HorizontalPodAutoscaler
-metadata:
-  name: api-hpa
-  namespace: notification-canada-ca
-spec:
-  minReplicas: 4
-  maxReplicas: 4
+      selectPolicy: Max            


### PR DESCRIPTION
## What happens when your PR merges?

* Setting HPA's for celery email and main to CPU 25% in staging and prod.

* New celery deployments will be deployed to production:
  * Celery-Primary (On demand nodes)
  * Celery-Scalable (Spot Nodes)
  * Celery-email-send-Primary (On demand nodes)
  * Celery-email-send-Scalable (Spot Nodes)
  * Celery-sms-send-Primary (On demand nodes)
  * Celery-sms-send-Scalable (Spot Nodes)

The old ones will remain in place, so we can make sure everything is working before we remove them. 
We will also have to release Terraform before deleting the old resources so that we don't get false alarms.

## What are you changing?
- [X] Changing kubernetes configuration

## Provide some background on the changes
Stabilizing prod and performance
