### PR TITLE
[MANIFEST] Setting api k8s to run on on demand only

### DIFF
--- a/env/production/node-selector-patch.yaml
+++ b/env/production/node-selector-patch.yaml
@@ -59,23 +59,9 @@ metadata:
 spec:
   template:
     spec:
-      affinity:
-        nodeAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 90
-            preference:
-              matchExpressions:
-              - key: eks.amazonaws.com/capacityType
-                operator: In
-                values:
-                - ON_DEMAND
-          - weight: 10
-            preference:
-              matchExpressions:
-              - key: karpenter.sh/capacity-type
-                operator: In
-                values:
-                - spot    
+      nodeSelector:
+        eks.amazonaws.com/capacityType: ON_DEMAND    
+
 ---
 ### ON DEMAND (PRIMARY) NODES - ALWAYS AVAILABLE
 

--- a/env/staging/node-selector-patch.yaml
+++ b/env/staging/node-selector-patch.yaml
@@ -59,23 +59,8 @@ metadata:
 spec:
   template:
     spec:
-      affinity:
-        nodeAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 90
-            preference:
-              matchExpressions:
-              - key: eks.amazonaws.com/capacityType
-                operator: In
-                values:
-                - ON_DEMAND
-          - weight: 10
-            preference:
-              matchExpressions:
-              - key: karpenter.sh/capacity-type
-                operator: In
-                values:
-                - spot    
+      nodeSelector:
+        eks.amazonaws.com/capacityType: ON_DEMAND    
 ---
 ### ON DEMAND (PRIMARY) NODES - ALWAYS AVAILABLE
 


### PR DESCRIPTION
## What happens when your PR merges?
We are seeing the k8s api scale down to 0 for reasons. This is causing occasional 502 alerts. We will force it to run on-demand only for now.

## What are you changing?
- [X] Changing kubernetes configuration

## Provide some background on the changes
Perf tuning