### PR TITLE
fix: staging sms-send cpu request 100m -> 50m

### DIFF
--- a/env/staging/performance.yaml
+++ b/env/staging/performance.yaml
@@ -209,7 +209,7 @@ spec:
   - resource:
       name: cpu
       target:
-        averageUtilization: 25
+        averageUtilization: 15
         type: Utilization
     type: Resource
   behavior:

--- a/env/staging/performance.yaml
+++ b/env/staging/performance.yaml
@@ -102,7 +102,7 @@ spec:
       - name: celery-sms-send-scalable
         resources:
           requests:
-            cpu: "100m"
+            cpu: "50m"
             memory: "500Mi"
           limits:
             cpu: "550m"
@@ -209,7 +209,7 @@ spec:
   - resource:
       name: cpu
       target:
-        averageUtilization: 15
+        averageUtilization: 25
         type: Utilization
     type: Resource
   behavior:


### PR DESCRIPTION
## What happens when your PR merges?
    - `fix:` - tag `main` as a new patch release

## What are you changing?
- [x] Changing kubernetes configuration

## Provide some background on the changes
sms-send hpa is too high. under load cpu hovers at about 25%, which is the current hpa target. This PR changes the cpu requested from the nodes from 100m to 50m
