### PR TITLE
fix: staging celery core request 300m -> 150m

### DIFF
--- a/env/staging/performance.yaml
+++ b/env/staging/performance.yaml
@@ -16,7 +16,7 @@ spec:
       - name: celery-primary
         resources:
           requests:
-            cpu: "300m"
+            cpu: "150m"
             memory: "500Mi"
           limits:
             cpu: "550m"
@@ -37,7 +37,7 @@ spec:
       - name: celery-sms-send-primary
         resources:
           requests:
-            cpu: "100m"
+            cpu: "50m"
             memory: "500Mi"
           limits:
             cpu: "550m"

--- a/env/staging/performance.yaml
+++ b/env/staging/performance.yaml
@@ -81,7 +81,7 @@ spec:
       - name: celery-scalable
         resources:
           requests:
-            cpu: "300m"
+            cpu: "150m"
             memory: "500Mi"
           limits:
             cpu: "550m"


### PR DESCRIPTION
## What happens when your PR merges?
    - `fix:` - tag `main` as a new patch release

## What are you changing?
- [ ] Releasing a new version of Notify
- [ ] Changing kubernetes configuration

## Provide some background on the changes
Celery pods are not scaling up fast enough to process callbacks (and not even getting to max pods)
