### PR TITLE
[MANIFEST] Adjust prod and dev scaling params

### DIFF
--- a/env/dev/performance.yaml
+++ b/env/dev/performance.yaml
@@ -33,7 +33,7 @@ spec:
       - name: celery-primary
         resources:
           requests:
-            cpu: "300m"
+            cpu: "150m"
             memory: "500Mi"
           limits:
             cpu: "550m"
@@ -54,7 +54,7 @@ spec:
       - name: celery-sms-send-primary
         resources:
           requests:
-            cpu: "100m"
+            cpu: "50m"
             memory: "500Mi"
           limits:
             cpu: "550m"
@@ -96,7 +96,7 @@ spec:
       - name: celery-scalable
         resources:
           requests:
-            cpu: "300m"
+            cpu: "150m"
             memory: "500Mi"
           limits:
             cpu: "550m"
@@ -117,7 +117,7 @@ spec:
       - name: celery-sms-send-scalable
         resources:
           requests:
-            cpu: "100m"
+            cpu: "50m"
             memory: "500Mi"
           limits:
             cpu: "550m"

--- a/env/production/performance.yaml
+++ b/env/production/performance.yaml
@@ -16,7 +16,7 @@ spec:
       - name: celery-primary
         resources:
           requests:
-            cpu: "300m"
+            cpu: "150m"
             memory: "500Mi"
           limits:
             cpu: "550m"
@@ -37,7 +37,7 @@ spec:
       - name: celery-sms-send-primary
         resources:
           requests:
-            cpu: "100m"
+            cpu: "50m"
             memory: "500Mi"
           limits:
             cpu: "550m"
@@ -81,7 +81,7 @@ spec:
       - name: celery-scalable
         resources:
           requests:
-            cpu: "300m"
+            cpu: "150m"
             memory: "500Mi"
           limits:
             cpu: "550m"
@@ -102,7 +102,7 @@ spec:
       - name: celery-sms-send-scalable
         resources:
           requests:
-            cpu: "100m"
+            cpu: "50m"
             memory: "500Mi"
           limits:
             cpu: "550m"


### PR DESCRIPTION
## What happens when your PR merges?
    - `[MANIFEST]` - tag `main` as a new patch release and deploy to production

## What are you changing?
- [x] Changing kubernetes configuration

## Provide some background on the changes
We found that the sms-send and core celery pods weren't scaling all the way up. 

We tweaked a few scaling related params:
- #2264 
- #2265 

and [tested in staging yesterday](https://gcdigital.slack.com/archives/C05K8349YCR/p1702415373806189).

This PR makes corresponding changes to the prod and dev environments.

## Checklist if making changes to Kubernetes:
- [x] I know how to get kubectl credentials in case it catches on fire

## After merging this PR
- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.