### PR TITLE
Removing cloudwatch from dev

### DIFF
--- a/env/dev/kustomization.yaml
+++ b/env/dev/kustomization.yaml
@@ -2,7 +2,7 @@ bases:
   - ../../base/karpenter
   - ../../base/kube-state-metrics
   #- ../../base/prometheus-cloudwatch
-  - ../../base/k8s-event-logger
+  #- ../../base/k8s-event-logger
   - ../../base/utils
   - ../../base/notify-admin
   - ../../base/notify-api
@@ -18,9 +18,9 @@ bases:
   - ../../base/notify-system
   
 resources:
-  - cwagent.yaml
-  - fluentbit.yaml
-  - cwagent-configmap.yaml
+  #- cwagent.yaml
+  #- fluentbit.yaml
+  #- cwagent-configmap.yaml
   - notification-service-account.yaml
   - api-target-group.yaml
   - admin-target-group.yaml
@@ -42,11 +42,12 @@ configMapGenerator:
 - name: application-config
   env: .env
 
-patches:
+patchesStrategicMerge:
   - performance.yaml
   - services.yaml
   - karpenter.yaml
   - node-selector-patch.yaml
+  - remove-celery-init-patch.yaml
 
 vars:
 - name: ADMIN_CLIENT_SECRET

--- a/env/dev/remove-celery-init-patch.yaml
+++ b/env/dev/remove-celery-init-patch.yaml
@@ -1,0 +1,72 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: celery-primary
+  namespace: notification-canada-ca
+spec:
+  template:
+    spec:
+      initContainers:
+        - name: wait-cwagent-ready
+          $patch: delete
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: celery-scalable
+  namespace: notification-canada-ca
+spec:
+  template:
+    spec:
+      initContainers:
+        - name: wait-cwagent-ready
+          $patch: delete
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: celery-email-send-primary
+  namespace: notification-canada-ca
+spec:
+  template:
+    spec:
+      initContainers:
+        - name: wait-cwagent-ready
+          $patch: delete
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: celery-email-send-scalable
+  namespace: notification-canada-ca
+spec:
+  template:
+    spec:
+      initContainers:
+        - name: wait-cwagent-ready
+          $patch: delete
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: celery-sms-send-primary
+  namespace: notification-canada-ca
+spec:
+  template:
+    spec:
+      initContainers:
+        - name: wait-cwagent-ready
+          $patch: delete
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: celery-sms-send-scalable
+  namespace: notification-canada-ca
+spec:
+  template:
+    spec:
+      initContainers:
+        - name: wait-cwagent-ready
+          $patch: delete
+


### PR DESCRIPTION
## What happens when your PR merges?
We don't want cwagent in dev. This will remove it and also remove the init container in celery in dev only.

## What are you changing?
- [ ] Changing kubernetes configuration

## Provide some background on the changes
Working on dev