### PR TITLE
[MANIFEST] - Reducing prod celery sms send hpa to 15 max

### DIFF
--- a/env/production/performance.yaml
+++ b/env/production/performance.yaml
@@ -204,7 +204,7 @@ metadata:
   namespace: notification-canada-ca
 spec:
   minReplicas: 3
-  maxReplicas: 20
+  maxReplicas: 15
   metrics:
   - resource:
       name: cpu


### PR DESCRIPTION
## What happens when your PR merges?
Prod will only scale up to 15 (vs 20) pods for SMS send to try and avoid the rate limit.

## What are you changing?
- [X] Changing kubernetes configuration

## Provide some background on the changes
Re: SMS rate limit w/ NS SMS Send

