### PR TITLE
[MANIFEST[ Reducing k8s api to 2 max pods in prod

### DIFF
--- a/env/production/performance.yaml
+++ b/env/production/performance.yaml
@@ -138,7 +138,7 @@ metadata:
   name:  api
   namespace: notification-canada-ca
 spec:
-  replicas: 4
+  replicas: 2
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -262,5 +262,5 @@ metadata:
   name: api-hpa
   namespace: notification-canada-ca
 spec:
-  minReplicas: 4
-  maxReplicas: 8
+  minReplicas: 1
+  maxReplicas: 2


### PR DESCRIPTION
## What happens when your PR merges?
Prod API HPA will only scale to 2 pods max since we don't need a ton of these and it's possible that spooling up to 8 caused node pressure.

## What are you changing?
- [X] Changing kubernetes configuration

## Provide some background on the changes
Re: incident-2024-03-06-notify-api-pods-take-too-long-to-start-in-production
