### PR TITLE
chore: Centralizing k8s rollouts to manifests

### DIFF
--- a/.github/workflows/admin-rollout-k8s-staging.yaml
+++ b/.github/workflows/admin-rollout-k8s-staging.yaml
@@ -1,0 +1,61 @@
+name: Staging - Admin Kubernetes Rollout
+on:
+  workflow_dispatch:
+    inputs:
+      docker_sha:
+        description: 'The SHA from the source docker build job'
+        required: true
+  repository_dispatch:
+    types: [webhook]
+    inputs:
+      docker_sha:
+        description: 'The SHA from the source docker build job'
+        required: true
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  HELMFILE_FILE_PATH: ${{ github.workspace }}/helmfile
+  STAGING_AWS_ACCOUNT: ${{ secrets.STAGING_AWS_ACCOUNT }}
+  DOCKER_SLUG: public.ecr.aws/v6b8u5o6/notify-admin
+
+jobs:
+  rollout:
+    runs-on: github-arc-ss-manifests-dev
+    name: Rollout on EKS
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
+        id: awsconfig
+        with:
+          aws-access-key-id: ${{ secrets.STAGING_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.STAGING_AWS_SECRET_ACCESS_KEY }}
+          aws-region: ca-central-1
+
+      - name: Checkout
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+        with:
+          # Fetches entire history, so we can analyze commits since last tag
+          fetch-depth: 0
+
+        # I'm cheating and using this action to install kubectl
+      - name: Setup helmfile
+        uses: mamezou-tech/setup-helmfile@v2.0.0
+        with:
+          install-kubectl: yes
+          install-helm: yes
+
+      - name: Configure kubeconfig
+        run: |
+          aws eks update-kubeconfig --name notification-canada-ca-staging-eks-cluster   
+          
+      - name: Update images in staging
+        run: |
+          DOCKER_TAG=${{ github.event.inputs.docker_sha }}
+          echo $DOCKER_TAG
+          kubectl set image deployment.apps/admin admin=$DOCKER_SLUG:$DOCKER_TAG -n=notification-canada-ca --kubeconfig=$HOME/.kube/config
+
+      - name: Notify Slack channel if this job failed
+        if: ${{ failure() }}
+        run: |
+          json="{'text':'<!here> CI is failing in <https://github.com/cds-snc/notification-manifests/actions/runs/${GITHUB_RUN_ID}|notification-manifests> !'}"
+          curl -X POST -H 'Content-type: application/json' --data "$json"  ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/api-rollout-k8s-staging.yaml
+++ b/.github/workflows/api-rollout-k8s-staging.yaml
@@ -37,6 +37,7 @@ jobs:
           # Fetches entire history, so we can analyze commits since last tag
           fetch-depth: 0
 
+        # I'm cheating and using this action to install kubectl
       - name: Setup helmfile
         uses: mamezou-tech/setup-helmfile@v2.0.0
         with:

--- a/.github/workflows/dd-api-rollout-k8s-staging.yaml
+++ b/.github/workflows/dd-api-rollout-k8s-staging.yaml
@@ -1,0 +1,61 @@
+name: Staging - Document Download API Kubernetes Rollout
+on:
+  workflow_dispatch:
+    inputs:
+      docker_sha:
+        description: 'The SHA from the source docker build job'
+        required: true
+  repository_dispatch:
+    types: [webhook]
+    inputs:
+      docker_sha:
+        description: 'The SHA from the source docker build job'
+        required: true
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  HELMFILE_FILE_PATH: ${{ github.workspace }}/helmfile
+  STAGING_AWS_ACCOUNT: ${{ secrets.STAGING_AWS_ACCOUNT }}
+  DOCKER_SLUG: public.ecr.aws/cds-snc/notify-document-download-api
+
+jobs:
+  rollout:
+    runs-on: github-arc-ss-manifests-dev
+    name: Rollout on EKS
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
+        id: awsconfig
+        with:
+          aws-access-key-id: ${{ secrets.STAGING_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.STAGING_AWS_SECRET_ACCESS_KEY }}
+          aws-region: ca-central-1
+
+      - name: Checkout
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+        with:
+          # Fetches entire history, so we can analyze commits since last tag
+          fetch-depth: 0
+
+        # I'm cheating and using this action to install kubectl
+      - name: Setup helmfile
+        uses: mamezou-tech/setup-helmfile@v2.0.0
+        with:
+          install-kubectl: yes
+          install-helm: yes
+
+      - name: Configure kubeconfig
+        run: |
+          aws eks update-kubeconfig --name notification-canada-ca-staging-eks-cluster   
+          
+      - name: Update images in staging
+        run: |
+          DOCKER_TAG=${{ github.event.inputs.docker_sha }}
+          echo $DOCKER_TAG
+          kubectl set image deployment.apps/document-download-api document-download-api=$DOCKER_SLUG:$DOCKER_TAG -n=notification-canada-ca --kubeconfig=$HOME/.kube/config
+
+      - name: Notify Slack channel if this job failed
+        if: ${{ failure() }}
+        run: |
+          json="{'text':'<!here> CI is failing in <https://github.com/cds-snc/notification-manifests/actions/runs/${GITHUB_RUN_ID}|notification-manifests> !'}"
+          curl -X POST -H 'Content-type: application/json' --data "$json"  ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/documentation-rollout-k8s-staging.yaml
+++ b/.github/workflows/documentation-rollout-k8s-staging.yaml
@@ -1,0 +1,61 @@
+name: Staging - Documentation Kubernetes Rollout
+on:
+  workflow_dispatch:
+    inputs:
+      docker_sha:
+        description: 'The SHA from the source docker build job'
+        required: true
+  repository_dispatch:
+    types: [webhook]
+    inputs:
+      docker_sha:
+        description: 'The SHA from the source docker build job'
+        required: true
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  HELMFILE_FILE_PATH: ${{ github.workspace }}/helmfile
+  STAGING_AWS_ACCOUNT: ${{ secrets.STAGING_AWS_ACCOUNT }}
+  DOCKER_SLUG: public.ecr.aws/cds-snc/notify-documentation
+
+jobs:
+  rollout:
+    runs-on: github-arc-ss-manifests-dev
+    name: Rollout on EKS
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
+        id: awsconfig
+        with:
+          aws-access-key-id: ${{ secrets.STAGING_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.STAGING_AWS_SECRET_ACCESS_KEY }}
+          aws-region: ca-central-1
+
+      - name: Checkout
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+        with:
+          # Fetches entire history, so we can analyze commits since last tag
+          fetch-depth: 0
+
+        # I'm cheating and using this action to install kubectl
+      - name: Setup helmfile
+        uses: mamezou-tech/setup-helmfile@v2.0.0
+        with:
+          install-kubectl: yes
+          install-helm: yes
+
+      - name: Configure kubeconfig
+        run: |
+          aws eks update-kubeconfig --name notification-canada-ca-staging-eks-cluster   
+          
+      - name: Update images in staging
+        run: |
+          DOCKER_TAG=${{ github.event.inputs.docker_sha }}
+          echo $DOCKER_TAG
+          kubectl set image deployment.apps/documentation documentation=$DOCKER_SLUG:$DOCKER_TAG -n=notification-canada-ca --kubeconfig=$HOME/.kube/config
+
+      - name: Notify Slack channel if this job failed
+        if: ${{ failure() }}
+        run: |
+          json="{'text':'<!here> CI is failing in <https://github.com/cds-snc/notification-manifests/actions/runs/${GITHUB_RUN_ID}|notification-manifests> !'}"
+          curl -X POST -H 'Content-type: application/json' --data "$json"  ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
## What happens when your PR merges?
3 (4 including a small update to api) GitHub actions will be created to do the kubernetes image rollout in staging. One action each for:
- API (plus Celery)
- Admin
- Document Download API
- Documentation

## What are you changing?
- [x] GitHub Workflows


## Provide some background on the changes
Re: Private EKS cluster - required to centralize all kubernetes actions.

## Checklist if making changes to Kubernetes:
- [x] I know how to get kubectl credentials in case it catches on fire

## After merging this PR
- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.