### PR TITLE
Staging to internal arc

### DIFF
--- a/.github/workflows/api-rollout-k8s-staging.yaml
+++ b/.github/workflows/api-rollout-k8s-staging.yaml
@@ -20,7 +20,7 @@ env:
 
 jobs:
   rollout:
-    runs-on: github-arc-ss-manifests-dev
+    runs-on: github-arc-ss-staging
     name: Rollout on EKS
     steps:
       - name: Configure AWS credentials

--- a/.github/workflows/helmfile_staging_apply.yaml
+++ b/.github/workflows/helmfile_staging_apply.yaml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   helmfile-apply:
-    runs-on: ubuntu-latest
+    runs-on: github-arc-ss-staging
     steps:
 
       - name: Inject token authentication

--- a/.github/workflows/helmfile_staging_plan.yaml
+++ b/.github/workflows/helmfile_staging_plan.yaml
@@ -10,7 +10,7 @@ env:
 
 jobs:
   helmfile-diff:
-    runs-on: ubuntu-latest
+    runs-on: github-arc-ss-staging
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0

--- a/.github/workflows/merge_to_main_staging.yaml
+++ b/.github/workflows/merge_to_main_staging.yaml
@@ -18,7 +18,7 @@ defaults:
 
 jobs:
   kubectl-apply:
-    runs-on: ubuntu-latest
+    runs-on: github-arc-ss-staging
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## What happens when your PR merges?
The staging kustomize and helmfile workflows will be executed on the internal github runners.

## What are you changing?
- [ ] Releasing a new version of Notify
- [X] Changing kubernetes configuration

## Provide some background on the changes
Pre-requisite for private EKS

## If you are releasing a new version of Notify, what components are you updating
- [ ] API
- [ ] Admin
- [ ] Documentation
- [ ] Document download API

## Checklist if releasing new version:
- [X] I made sure that the changes are as expected in [Notify staging](https://staging.notification.cdssandbox.xyz/)
- [X] I have checked if the docker images I am referencing exist
    - [ ] [api lambda](https://ca-central-1.console.aws.amazon.com/ecr/repositories/private/296255494825/notify/api-lambda?region=ca-central-1) (requires Notification-Production / AdministratorAccess login)
    - [ ] [api k8s](https://gallery.ecr.aws/v6b8u5o6/notify-api)
    - [ ] [admin](https://gallery.ecr.aws/v6b8u5o6/notify-admin)
    - [ ] [documentation](https://gallery.ecr.aws/v6b8u5o6/notify-documentation)
    - [ ] [document download API](https://gallery.ecr.aws/v6b8u5o6/notify-document-download-api)

## Checklist if making changes to Kubernetes:
- [X] I know how to get kubectl credentials in case it catches on fire

## After merging this PR
- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.