### PR TITLE
chore: Fixing helmfile staging and reverting merge to main staging

### DIFF
--- a/.github/workflows/helmfile_staging_apply.yaml
+++ b/.github/workflows/helmfile_staging_apply.yaml
@@ -30,6 +30,11 @@ jobs:
         with:
           # Fetches entire history, so we can analyze commits since last tag
           fetch-depth: 0
+      - name: Setup helmfile
+        uses: mamezou-tech/setup-helmfile@v2.0.0
+        with:
+          install-kubectl: yes
+          install-helm: yes          
       - name: Configure kubeconfig
         run: |
           aws eks update-kubeconfig --name notification-canada-ca-staging-eks-cluster     

--- a/.github/workflows/merge_to_main_staging.yaml
+++ b/.github/workflows/merge_to_main_staging.yaml
@@ -18,7 +18,7 @@ defaults:
 
 jobs:
   kubectl-apply:
-    runs-on: github-arc-ss-staging
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## What happens when your PR merges?
I somehow deleted the helmfile install step on staging helmfile apply. Put that back in.

Also, the mergeToMainStaging workflow is using the sentinel forwarder which I missed when doing the internal ARC. I'm reverting that one for now.

## What are you changing?
- [ ] Releasing a new version of Notify
- [X] Changing kubernetes configuration

## Provide some background on the changes
Re: Private EKS cluster

## Checklist if making changes to Kubernetes:
- [x] I know how to get kubectl credentials in case it catches on fire

## After merging this PR
- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.