### PR TITLE
docker in docker for sentinel

### DIFF
--- a/helmfile/overrides/system/github-arc-scaleset.yaml.gotmpl
+++ b/helmfile/overrides/system/github-arc-scaleset.yaml.gotmpl
@@ -3,6 +3,8 @@ githubConfigUrl: https://github.com/cds-snc/notification-manifests
 controllerServiceAccount:
    namespace: github-arc-controller
    name: github-arc-gha-rs-controller
+containerMode:
+  type: dind
 template:
   spec:
     containers:
@@ -13,4 +15,3 @@ template:
       {{ if not (eq .Environment.Name "production") }}
       image: {{ requiredEnv "GITHUB_ARC_RUNNER_REPOSITORY_URL" }}:bootstrap
       {{ end }}
-  


### PR DESCRIPTION
## What happens when your PR merges?
This will allow the github arc runners to launch docker steps inside them, by connecting to the root docker sock on the node.

This is needed for the sentinel job in the merge to staging github action.

## What are you changing?
- [ ] Releasing a new version of Notify
- [X] Changing kubernetes configuration

## Provide some background on the changes
Re: Private EKS prerequisites

## Checklist if making changes to Kubernetes:
- [X] I know how to get kubectl credentials in case it catches on fire

## After merging this PR
- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.