### PR TITLE
chore: setting merge to main staging to run internally againg

### DIFF
--- a/.github/workflows/merge_to_main_staging.yaml
+++ b/.github/workflows/merge_to_main_staging.yaml
@@ -18,7 +18,7 @@ defaults:
 
 jobs:
   kubectl-apply:
-    runs-on: ubuntu-latest
+    runs-on: github-arc-ss-staging
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## What happens when your PR merges?
The merge to main staging github action should now run properly on github arc.


## What are you changing?
- [ ] Releasing a new version of Notify
- [X] Changing kubernetes configuration

## Provide some background on the changes
Re: private eks prerequisites
## Checklist if making changes to Kubernetes:
- [X] I know how to get kubectl credentials in case it catches on fire

## After merging this PR
- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.