### PR TITLE
chore: ARC pullPolicy and kubectl version

### DIFF
--- a/.github/workflows/merge_to_main_staging.yaml
+++ b/.github/workflows/merge_to_main_staging.yaml
@@ -41,6 +41,7 @@ jobs:
         with:
           install-kubectl: yes
           install-helm: yes
+          kubectl-version: 1.23.6
 
       - name: Decrypt staging env
         run: |

--- a/helmfile/overrides/system/github-arc-scaleset.yaml.gotmpl
+++ b/helmfile/overrides/system/github-arc-scaleset.yaml.gotmpl
@@ -15,3 +15,4 @@ template:
       {{ if not (eq .Environment.Name "production") }}
       image: {{ requiredEnv "GITHUB_ARC_RUNNER_REPOSITORY_URL" }}:bootstrap
       {{ end }}
+      imagePullPolicy: Always


### PR DESCRIPTION
## What happens when your PR merges?
Setting the github ARC runner to always pull latest image.

Explicitly setting the kubectl version in the installation.

## Provide some background on the changes
Prerequisite for private eks
