### PR TITLE
chore: reverting to previous GHA for today

### DIFF
--- a/.github/workflows/merge_to_main_staging.yaml
+++ b/.github/workflows/merge_to_main_staging.yaml
@@ -1,7 +1,6 @@
 name: "Merge to main (Staging)"
 
 on:
-  
   push:
     branches:
       - main
@@ -19,7 +18,7 @@ defaults:
 
 jobs:
   kubectl-apply:
-    runs-on: github-arc-ss-staging
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
@@ -35,13 +34,12 @@ jobs:
           aws-secret-access-key: ${{ secrets.STAGING_AWS_SECRET_ACCESS_KEY }}
           aws-region: ca-central-1
 
-      # I'm cheating and using this action to install kubectl
-      - name: Setup helmfile
-        uses: mamezou-tech/setup-helmfile@v2.0.0
-        with:
-          install-kubectl: yes
-          install-helm: yes
-          kubectl-version: 1.23.6
+      - name: Install kubectl
+        run: |
+          curl -LO https://dl.k8s.io/release/v$KUBECTL_VERSION/bin/linux/amd64/kubectl
+          chmod +x kubectl
+          mv kubectl /usr/local/bin/
+          kubectl version --client
 
       - name: Decrypt staging env
         run: |
@@ -108,5 +106,5 @@ jobs:
       - name: Notify Slack channel if this job failed
         if: ${{ failure() }}
         run: |
-          json="{'text':'<!here> Manifests Merge To Staging CI is failing in <https://github.com/cds-snc/notification-manifests/|notification-manifests> !'}"
+          json="{'text':'<!here> CI is failing in <https://github.com/cds-snc/notification-manifests/|notification-manifests> !'}"
           curl -X POST -H 'Content-type: application/json' --data "$json"  ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
## What happens when your PR merges?
Reverting to previous GHA for merge main to staging for today - the kubectl version staging needs is too old. I'm going to have to fix manifests tomorrow.
