### PR TITLE
Switching github arc to app id

### DIFF
--- a/helmfile/overrides/system/github-arc.yaml.gotmpl
+++ b/helmfile/overrides/system/github-arc.yaml.gotmpl
@@ -8,12 +8,20 @@ secretProviderClass:
   provider: aws
   parameters:
     objects: |
-      - objectName: GITHUB_ARC_PAT
+      - objectName: PR_BOT_APP_ID
         objectType: "secretsmanager"
+      - objectName: PR_BOT_INSTALLATION_ID
+        objectType: "secretsmanager"        
+      - objectName: PR_BOT_PRIVATE_KEY
+        objectType: "secretsmanager"          
   secretObjects:
     - data:
-      - key: github_token
-        objectName: GITHUB_ARC_PAT
+      - key: github_app_id
+        objectName: PR_BOT_APP_ID
+      - key: github_app_installation_id
+        objectName: PR_BOT_INSTALLATION_ID
+      - key: github_app_private_key
+        objectName: PR_BOT_PRIVATE_KEY                
       secretName: github-arc
       type: Opaque
 volumes:


### PR DESCRIPTION
## What happens when your PR merges?
Github ARC will now use a github app for authentication instead of a PAT

NOTE: [This Terraform PR must be merged first](https://github.com/cds-snc/notification-terraform/pull/1205)

## What are you changing?
- [x] Changing kubernetes configuration

## Provide some background on the changes
Re: Private EKS cluster


## Checklist if making changes to Kubernetes:
- [x] I know how to get kubectl credentials in case it catches on fire

## After merging this PR
- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.