### PR TITLE
chore: update entity kind as resource

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -2,7 +2,7 @@
 # https://backstage.cdssandbox.xyz/
 ---
 apiVersion: backstage.io/v1alpha1
-kind: Component
+kind: Resource
 metadata:
   name: notification-manifests
   description: >-
@@ -13,7 +13,7 @@ metadata:
   labels:
     license: MIT
 spec:
-  type: website
+  type: infrastructure
   lifecycle: production
   owner: group:cds-snc/notify-dev
   system: gc-notification


### PR DESCRIPTION
## What happens when your PR merges?

Updating the metadata values of the catalog's entity.

## What are you changing?

Changing to type of entity Resource from Component.

## Provide some background on the changes

Documentation update

## If you are releasing a new version of Notify, what components are you updating

N/A

## Checklist if releasing new version:
- [ ] I made sure that the changes are as expected in [Notify staging](https://staging.notification.cdssandbox.xyz/)
- [ ] I have checked if the docker images I am referencing exist
    - [ ] [api lambda](https://ca-central-1.console.aws.amazon.com/ecr/repositories/private/296255494825/notify/api-lambda?region=ca-central-1) (requires Notification-Production / AdministratorAccess login)
    - [ ] [api k8s](https://gallery.ecr.aws/v6b8u5o6/notify-api)
    - [ ] [admin](https://gallery.ecr.aws/v6b8u5o6/notify-admin)
    - [ ] [documentation](https://gallery.ecr.aws/v6b8u5o6/notify-documentation)
    - [ ] [document download API](https://gallery.ecr.aws/v6b8u5o6/notify-document-download-api)

## Checklist if making changes to Kubernetes:
- [ ] I know how to get kubectl credentials in case it catches on fire

## After merging this PR
- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.