### PR TITLE
Forcing fluent bit to be system critical

### DIFF
--- a/env/dev/fluentbit.yaml
+++ b/env/dev/fluentbit.yaml
@@ -330,6 +330,7 @@ spec:
         version: v1
         kubernetes.io/cluster-service: "true"
     spec:
+      priorityClassName: "system-cluster-critical"
       initContainers:
       - name: wait-for-init
         image: busybox:1.28

--- a/env/production/fluentbit.yaml
+++ b/env/production/fluentbit.yaml
@@ -331,6 +331,7 @@ spec:
         version: v1
         kubernetes.io/cluster-service: "true"
     spec:
+      priorityClassName: "system-cluster-critical"
       initContainers:
       - name: wait-for-init
         image: busybox:1.28

--- a/env/staging/fluentbit.yaml
+++ b/env/staging/fluentbit.yaml
@@ -352,6 +352,7 @@ spec:
         version: v1
         kubernetes.io/cluster-service: "true"
     spec:
+      priorityClassName: "system-cluster-critical"
       initContainers:
       - name: wait-for-init
         image: busybox:1.28


### PR DESCRIPTION
## What happens when your PR merges?
Fluent bit will be system critical and will evict pods to make sure it's running.

## What are you changing?
- [X] Changing kubernetes configuration

## Provide some background on the changes
While perf testing, we noticed that fluentbit didn't always find a spot on its node because celery took too many resources. 

## Checklist if making changes to Kubernetes:
- [x] I know how to get kubectl credentials in case it catches on fire

## After merging this PR
- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.