### PR TITLE
[MANIFEST] - Enabling arc images in prod

### DIFF
--- a/helmfile/overrides/system/github-arc-scaleset.yaml.gotmpl
+++ b/helmfile/overrides/system/github-arc-scaleset.yaml.gotmpl
@@ -11,8 +11,5 @@ template:
     - name: runner
       command: 
         - /home/runner/run.sh
-      ## TODO: remove this if statement when launching to production
-      {{ if not (eq .Environment.Name "production") }}
       image: {{ requiredEnv "GITHUB_ARC_RUNNER_REPOSITORY_URL" }}:bootstrap
-      {{ end }}
       imagePullPolicy: Always


### PR DESCRIPTION
## What happens when your PR merges?
I had conditioned out using the custom docker image for github arc in production. Need to remove that condition so that the github arc runners actually run.

## What are you changing?
- [ ] Releasing a new version of Notify
- [x] Changing kubernetes configuration

## Provide some background on the changes
Re: Prep for private EKS in prod

## Checklist if making changes to Kubernetes:
- [x] I know how to get kubectl credentials in case it catches on fire

## After merging this PR
- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.