### PR TITLE
Upping max gha arc  runners to 20

### DIFF
--- a/helmfile/overrides/system/github-arc-scaleset.yaml.gotmpl
+++ b/helmfile/overrides/system/github-arc-scaleset.yaml.gotmpl
@@ -1,5 +1,6 @@
 githubConfigSecret: github-arc
 githubConfigUrl: https://github.com/cds-snc/notification-manifests
+maxRunners: 20
 controllerServiceAccount:
    namespace: github-arc-controller
    name: github-arc-gha-rs-controller


### PR DESCRIPTION
## What happens when your PR merges?
Setting the maximum number of runners to 20 in Github ARC. This is just preventative maintenance.

## What are you changing?
- [ ] Releasing a new version of Notify
- [x] Changing kubernetes configuration

## Provide some background on the changes
While investigating today's issue with the runners not spinning up, I figured it would be a good idea to up this number as well.

## If you are releasing a new version of Notify, what components are you updating
- [ ] API
- [ ] Admin
- [ ] Documentation
- [ ] Document download API


## Checklist if making changes to Kubernetes:
- [x] I know how to get kubectl credentials in case it catches on fire

## After merging this PR
- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.