### PR TITLE
Updating Supporting Workflows For Github ARC

### DIFF
--- a/.github/workflows/helmfile_production_apply.yaml
+++ b/.github/workflows/helmfile_production_apply.yaml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   helmfile-apply:
-    runs-on: ubuntu-latest
+    runs-on: github-arc-ss-production
     steps:
 
       - name: Inject token authentication

--- a/.github/workflows/helmfile_production_plan.yaml
+++ b/.github/workflows/helmfile_production_plan.yaml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   helmfile-diff:
-    runs-on: ubuntu-latest
+    runs-on: github-arc-ss-production
     steps:
 
       - name: Inject token authentication

--- a/.github/workflows/syntax_check_prod.yaml
+++ b/.github/workflows/syntax_check_prod.yaml
@@ -3,9 +3,6 @@ name: Testing Prod Manifest
 on: 
   - pull_request
 
-env:
-  KUBECTL_VERSION: 1.23.6
-
 jobs:
   testing_manifest:
     runs-on: ubuntu-latest
@@ -14,12 +11,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
 
-      - name: Install kubectl
-        run: |
-          curl -LO https://dl.k8s.io/release/v$KUBECTL_VERSION/bin/linux/amd64/kubectl
-          chmod +x kubectl
-          mv kubectl /usr/local/bin/
-          kubectl version --client
+      # We are using this to install kubectl in this case
+      - name: Setup helmfile
+        uses: mamezou-tech/setup-helmfile@v2.0.0
+        with:
+          install-kubectl: yes
+          install-helm: yes
 
       - name: Add fake .env
         run: |


### PR DESCRIPTION
## What happens when your PR merges?
The workflows supporting production releases will be updated to use the same version of kubectl and run on github arc as required

## What are you changing?
- [ ] Releasing a new version of Notify
- [ ] Changing kubernetes configuration
- [x] Github workflows

## Provide some background on the changes
Prerequisite for private EKS cluster in production


## Checklist if making changes to Kubernetes:
- [x] I know how to get kubectl credentials in case it catches on fire

## After merging this PR
- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.