### PR TITLE
Cert Manager on Primary Nodes Only

### DIFF
--- a/env/dev/kustomization.yaml
+++ b/env/dev/kustomization.yaml
@@ -70,6 +70,9 @@ patches:
 - path: nodeselectors/celery-sms-send-scalable-node-selector-patch.yaml
 - path: nodeselectors/document-download-api-node-selector-patch.yaml
 - path: nodeselectors/documentation-node-selector-patch.yaml
+- path: nodeselectors/cert-manager.yaml
+- path: nodeselectors/cert-manager-cainjector.yaml
+- path: nodeselectors/cert-manager-webhook.yaml
 
 - path: celery-init-delete/celery-email-send-primary-init-delete-patch.yaml
 - path: celery-init-delete/celery-email-send-scalable-init-delete-patch.yaml

--- a/env/dev/nodeselectors/cert-manager-cainjector.yaml
+++ b/env/dev/nodeselectors/cert-manager-cainjector.yaml
@@ -1,0 +1,13 @@
+# Notify Admin
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: cert-manager-cainjector
+  name:  cert-manager-cainjector
+  namespace: cert-manager
+spec:
+  template:
+    spec:
+      nodeSelector:
+        eks.amazonaws.com/capacityType: ON_DEMAND

--- a/env/dev/nodeselectors/cert-manager-webhook.yaml
+++ b/env/dev/nodeselectors/cert-manager-webhook.yaml
@@ -1,0 +1,13 @@
+# Notify Admin
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: cert-manager-webhook
+  name:  cert-manager-webhook
+  namespace: cert-manager
+spec:
+  template:
+    spec:
+      nodeSelector:
+        eks.amazonaws.com/capacityType: ON_DEMAND

--- a/env/dev/nodeselectors/cert-manager.yaml
+++ b/env/dev/nodeselectors/cert-manager.yaml
@@ -1,0 +1,13 @@
+# Notify Admin
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: cert-manager-webhook
+  name:  cert-manager-webhook
+  namespace: cert-manager
+spec:
+  template:
+    spec:
+      nodeSelector:
+        eks.amazonaws.com/capacityType: ON_DEMAND

--- a/env/production/kustomization.yaml
+++ b/env/production/kustomization.yaml
@@ -58,6 +58,9 @@ patches:
   - path: nodeselectors/celery-sms-send-scalable-node-selector-patch.yaml
   - path: nodeselectors/document-download-api-node-selector-patch.yaml
   - path: nodeselectors/documentation-node-selector-patch.yaml
+  - path: nodeselectors/cert-manager.yaml
+  - path: nodeselectors/cert-manager-cainjector.yaml
+  - path: nodeselectors/cert-manager-webhook.yaml
   
   - path: karpenter/aws-node-template-patch.yaml
   - path: karpenter/configmap-patch.yaml

--- a/env/production/nodeselectors/cert-manager-cainjector.yaml
+++ b/env/production/nodeselectors/cert-manager-cainjector.yaml
@@ -1,0 +1,13 @@
+# Notify Admin
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: cert-manager-cainjector
+  name:  cert-manager-cainjector
+  namespace: cert-manager
+spec:
+  template:
+    spec:
+      nodeSelector:
+        eks.amazonaws.com/capacityType: ON_DEMAND

--- a/env/production/nodeselectors/cert-manager-webhook.yaml
+++ b/env/production/nodeselectors/cert-manager-webhook.yaml
@@ -1,0 +1,13 @@
+# Notify Admin
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: cert-manager-webhook
+  name:  cert-manager-webhook
+  namespace: cert-manager
+spec:
+  template:
+    spec:
+      nodeSelector:
+        eks.amazonaws.com/capacityType: ON_DEMAND

--- a/env/production/nodeselectors/cert-manager.yaml
+++ b/env/production/nodeselectors/cert-manager.yaml
@@ -1,0 +1,13 @@
+# Notify Admin
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: cert-manager-webhook
+  name:  cert-manager-webhook
+  namespace: cert-manager
+spec:
+  template:
+    spec:
+      nodeSelector:
+        eks.amazonaws.com/capacityType: ON_DEMAND

--- a/env/staging/kustomization.yaml
+++ b/env/staging/kustomization.yaml
@@ -47,7 +47,9 @@ patches:
 - path: performance/celery-sms-send-scalable-hpa-patch.yaml
 - path: performance/document-download-api-hpa-patch.yaml
 - path: performance/documentation-deployment-patch.yaml
-
+- path: nodeselectors/cert-manager.yaml
+- path: nodeselectors/cert-manager-cainjector.yaml
+- path: nodeselectors/cert-manager-webhook.yaml
 
 - path: services/admin-service-patch.yaml
 - path: services/api-service-patch.yaml

--- a/env/staging/nodeselectors/cert-manager-cainjector.yaml
+++ b/env/staging/nodeselectors/cert-manager-cainjector.yaml
@@ -1,0 +1,13 @@
+# Notify Admin
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: cert-manager-cainjector
+  name:  cert-manager-cainjector
+  namespace: cert-manager
+spec:
+  template:
+    spec:
+      nodeSelector:
+        eks.amazonaws.com/capacityType: ON_DEMAND

--- a/env/staging/nodeselectors/cert-manager-webhook.yaml
+++ b/env/staging/nodeselectors/cert-manager-webhook.yaml
@@ -1,0 +1,13 @@
+# Notify Admin
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: cert-manager-webhook
+  name:  cert-manager-webhook
+  namespace: cert-manager
+spec:
+  template:
+    spec:
+      nodeSelector:
+        eks.amazonaws.com/capacityType: ON_DEMAND

--- a/env/staging/nodeselectors/cert-manager.yaml
+++ b/env/staging/nodeselectors/cert-manager.yaml
@@ -1,0 +1,13 @@
+# Notify Admin
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: cert-manager-webhook
+  name:  cert-manager-webhook
+  namespace: cert-manager
+spec:
+  template:
+    spec:
+      nodeSelector:
+        eks.amazonaws.com/capacityType: ON_DEMAND


### PR DESCRIPTION
## What happens when your PR merges?
The Cert-Manager deployments will only be deployed to primary nodes, and not spot instances.

## What are you changing?
- [ ] Releasing a new version of Notify
- [x] Changing kubernetes configuration

## Provide some background on the changes
We got a sentinel alert that indicated odd activity w/ cert-manager. It was benign, but was a result of running on a spot instance and being evicted.

## Checklist if releasing new version:
- [ ] I made sure that the changes are as expected in [Notify staging](https://staging.notification.cdssandbox.xyz/)
- [ ] I have checked if the docker images I am referencing exist
    - [ ] [api lambda](https://ca-central-1.console.aws.amazon.com/ecr/repositories/private/296255494825/notify/api-lambda?region=ca-central-1) (requires Notification-Production / AdministratorAccess login)
    - [ ] [api k8s](https://gallery.ecr.aws/v6b8u5o6/notify-api)
    - [ ] [admin](https://gallery.ecr.aws/v6b8u5o6/notify-admin)
    - [ ] [documentation](https://gallery.ecr.aws/v6b8u5o6/notify-documentation)
    - [ ] [document download API](https://gallery.ecr.aws/v6b8u5o6/notify-document-download-api)

## Checklist if making changes to Kubernetes:
- [ ] I know how to get kubectl credentials in case it catches on fire

## After merging this PR
- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.