### PR TITLE
Specifying helmfile version in Github actions

### DIFF
--- a/.github/workflows/helmfile_production_apply.yaml
+++ b/.github/workflows/helmfile_production_apply.yaml
@@ -51,3 +51,4 @@ jobs:
         uses: helmfile/helmfile-action@v1.0.0
         with:
           helmfile-args: apply --environment production
+          helmfile-workdirectory: ${{ github.workspace }}/helmfile

--- a/.github/workflows/helmfile_production_apply.yaml
+++ b/.github/workflows/helmfile_production_apply.yaml
@@ -38,6 +38,7 @@ jobs:
         with:
           install-kubectl: yes
           install-helm: yes       
+          helmfile-version: "v0.151.0"
       - name: Configure kubeconfig
         run: |
           aws eks update-kubeconfig --name notification-canada-ca-production-eks-cluster   

--- a/.github/workflows/helmfile_production_plan.yaml
+++ b/.github/workflows/helmfile_production_plan.yaml
@@ -49,9 +49,11 @@ jobs:
       - name: Helmfile Diff
         id: helmfile_diff
         run: |
+          pushd helmfile
           echo 'var<<EOF' >> $GITHUB_OUTPUT
           helmfile --environment staging diff >> $GITHUB_OUTPUT
           echo 'EOF' >> $GITHUB_OUTPUT
+          popd
       - name: Helmfile Diff Comment
         uses: mshick/add-pr-comment@v2
         with:

--- a/.github/workflows/helmfile_production_plan.yaml
+++ b/.github/workflows/helmfile_production_plan.yaml
@@ -38,6 +38,7 @@ jobs:
         with:
           install-kubectl: yes
           install-helm: yes
+          helmfile-version: "v0.151.0"
       - name: Configure kubeconfig
         run: |
           aws eks update-kubeconfig --name notification-canada-ca-production-eks-cluster   

--- a/.github/workflows/helmfile_staging_apply.yaml
+++ b/.github/workflows/helmfile_staging_apply.yaml
@@ -48,4 +48,5 @@ jobs:
         id: helmfile_apply
         uses: helmfile/helmfile-action@v1.0.0
         with:
+          helmfile-workdirectory: ${{ github.workspace }}/helmfile
           helmfile-args: apply --environment staging

--- a/.github/workflows/helmfile_staging_apply.yaml
+++ b/.github/workflows/helmfile_staging_apply.yaml
@@ -35,7 +35,8 @@ jobs:
         uses: mamezou-tech/setup-helmfile@v2.0.0
         with:
           install-kubectl: yes
-          install-helm: yes          
+          install-helm: yes        
+          helmfile-version: "v0.151.0"  
       - name: Configure kubeconfig
         run: |
           aws eks update-kubeconfig --name notification-canada-ca-staging-eks-cluster     

--- a/.github/workflows/helmfile_staging_apply_specific_app.yaml
+++ b/.github/workflows/helmfile_staging_apply_specific_app.yaml
@@ -71,7 +71,9 @@ jobs:
       - name: Run helmfile
         id: helmfile_apply
         run: |
-          helmfile --environment staging -l ${{ github.event.inputs.selector }} apply
+        pushd helmfile
+        helmfile --environment staging -l ${{ github.event.inputs.selector }} apply
+        popd
 
       - name: Notify Slack channel if this job failed
         if: ${{ failure() }}

--- a/.github/workflows/helmfile_staging_apply_specific_app.yaml
+++ b/.github/workflows/helmfile_staging_apply_specific_app.yaml
@@ -57,6 +57,7 @@ jobs:
         with:
           install-kubectl: yes
           install-helm: yes
+          helmfile-version: "v0.151.0"
 
       - name: Configure kubeconfig
         run: |

--- a/.github/workflows/helmfile_staging_apply_specific_app.yaml
+++ b/.github/workflows/helmfile_staging_apply_specific_app.yaml
@@ -71,9 +71,9 @@ jobs:
       - name: Run helmfile
         id: helmfile_apply
         run: |
-        pushd helmfile
-        helmfile --environment staging -l ${{ github.event.inputs.selector }} apply
-        popd
+          pushd helmfile
+          helmfile --environment staging -l ${{ github.event.inputs.selector }} apply
+          popd
 
       - name: Notify Slack channel if this job failed
         if: ${{ failure() }}

--- a/.github/workflows/helmfile_staging_plan.yaml
+++ b/.github/workflows/helmfile_staging_plan.yaml
@@ -41,9 +41,11 @@ jobs:
       - name: Helmfile Diff
         id: helmfile_diff
         run: |
+          pushd helmfile
           echo 'var<<EOF' >> $GITHUB_OUTPUT
           helmfile --environment staging diff >> $GITHUB_OUTPUT
           echo 'EOF' >> $GITHUB_OUTPUT
+          popd
       - name: Helmfile Diff Comment
         uses: mshick/add-pr-comment@v2
         with:

--- a/.github/workflows/helmfile_staging_plan.yaml
+++ b/.github/workflows/helmfile_staging_plan.yaml
@@ -30,6 +30,7 @@ jobs:
         with:
           install-kubectl: yes
           install-helm: yes
+          helmfile-version: "v0.151.0"
       - name: Configure kubeconfig
         run: |
           aws eks update-kubeconfig --name notification-canada-ca-staging-eks-cluster   


### PR DESCRIPTION
## What happens when your PR merges?
To fix the issue we're seeing now with failed helmfile rollouts - I believe that the latest helmfile version is the culprit. They've moved to a 1.0.0 release candidate.

## What are you changing?
- [ ] Releasing a new version of Notify
- [ ] Changing kubernetes configuration
- [x] Changing Github Actions configuration

## Provide some background on the changes
Re: Failed deployments

## Checklist if making changes to Kubernetes:
- [x] I know how to get kubectl credentials in case it catches on fire

## After merging this PR
- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.