### PR TITLE
Adding failure notifications for helmfile apply

### DIFF
--- a/.github/workflows/helmfile_production_apply.yaml
+++ b/.github/workflows/helmfile_production_apply.yaml
@@ -52,3 +52,9 @@ jobs:
           pushd helmfile
           helmfile --environment production apply
           popd
+
+      - name: Notify Slack channel if this job failed
+        if: ${{ failure() }}
+        run: |
+          json="{'text':'<!here> Production Helmfile Apply is Failing <https://github.com/cds-snc/notification-manifests/|notification-manifests> !'}"
+          curl -X POST -H 'Content-type: application/json' --data "$json"  ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/helmfile_staging_apply.yaml
+++ b/.github/workflows/helmfile_staging_apply.yaml
@@ -50,3 +50,9 @@ jobs:
           pushd helmfile
           helmfile --environment staging apply
           popd
+
+      - name: Notify Slack channel if this job failed
+        if: ${{ failure() }}
+        run: |
+          json="{'text':'<!here> Staging Helmfile Apply is Failing <https://github.com/cds-snc/notification-manifests/|notification-manifests> !'}"
+          curl -X POST -H 'Content-type: application/json' --data "$json"  ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
## What happens when your PR merges?
We weren't getting alerted on helmfile apply failures. Here's a thing to fix that.

## What are you changing?
- [ ] Releasing a new version of Notify
- [ ] Changing kubernetes configuration
- [x] Github workflows

## Provide some background on the changes
Saw some failed releases for helmfile 

