### PR TITLE
[MANIFEST] IMDSv2 for fluent bit

### DIFF
--- a/env/production/fluentbit.yaml
+++ b/env/production/fluentbit.yaml
@@ -220,7 +220,7 @@ data:
     [FILTER]
         Name                aws
         Match               dataplane.*
-        imds_version        v1
+        imds_version        v2
 
     [OUTPUT]
         Name                cloudwatch_logs
@@ -268,7 +268,7 @@ data:
     [FILTER]
         Name                aws
         Match               host.*
-        imds_version        v1
+        imds_version        v2
 
     [OUTPUT]
         Name                cloudwatch_logs


### PR DESCRIPTION
## What happens when your PR merges?
Fluent Bit will be upgraded to IMDSv2 in Production

## What are you changing?
- [ ] Releasing a new version of Notify
- [x] Changing kubernetes configuration

## Provide some background on the changes
Part of IMDSv2 conversion

## Checklist if making changes to Kubernetes:
- [x] I know how to get kubectl credentials in case it catches on fire

## After merging this PR
- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.