### PR TITLE
Added support for release_tag parameter and refer in k8 image update

### DIFF
--- a/.github/workflows/ipv4-geolocate-webservice-staging.yaml
+++ b/.github/workflows/ipv4-geolocate-webservice-staging.yaml
@@ -50,9 +50,9 @@ jobs:
 
       - name: Update images in staging
         run: |
-          DOCKER_TAG=${{ github.event.inputs.docker_sha }}
-          echo $DOCKER_TAG
-          kubectl set image deployment.apps/ipv4 ipv4=$DOCKER_SLUG:$DOCKER_TAG -n=notification-canada-ca --kubeconfig=$HOME/.kube/config
+          IPV4_RELEASE_TAG=${{ github.event.inputs.release_tag }}
+          echo $IPV4_RELEASE_TAG
+          kubectl set image deployment.apps/ipv4 ipv4=$DOCKER_SLUG:$IPV4_RELEASE_TAG -n=notification-canada-ca --kubeconfig=$HOME/.kube/config
 
       - name: Restart deployments in staging
         run: |


### PR DESCRIPTION
## What happens when your PR merges?
- Prefix the title of your PR:
    - `fix:` - tag `main` as a new patch release
    - `feat:` - tag `main` as a new minor release
    - `BREAKING CHANGE:` - tag `main` as a new major release
    - `[MANIFEST]` or `[AUTO-PR]` - tag `main` as a new patch release and deploy to production
    - `chore:` - use for changes to non-app code (ex: GitHub actions)
- Alternatively, change the [VERSION file](https://github.com/cds-snc/notification-manifests/blob/main/VERSION) - this will not create a new tag, but rather will release the tag in `VERSION` to production.

## What are you changing?

Because the ipv4 image has a date suffix instead of the traditional github sha ID (there is one release per day), the github action calling its workflow needs to reference to the proper kubernetes image reference within Kubernetes by using the release tag (today's release date more specifically).

- [ ] Releasing a new version of Notify
- [ ] Changing kubernetes configuration

## Provide some background on the changes

We are fixing the broken ipv4 build process in staging. 

## If you are releasing a new version of Notify, what components are you updating
- [ ] API
- [ ] Admin
- [ ] Documentation
- [ ] Document download API

## Checklist if releasing new version:
- [ ] I made sure that the changes are as expected in [Notify staging](https://staging.notification.cdssandbox.xyz/)
- [ ] I have checked if the docker images I am referencing exist
    - [ ] [api lambda](https://ca-central-1.console.aws.amazon.com/ecr/repositories/private/296255494825/notify/api-lambda?region=ca-central-1) (requires Notification-Production / AdministratorAccess login)
    - [ ] [api k8s](https://gallery.ecr.aws/v6b8u5o6/notify-api)
    - [ ] [admin](https://gallery.ecr.aws/v6b8u5o6/notify-admin)
    - [ ] [documentation](https://gallery.ecr.aws/v6b8u5o6/notify-documentation)
    - [ ] [document download API](https://gallery.ecr.aws/v6b8u5o6/notify-document-download-api)

## Checklist if making changes to Kubernetes:
- [ ] I know how to get kubectl credentials in case it catches on fire

## After merging this PR
- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.