### PR TITLE
[MANIFEST] Revert this morning's release

### DIFF
--- a/.github/workflows/merge_to_main_production.yaml
+++ b/.github/workflows/merge_to_main_production.yaml
@@ -9,7 +9,7 @@ on:
 
 env:
   PRIVATE_ECR: ${{ secrets.PRODUCTION_AWS_ACCOUNT }}.dkr.ecr.ca-central-1.amazonaws.com/notify
-  API_LAMBDA_IMAGE: api-lambda:661caad
+  API_LAMBDA_IMAGE: api-lambda:4ef95ad
   HEARTBEAT_IMAGE: heartbeat:5c8da95
   SYSTEM_STATUS_IMAGE: system_status:078cf82
   OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.PRODUCTION_OP_SERVICE_ACCOUNT_TOKEN }}

--- a/.github/workflows/merge_to_main_production.yaml
+++ b/.github/workflows/merge_to_main_production.yaml
@@ -9,7 +9,7 @@ on:
 
 env:
   PRIVATE_ECR: ${{ secrets.PRODUCTION_AWS_ACCOUNT }}.dkr.ecr.ca-central-1.amazonaws.com/notify
-  API_LAMBDA_IMAGE: api-lambda:4ef95ad
+  API_LAMBDA_IMAGE: api-lambda:45442d0
   HEARTBEAT_IMAGE: heartbeat:5c8da95
   SYSTEM_STATUS_IMAGE: system_status:078cf82
   OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.PRODUCTION_OP_SERVICE_ACCOUNT_TOKEN }}

--- a/env/production/kustomization.yaml
+++ b/env/production/kustomization.yaml
@@ -58,11 +58,11 @@ patches:
 
 images:
   - name: admin
-    newName: public.ecr.aws/cds-snc/notify-admin:c878f83
+    newName: public.ecr.aws/cds-snc/notify-admin:74bb5a6
   - name: api
-    newName: public.ecr.aws/cds-snc/notify-api:4ef95ad
+    newName: public.ecr.aws/cds-snc/notify-api:45442d0
   - name: document-download-api
-    newName: public.ecr.aws/cds-snc/notify-document-download-api:21a8aa8
+    newName: public.ecr.aws/cds-snc/notify-document-download-api:cdf8a3e
   - name: documentation
     newName: public.ecr.aws/cds-snc/notify-documentation:7bc5e5d
 configMapGenerator:

--- a/env/production/kustomization.yaml
+++ b/env/production/kustomization.yaml
@@ -60,7 +60,7 @@ images:
   - name: admin
     newName: public.ecr.aws/cds-snc/notify-admin:c878f83
   - name: api
-    newName: public.ecr.aws/cds-snc/notify-api:661caad
+    newName: public.ecr.aws/cds-snc/notify-api:4ef95ad
   - name: document-download-api
     newName: public.ecr.aws/cds-snc/notify-document-download-api:21a8aa8
   - name: documentation


### PR DESCRIPTION
## What happens when your PR merges?
Revert this morning's release

## What are you changing?
- [x] Releasing a new version of Notify
- [ ] Changing kubernetes configuration

## Provide some background on the changes
Incident actions 

## If you are releasing a new version of Notify, what components are you updating
- [x] API
- [x] Admin
- [ ] Documentation
- [x] Document download API

## Checklist if releasing new version:
- [ ] I made sure that the changes are as expected in [Notify staging](https://staging.notification.cdssandbox.xyz/)
- [ ] I have checked if the docker images I am referencing exist
    - [ ] [api lambda](https://ca-central-1.console.aws.amazon.com/ecr/repositories/private/296255494825/notify/api-lambda?region=ca-central-1) (requires Notification-Production / AdministratorAccess login)
    - [ ] [api k8s](https://gallery.ecr.aws/v6b8u5o6/notify-api)
    - [ ] [admin](https://gallery.ecr.aws/v6b8u5o6/notify-admin)
    - [ ] [documentation](https://gallery.ecr.aws/v6b8u5o6/notify-documentation)
    - [ ] [document download API](https://gallery.ecr.aws/v6b8u5o6/notify-document-download-api)

## Checklist if making changes to Kubernetes:
- [ ] I know how to get kubectl credentials in case it catches on fire

## After merging this PR
- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.