### PR TITLE
fix: use FF_TEMPLATE_CATEGORY in celery

### DIFF
--- a/base/notify-celery-email-send-primary/celery-email-send-deployment.yaml
+++ b/base/notify-celery-email-send-primary/celery-email-send-deployment.yaml
@@ -72,6 +72,8 @@ spec:
               value: '$(FF_SPIKE_SMS_DAILY_LIMIT)'
             - name: FF_SMS_PARTS_UI
               value: '$(FF_SMS_PARTS_UI)'
+            - name: FF_TEMPLATE_CATEGORY
+              value: '$(FF_TEMPLATE_CATEGORY)'
             - name: FIDO2_DOMAIN
               value: '$(FIDO2_DOMAIN)'
             - name: HC_EN_SERVICE_ID

--- a/base/notify-celery-email-send-scalable/celery-email-send-deployment.yaml
+++ b/base/notify-celery-email-send-scalable/celery-email-send-deployment.yaml
@@ -72,6 +72,8 @@ spec:
               value: '$(FF_SPIKE_SMS_DAILY_LIMIT)'
             - name: FF_SMS_PARTS_UI
               value: '$(FF_SMS_PARTS_UI)'
+            - name: FF_TEMPLATE_CATEGORY
+              value: '$(FF_TEMPLATE_CATEGORY)'              
             - name: FIDO2_DOMAIN
               value: '$(FIDO2_DOMAIN)'
             - name: HC_EN_SERVICE_ID

--- a/base/notify-celery-email-send/celery-email-send-deployment.yaml
+++ b/base/notify-celery-email-send/celery-email-send-deployment.yaml
@@ -72,6 +72,8 @@ spec:
               value: '$(FF_SPIKE_SMS_DAILY_LIMIT)'
             - name: FF_SMS_PARTS_UI
               value: '$(FF_SMS_PARTS_UI)'
+            - name: FF_TEMPLATE_CATEGORY
+              value: '$(FF_TEMPLATE_CATEGORY)'              
             - name: FIDO2_DOMAIN
               value: '$(FIDO2_DOMAIN)'
             - name: HC_EN_SERVICE_ID

--- a/base/notify-celery-sms-send-primary/celery-sms-send-deployment.yaml
+++ b/base/notify-celery-sms-send-primary/celery-sms-send-deployment.yaml
@@ -72,6 +72,8 @@ spec:
             value: '$(FF_SPIKE_SMS_DAILY_LIMIT)'
           - name: FF_SMS_PARTS_UI
             value: '$(FF_SMS_PARTS_UI)'
+          - name: FF_TEMPLATE_CATEGORY
+            value: '$(FF_TEMPLATE_CATEGORY)'
           - name: FIDO2_DOMAIN
             value: '$(FIDO2_DOMAIN)'
           - name: HC_EN_SERVICE_ID

--- a/base/notify-celery-sms-send-scalable/celery-sms-send-deployment.yaml
+++ b/base/notify-celery-sms-send-scalable/celery-sms-send-deployment.yaml
@@ -72,6 +72,8 @@ spec:
             value: '$(FF_SPIKE_SMS_DAILY_LIMIT)'
           - name: FF_SMS_PARTS_UI
             value: '$(FF_SMS_PARTS_UI)'
+          - name: FF_TEMPLATE_CATEGORY
+            value: '$(FF_TEMPLATE_CATEGORY)'            
           - name: FIDO2_DOMAIN
             value: '$(FIDO2_DOMAIN)'
           - name: HC_EN_SERVICE_ID

--- a/base/notify-celery-sms-send/celery-sms-send-deployment.yaml
+++ b/base/notify-celery-sms-send/celery-sms-send-deployment.yaml
@@ -72,6 +72,8 @@ spec:
             value: '$(FF_SPIKE_SMS_DAILY_LIMIT)'
           - name: FF_SMS_PARTS_UI
             value: '$(FF_SMS_PARTS_UI)'
+          - name: FF_TEMPLATE_CATEGORY
+            value: '$(FF_TEMPLATE_CATEGORY)'
           - name: FIDO2_DOMAIN
             value: '$(FIDO2_DOMAIN)'
           - name: HC_EN_SERVICE_ID


### PR DESCRIPTION
## What happens when your PR merges?
    - `fix:` - tag `main` as a new patch release

## What are you changing?
- [ ] Releasing a new version of Notify
- [x] Changing kubernetes configuration

## Provide some background on the changes
The new feature flag is [now used](https://github.com/cds-snc/notification-api/pull/2216) in code run by celery.



## Checklist if making changes to Kubernetes:
- [x] I know how to get kubectl credentials in case it catches on fire

## After merging this PR
- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.