### PR TITLE
fix: allow metrics for namespaces

### DIFF
--- a/helmfile/overrides/system/kube-state-metrics.yaml.gotmpl
+++ b/helmfile/overrides/system/kube-state-metrics.yaml.gotmpl
@@ -17,3 +17,4 @@ metricAllowlist:
   - pods=[*]
   - nodes=[*]
   - deployments=[*]
+  - namespaces=[*]


### PR DESCRIPTION
## What happens when your PR merges?
- Prefix the title of your PR:
    - `fix:` - tag `main` as a new patch release

## What are you changing?
- [ ] Releasing a new version of Notify
- [x] Changing kubernetes configuration

## Provide some background on the changes
https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/398

Hopefully this will allow the namespace metrics to be exposed.

## Checklist if making changes to Kubernetes:
- [ ] I know how to get kubectl credentials in case it catches on fire

## After merging this PR
- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.