### PR TITLE
Revert "fix: allow metrics for namespaces"

### DIFF
--- a/helmfile/overrides/system/kube-state-metrics.yaml.gotmpl
+++ b/helmfile/overrides/system/kube-state-metrics.yaml.gotmpl
@@ -17,4 +17,3 @@ metricAllowlist:
   - pods=[*]
   - nodes=[*]
   - deployments=[*]
-  - namespaces=[*]


### PR DESCRIPTION
Reverts cds-snc/notification-manifests#2824

> "Let's see if this does what we want!"

It did not. 😞 