### PR TITLE
Revert "Paring down kube state metrics"

### DIFF
--- a/helmfile/overrides/system/kube-state-metrics.yaml.gotmpl
+++ b/helmfile/overrides/system/kube-state-metrics.yaml.gotmpl
@@ -12,8 +12,3 @@ selfMonitor:
   # telemetryHost: 0.0.0.0
   # telemetryPort: 8081
   # telemetryNodePort: 0
-
-metricAllowlist:
-  - pods=[*]
-  - nodes=[*]
-  - deployments=[*]


### PR DESCRIPTION
Reverts cds-snc/notification-manifests#2791

Let's see how much of Ben's work we can revert before he comes back. And this one might even fix the missing data in our dashboards!