### PR TITLE
Fix/update staging smoketest cron

### DIFF
--- a/.github/workflows/smoke_test.yaml
+++ b/.github/workflows/smoke_test.yaml
@@ -5,7 +5,7 @@ on:
     branches:
       - "release-*"
   schedule:
-    - cron: "0 */3 * * *"
+    - cron: "0 0,3,6,9,12,15,18,21 * * *"
 defaults:
   run:
     shell: bash

--- a/.github/workflows/smoke_test.yaml
+++ b/.github/workflows/smoke_test.yaml
@@ -5,7 +5,7 @@ on:
     branches:
       - "release-*"
   schedule:
-    - cron: "0 0,3,6,9,12,15,18,21 * * *"
+    - cron: "0 0,3,6,9,12,15,18 * * *"
 defaults:
   run:
     shell: bash

--- a/.github/workflows/smoke_test.yaml
+++ b/.github/workflows/smoke_test.yaml
@@ -5,7 +5,7 @@ on:
     branches:
       - "release-*"
   schedule:
-    - cron: "0 0,3,6,9,12,15,18 * * *"
+    - cron: "0 3,6,9,12,15,18,21 * * *"
 defaults:
   run:
     shell: bash


### PR DESCRIPTION
## What happens when your PR merges?

This PR updates the staging smoke test workflow to not run during the performance tests (12AM UTC).

The cron has been updated from:
- `0 */3 * * *` (every 3 hours)
to:
- `0 3,6,9,12,15,18,21 * * *` (every 3 hours except for 00:00)


## Checklist if releasing new version:
- [ ] I made sure that the changes are as expected in [Notify staging](https://staging.notification.cdssandbox.xyz/)
- [ ] I have checked if the docker images I am referencing exist
    - [ ] [api lambda](https://ca-central-1.console.aws.amazon.com/ecr/repositories/private/296255494825/notify/api-lambda?region=ca-central-1) (requires Notification-Production / AdministratorAccess login)
    - [ ] [api k8s](https://gallery.ecr.aws/v6b8u5o6/notify-api)
    - [ ] [admin](https://gallery.ecr.aws/v6b8u5o6/notify-admin)
    - [ ] [documentation](https://gallery.ecr.aws/v6b8u5o6/notify-documentation)
    - [ ] [document download API](https://gallery.ecr.aws/v6b8u5o6/notify-document-download-api)

## Checklist if making changes to Kubernetes:
- [ ] I know how to get kubectl credentials in case it catches on fire

## After merging this PR
- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.