### PR TITLE
fix: fix production helm plan

### DIFF
--- a/.github/workflows/helmfile_production_plan.yaml
+++ b/.github/workflows/helmfile_production_plan.yaml
@@ -69,7 +69,7 @@ jobs:
         run: |
           pushd helmfile
           echo 'var<<EOF' >> $GITHUB_OUTPUT
-          helmfile --environment staging diff >> $GITHUB_OUTPUT
+          helmfile --environment production diff >> $GITHUB_OUTPUT
           echo 'EOF' >> $GITHUB_OUTPUT
           popd
       - name: Helmfile Diff Comment


### PR DESCRIPTION
## What happens when your PR merges?
- Prefix the title of your PR:
    - `fix:` - tag `main` as a new patch release

## What are you changing?
- [ ] Changing kubernetes configuration

## Provide some background on the changes

The production helm plan has always been broken but we don't usually trigger it (ie with a direct VERSION change) so we haven't noticed until now!

## Checklist if making changes to Kubernetes:
- [ ] I know how to get kubectl credentials in case it catches on fire
