### PR TITLE
sms send scalable 30 -> 40

### DIFF
--- a/env/staging/performance/celery-sms-send-scalable-hpa-patch.yaml
+++ b/env/staging/performance/celery-sms-send-scalable-hpa-patch.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: notification-canada-ca
 spec:
   minReplicas: 3
-  maxReplicas: 30
+  maxReplicas: 40
   metrics:
   - resource:
       name: cpu


### PR DESCRIPTION

## What are you changing?
- [ ] Releasing a new version of Notify
- [x] Changing kubernetes configuration

## Provide some background on the changes

Investigating scaling up our SMS sending: bump up the max celery sms-send-scalable pods from 30 to 40.

## Checklist if making changes to Kubernetes:
- [x] I know how to get kubectl credentials in case it catches on fire

## After merging this PR
- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.