### PR TITLE
Fixes for Dev

### DIFF
--- a/env/dev/admin-target-group.yaml
+++ b/env/dev/admin-target-group.yaml
@@ -8,3 +8,4 @@ spec:
     name: admin
     port: 6012
   targetGroupARN: arn:aws:elasticloadbalancing:ca-central-1:800095993820:targetgroup/notification-canada-ca-alb-admin/e2755abaad576738
+  targetType: instance

--- a/env/dev/api-target-group.yaml
+++ b/env/dev/api-target-group.yaml
@@ -8,3 +8,4 @@ spec:
     name: api
     port: 6011
   targetGroupARN: arn:aws:elasticloadbalancing:ca-central-1:800095993820:targetgroup/notification-canada-ca-alb-api/f846c4e2dabc1ec8
+  targetType: instance

--- a/env/dev/aws-auth-configmap.yaml
+++ b/env/dev/aws-auth-configmap.yaml
@@ -12,7 +12,7 @@ data:
       username: system:node:{{EC2PrivateDNSName}}
     - groups:
       - system:masters
-      rolearn: arn:aws:iam::800095993820:role/AWSReservedSSO_AWSAdministratorAccess_4085b2fdb6f29f43
+      rolearn: arn:aws:iam::800095993820:role/AWSReservedSSO_AWSAdministratorAccess_e6e62a284c3c35fc
       username: AWSAdministratorAccess:{{SessionName}}
     - rolearn: arn:aws:iam::800095993820:role/notification-admin-apply
       username: notification-admin-apply

--- a/env/dev/document-download-api-target-group.yaml
+++ b/env/dev/document-download-api-target-group.yaml
@@ -8,3 +8,4 @@ spec:
     name: document-download-api
     port: 7000
   targetGroupARN: arn:aws:elasticloadbalancing:ca-central-1:800095993820:targetgroup/notification-document-api/cf8b9d4db3bfe004
+  targetType: instance

--- a/env/dev/documentation-target-group.yaml
+++ b/env/dev/documentation-target-group.yaml
@@ -8,3 +8,4 @@ spec:
     name: documentation
     port: 80
   targetGroupARN: arn:aws:elasticloadbalancing:ca-central-1:800095993820:targetgroup/notification-documentation/51a7226882f5bc43
+  targetType: instance

--- a/env/dev/kustomization.yaml
+++ b/env/dev/kustomization.yaml
@@ -10,7 +10,6 @@ resources:
   - admin-target-group.yaml
   - document-download-api-target-group.yaml
   - documentation-target-group.yaml
-  - aws-auth-configmap.yaml
   - ../../base/prometheus-cloudwatch
   - ../../base/notify-admin
   - ../../base/notify-api


### PR DESCRIPTION
## What happens when your PR merges?
Dev only - I have hard-coded the target type in the target group bindings, and removed the aws-auth config map which is now managed by terraform for dev.

## What are you changing?
- [ ] Changing kubernetes configuration

## Provide some background on the changes
Dev was failing creation due to bad aws-auth configmap, and target group bindings being created too quickly.

## Checklist if making changes to Kubernetes:
- [x] I know how to get kubectl credentials in case it catches on fire

## After merging this PR
- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.