### PR TITLE
[MANIFEST] Added functionality to clear cache after prod deploy

### DIFF
--- a/.github/workflows/merge_to_main_production.yaml
+++ b/.github/workflows/merge_to_main_production.yaml
@@ -162,6 +162,8 @@ jobs:
   clear-cache:
     needs: kubectl-apply
     uses: ./.github/workflows/clear-notify-cache.yaml
+    with:
+      environment: production
     secrets:
       CACHE_CLEAR_USER_NAME: ${{ secrets.PRODUCTION_CACHE_CLEAR_USER_NAME }}
       CACHE_CLEAR_CLIENT_SECRET: ${{ secrets.PRODUCTION_CACHE_CLEAR_CLIENT_SECRET }}

--- a/.github/workflows/merge_to_main_production.yaml
+++ b/.github/workflows/merge_to_main_production.yaml
@@ -158,3 +158,11 @@ jobs:
         run: |
           json="{'text':'<!here> CI is failing in <https://github.com/cds-snc/notification-manifests/|notification-manifests> !'}"
           curl -X POST -H 'Content-type: application/json' --data "$json"  ${{ secrets.SLACK_WEBHOOK }}
+
+  clear-cache:
+    needs: kubectl-apply
+    uses: ./.github/workflows/clear-notify-cache.yaml
+    secrets:
+      CACHE_CLEAR_USER_NAME: ${{ secrets.PRODUCTION_CACHE_CLEAR_USER_NAME }}
+      CACHE_CLEAR_CLIENT_SECRET: ${{ secrets.PRODUCTION_CACHE_CLEAR_CLIENT_SECRET }}
+      API_URL: ${{ secrets.PRODUCTION_API_URL }}


### PR DESCRIPTION
Reverts cds-snc/notification-manifests#2923

Error was this:
```
[Invalid workflow file: .github/workflows/merge_to_main_production.yaml#L164](https://github.com/cds-snc/notification-manifests/actions/runs/10794088993/workflow)
The workflow is not valid. .github/workflows/merge_to_main_production.yaml (Line: 164, Col: 11): Input environment is required, but not provided while calling.
```

Fixed it by adding the environment to the job