### PR TITLE
Moving create vpn config to script

### DIFF
--- a/.github/workflows/helmfile_production_apply.yaml
+++ b/.github/workflows/helmfile_production_apply.yaml
@@ -58,19 +58,7 @@ jobs:
 
       - name: Retrieve VPN Config
         run: |
-          git clone https://github.com/cds-snc/notification-terraform.git /var/tmp/notification-terraform
-          cd /var/tmp/notification-terraform/env/production/eks
-          export INFRASTRUCTURE_VERSION=$(cat ../../../.github/workflows/infrastructure_version.txt)
-          ENDPOINT_ID=$(terragrunt output --raw gha_vpn_id)
-          CERT=$(terragrunt output --raw gha_vpn_certificate)
-          KEY=$(terragrunt output --raw gha_vpn_key)
-          aws ec2 export-client-vpn-client-configuration --client-vpn-endpoint-id $ENDPOINT_ID --output text > /var/tmp/production.ovpn
-          echo "<cert>
-          $CERT
-          </cert>" >> /var/tmp/production.ovpn
-          echo "<key>
-          $KEY
-          </key>" >> /var/tmp/production.ovpn        
+          scripts/createVPNConfig.sh production 2> /dev/null   
 
       - name: Connect to VPN
         uses: "kota65535/github-openvpn-connect-action@cd2ed8a90cc7b060dc4e001143e811b5f7ea0af5" # v3.1.0

--- a/.github/workflows/helmfile_production_plan.yaml
+++ b/.github/workflows/helmfile_production_plan.yaml
@@ -59,19 +59,7 @@ jobs:
 
       - name: Retrieve VPN Config
         run: |
-          git clone https://github.com/cds-snc/notification-terraform.git /var/tmp/notification-terraform
-          cd /var/tmp/notification-terraform/env/production/eks
-          export INFRASTRUCTURE_VERSION=$(cat ../../../.github/workflows/infrastructure_version.txt)
-          ENDPOINT_ID=$(terragrunt output --raw gha_vpn_id)
-          CERT=$(terragrunt output --raw gha_vpn_certificate)
-          KEY=$(terragrunt output --raw gha_vpn_key)
-          aws ec2 export-client-vpn-client-configuration --client-vpn-endpoint-id $ENDPOINT_ID --output text > /var/tmp/production.ovpn
-          echo "<cert>
-          $CERT
-          </cert>" >> /var/tmp/production.ovpn
-          echo "<key>
-          $KEY
-          </key>" >> /var/tmp/production.ovpn          
+          scripts/createVPNConfig.sh production 2> /dev/null            
 
       - name: Connect to VPN
         uses: "kota65535/github-openvpn-connect-action@cd2ed8a90cc7b060dc4e001143e811b5f7ea0af5" # v3.1.0

--- a/.github/workflows/helmfile_staging_apply.yaml
+++ b/.github/workflows/helmfile_staging_apply.yaml
@@ -56,18 +56,7 @@ jobs:
 
       - name: Retrieve VPN Config
         run: |
-          git clone https://github.com/cds-snc/notification-terraform.git /var/tmp/notification-terraform
-          cd /var/tmp/notification-terraform/env/staging/eks
-          ENDPOINT_ID=$(terragrunt output --raw gha_vpn_id)
-          CERT=$(terragrunt output --raw gha_vpn_certificate)
-          KEY=$(terragrunt output --raw gha_vpn_key)
-          aws ec2 export-client-vpn-client-configuration --client-vpn-endpoint-id $ENDPOINT_ID --output text > /var/tmp/staging.ovpn
-          echo "<cert>
-          $CERT
-          </cert>" >> /var/tmp/staging.ovpn
-          echo "<key>
-          $KEY
-          </key>" >> /var/tmp/staging.ovpn    
+          scripts/createVPNConfig.sh staging 2> /dev/null  
 
       - name: Connect to VPN
         uses: "kota65535/github-openvpn-connect-action@cd2ed8a90cc7b060dc4e001143e811b5f7ea0af5" # v3.1.0

--- a/.github/workflows/helmfile_staging_apply_specific_app.yaml
+++ b/.github/workflows/helmfile_staging_apply_specific_app.yaml
@@ -74,18 +74,7 @@ jobs:
 
       - name: Retrieve VPN Config
         run: |
-          git clone https://github.com/cds-snc/notification-terraform.git /var/tmp/notification-terraform
-          cd /var/tmp/notification-terraform/env/staging/eks
-          ENDPOINT_ID=$(terragrunt output --raw gha_vpn_id)
-          CERT=$(terragrunt output --raw gha_vpn_certificate)
-          KEY=$(terragrunt output --raw gha_vpn_key)
-          aws ec2 export-client-vpn-client-configuration --client-vpn-endpoint-id $ENDPOINT_ID --output text > /var/tmp/staging.ovpn
-          echo "<cert>
-          $CERT
-          </cert>" >> /var/tmp/staging.ovpn
-          echo "<key>
-          $KEY
-          </key>" >> /var/tmp/staging.ovpn          
+          scripts/createVPNConfig.sh staging 2> /dev/null     
 
       - name: Connect to VPN
         uses: "kota65535/github-openvpn-connect-action@cd2ed8a90cc7b060dc4e001143e811b5f7ea0af5" # v3.1.0

--- a/.github/workflows/helmfile_staging_plan.yaml
+++ b/.github/workflows/helmfile_staging_plan.yaml
@@ -48,18 +48,7 @@ jobs:
 
       - name: Retrieve VPN Config
         run: |
-          git clone https://github.com/cds-snc/notification-terraform.git /var/tmp/notification-terraform
-          cd /var/tmp/notification-terraform/env/staging/eks
-          ENDPOINT_ID=$(terragrunt output --raw gha_vpn_id)
-          CERT=$(terragrunt output --raw gha_vpn_certificate)
-          KEY=$(terragrunt output --raw gha_vpn_key)
-          aws ec2 export-client-vpn-client-configuration --client-vpn-endpoint-id $ENDPOINT_ID --output text > /var/tmp/staging.ovpn
-          echo "<cert>
-          $CERT
-          </cert>" >> /var/tmp/staging.ovpn
-          echo "<key>
-          $KEY
-          </key>" >> /var/tmp/staging.ovpn          
+          scripts/createVPNConfig.sh staging 2> /dev/null
 
       - name: Connect to VPN
         uses: "kota65535/github-openvpn-connect-action@cd2ed8a90cc7b060dc4e001143e811b5f7ea0af5" # v3.1.0

--- a/.github/workflows/merge_to_main_production.yaml
+++ b/.github/workflows/merge_to_main_production.yaml
@@ -63,19 +63,7 @@ jobs:
 
       - name: Retrieve VPN Config
         run: |
-          git clone https://github.com/cds-snc/notification-terraform.git /var/tmp/notification-terraform
-          cd /var/tmp/notification-terraform/env/production/eks
-          export INFRASTRUCTURE_VERSION=$(cat ../../../.github/workflows/infrastructure_version.txt)
-          ENDPOINT_ID=$(terragrunt output --raw gha_vpn_id)
-          CERT=$(terragrunt output --raw gha_vpn_certificate)
-          KEY=$(terragrunt output --raw gha_vpn_key)
-          aws ec2 export-client-vpn-client-configuration --client-vpn-endpoint-id $ENDPOINT_ID --output text > /var/tmp/production.ovpn
-          echo "<cert>
-          $CERT
-          </cert>" >> /var/tmp/production.ovpn
-          echo "<key>
-          $KEY
-          </key>" >> /var/tmp/production.ovpn        
+          scripts/createVPNConfig.sh production 2> /dev/null
 
       - name: Connect to VPN
         uses: "kota65535/github-openvpn-connect-action@cd2ed8a90cc7b060dc4e001143e811b5f7ea0af5" # v3.1.0

--- a/.github/workflows/merge_to_main_staging.yaml
+++ b/.github/workflows/merge_to_main_staging.yaml
@@ -56,19 +56,7 @@ jobs:
 
       - name: Retrieve VPN Config
         run: |
-          git clone https://github.com/cds-snc/notification-terraform.git /var/tmp/notification-terraform
-          cd /var/tmp/notification-terraform/env/staging/eks
-          ENDPOINT_ID=$(terragrunt output --raw gha_vpn_id)
-          CERT=$(terragrunt output --raw gha_vpn_certificate)
-          KEY=$(terragrunt output --raw gha_vpn_key)
-          aws ec2 export-client-vpn-client-configuration --client-vpn-endpoint-id $ENDPOINT_ID --output text > /var/tmp/staging.ovpn
-          echo "<cert>
-          $CERT
-          </cert>" >> /var/tmp/staging.ovpn
-          echo "<key>
-          $KEY
-          </key>" >> /var/tmp/staging.ovpn          
-
+          scripts/createVPNConfig.sh staging 2> /dev/null
       - name: Connect to VPN
         uses: "kota65535/github-openvpn-connect-action@cd2ed8a90cc7b060dc4e001143e811b5f7ea0af5" # v3.1.0
         with:

--- a/scripts/createVPNConfig.sh
+++ b/scripts/createVPNConfig.sh
@@ -5,6 +5,7 @@
 ENVIRONMENT=$1
 git clone https://github.com/cds-snc/notification-terraform.git /var/tmp/notification-terraform
 cd /var/tmp/notification-terraform/env/$ENVIRONMENT/eks
+export INFRASTRUCTURE_VERSION=$(cat ../../../.github/workflows/infrastructure_version.txt)
 ENDPOINT_ID=$(terragrunt output --raw gha_vpn_id)
 CERT=$(terragrunt output --raw gha_vpn_certificate)
 KEY=$(terragrunt output --raw gha_vpn_key)

--- a/scripts/createVPNConfig.sh
+++ b/scripts/createVPNConfig.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# This script will create a VPN configuration file for the specified environment
+# Usage: ./createVPNConfig.sh <environment>
+# Example: ./createVPNConfig.sh staging
+ENVIRONMENT=$1
+git clone https://github.com/cds-snc/notification-terraform.git /var/tmp/notification-terraform
+cd /var/tmp/notification-terraform/env/$ENVIRONMENT/eks
+ENDPOINT_ID=$(terragrunt output --raw gha_vpn_id)
+CERT=$(terragrunt output --raw gha_vpn_certificate)
+KEY=$(terragrunt output --raw gha_vpn_key)
+aws ec2 export-client-vpn-client-configuration --client-vpn-endpoint-id $ENDPOINT_ID --output text > /var/tmp/$ENVIRONMENT.ovpn
+echo "<cert>
+$CERT
+</cert>" >> /var/tmp/$ENVIRONMENT.ovpn
+echo "<key>
+$KEY
+</key>" >> /var/tmp/$ENVIRONMENT.ovpn


### PR DESCRIPTION
## What happens when your PR merges?
Moving the auto generation of vpn config to a script and suppressing error outputs to be safe.

## What are you changing?
- [ ] Releasing a new version of Notify
- [ ] Changing kubernetes configuration
- [x] Github Workflows

## Provide some background on the changes
Part of VPN reconfig

## Checklist if making changes to Kubernetes:
- [x] I know how to get kubectl credentials in case it catches on fire

## After merging this PR
- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.