### PR TITLE
set staging sms hpa to max 27

### DIFF
--- a/env/staging/performance/celery-sms-send-scalable-hpa-patch.yaml
+++ b/env/staging/performance/celery-sms-send-scalable-hpa-patch.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: notification-canada-ca
 spec:
   minReplicas: 3
-  maxReplicas: 15
+  maxReplicas: 27
   metrics:
   - resource:
       name: cpu


### PR DESCRIPTION
## What happens when your PR merges?

## What are you changing?

- [x] Changing kubernetes configuration

## Provide some background on the changes

Set the `celery-sms-send-scalable-hpa` max pods to 27. This will give us 30 sms sending pods in total, which should send at a rate of around 5000 notifications per minute (which would be 10000 fragments / minute for our average of 2 fragments / sms in production).

We'll use this to test (using internal test numbers) what happens to the system if we try to send at this rate! 📈 
