### PR TITLE
bootstrapping popeye-scanner action

### DIFF
--- a/.github/workflows/popeye-scanner.yaml
+++ b/.github/workflows/popeye-scanner.yaml
@@ -49,12 +49,7 @@ jobs:
         run: |
           aws eks update-kubeconfig --name notification-canada-ca-staging-eks-cluster   
           kubectl config rename-context arn:aws:eks:ca-central-1:$STAGING_AWS_ACCOUNT:cluster/notification-canada-ca-staging-eks-cluster staging
-      - name: Load EnvVars
+      - name: Popeye Report
         run: |
-            ./helmfile/getContext.sh -g
-      - name: Popeye Score
-        id: popeye-score
-        uses: kabute/popeye-github-actions@v9
-        env:
-          POPEYE_MIN_SCORE: 80
-          KUBECONFIG_DATA: ${{ secrets.STAGING_KUBECONFIG_SECRET }}
+          brew install derailed/popeye/popeye
+          popeye -n notification-canada-ca

--- a/.github/workflows/popeye-scanner.yaml
+++ b/.github/workflows/popeye-scanner.yaml
@@ -1,0 +1,57 @@
+name: Popeye Scanner
+
+on:
+  workflow_dispatch:
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  HELMFILE_FILE_PATH: ${{ github.workspace }}/helmfile
+  STAGING_AWS_ACCOUNT: ${{ secrets.STAGING_AWS_ACCOUNT }}
+  
+jobs:
+  Popeye-Scanner:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
+        id: awsconfig
+        with:
+          aws-access-key-id: ${{ secrets.STAGING_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.STAGING_AWS_SECRET_ACCESS_KEY }}
+          aws-region: ca-central-1
+      - name: Checkout
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+        with:
+          # Fetches entire history, so we can analyze commits since last tag
+          fetch-depth: 0    
+      - name: Install OpenVPN
+        run: |
+          sudo apt update
+          sudo apt install -y openvpn openvpn-systemd-resolved
+      - name: Setup Terraform tools
+        uses: cds-snc/terraform-tools-setup@v1
+        env: # In case you want to override default versions
+            CONFTEST_VERSION: 0.30.0 
+            TERRAFORM_VERSION: 1.6.2
+            TERRAGRUNT_VERSION: 0.44.4
+            TF_SUMMARIZE_VERSION: 0.2.3                    
+      - name: Retrieve VPN Config
+        run: |
+          scripts/createVPNConfig.sh staging 2> /dev/null
+      - name: Connect to VPN
+        uses: "kota65535/github-openvpn-connect-action@cd2ed8a90cc7b060dc4e001143e811b5f7ea0af5" # v3.1.0
+        with:
+          config_file: /var/tmp/staging.ovpn
+          echo_config: false                  
+      - name: Configure kubeconfig
+        run: |
+          aws eks update-kubeconfig --name notification-canada-ca-staging-eks-cluster   
+          kubectl config rename-context arn:aws:eks:ca-central-1:$STAGING_AWS_ACCOUNT:cluster/notification-canada-ca-staging-eks-cluster staging
+      - name: Load EnvVars
+        run: |
+            ./helmfile/getContext.sh -g
+      - name: Popeye Score
+        id: popeye-score
+        uses: actions/popeye-github-actions@v9
+        env:
+          POPEYE_MIN_SCORE: 80

--- a/.github/workflows/popeye-scanner.yaml
+++ b/.github/workflows/popeye-scanner.yaml
@@ -2,6 +2,8 @@ name: Popeye Scanner
 
 on:
   workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize, reopened]
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/popeye-scanner.yaml
+++ b/.github/workflows/popeye-scanner.yaml
@@ -54,6 +54,6 @@ jobs:
             ./helmfile/getContext.sh -g
       - name: Popeye Score
         id: popeye-score
-        uses: actions/popeye-github-actions@v9
+        uses: kabute/popeye-github-actions@v9
         env:
           POPEYE_MIN_SCORE: 80

--- a/.github/workflows/popeye-scanner.yaml
+++ b/.github/workflows/popeye-scanner.yaml
@@ -57,3 +57,4 @@ jobs:
         uses: kabute/popeye-github-actions@v9
         env:
           POPEYE_MIN_SCORE: 80
+          KUBECONFIG_DATA: ${{ secrets.STAGING_KUBECONFIG_SECRET }}


### PR DESCRIPTION
## What happens when your PR merges?

- Prefix the title of your PR:
  - `fix:` - tag `main` as a new patch release
  - `feat:` - tag `main` as a new minor release
  - `BREAKING CHANGE:` - tag `main` as a new major release
  - `[MANIFEST]` or `[AUTO-PR]` - tag `main` as a new patch release and deploy to production
  - `chore:` - use for changes to non-app code (ex: GitHub actions)
- Alternatively, change the [VERSION file](https://github.com/cds-snc/notification-manifests/blob/main/VERSION) - this will not create a new tag, but rather will release the tag in `VERSION` to production.

## What are you changing?

- [ ] Releasing a new version of Notify
- [ ] Changing kubernetes configuration

## Provide some background on the changes

> Give details ex. Security patching, content update, more API pods etc

## If you are releasing a new version of Notify, what components are you updating

- [ ] API
- [ ] Admin
- [ ] Documentation
- [ ] Document download API

## Checklist if releasing new version

- [ ] I made sure that the changes are as expected in [Notify staging](https://staging.notification.cdssandbox.xyz/)
- [ ] I have checked if the docker images I am referencing exist
  - [ ] [api lambda](https://ca-central-1.console.aws.amazon.com/ecr/repositories/private/296255494825/notify/api-lambda?region=ca-central-1) (requires Notification-Production / AdministratorAccess login)
  - [ ] [api k8s](https://gallery.ecr.aws/v6b8u5o6/notify-api)
  - [ ] [admin](https://gallery.ecr.aws/v6b8u5o6/notify-admin)
  - [ ] [documentation](https://gallery.ecr.aws/v6b8u5o6/notify-documentation)
  - [ ] [document download API](https://gallery.ecr.aws/v6b8u5o6/notify-document-download-api)

## Checklist if making changes to Kubernetes

- [ ] I know how to get kubectl credentials in case it catches on fire

## After merging this PR

- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.
