### PR TITLE
fix: VPN Config

### DIFF
--- a/.github/workflows/helmfile_production_apply.yaml
+++ b/.github/workflows/helmfile_production_apply.yaml
@@ -52,10 +52,10 @@ jobs:
       - name: Setup Terraform tools
         uses: cds-snc/terraform-tools-setup@v1
         env: # In case you want to override default versions
-            CONFTEST_VERSION: 0.30.0 
-            TERRAFORM_VERSION: 1.6.2
-            TERRAGRUNT_VERSION: 0.44.4
-            TF_SUMMARIZE_VERSION: 0.2.3            
+          CONFTEST_VERSION: 0.30.0 
+          TERRAFORM_VERSION: 1.9.5
+          TERRAGRUNT_VERSION: 0.66.9
+          TF_SUMMARIZE_VERSION: 0.2.3                           
 
       - name: Install 1Pass CLI
         run: |

--- a/.github/workflows/helmfile_production_apply.yaml
+++ b/.github/workflows/helmfile_production_apply.yaml
@@ -56,6 +56,11 @@ jobs:
             TERRAGRUNT_VERSION: 0.44.4
             TF_SUMMARIZE_VERSION: 0.2.3            
 
+      - name: Install 1Pass CLI
+        run: |
+          curl -o 1pass.deb https://downloads.1password.com/linux/debian/amd64/stable/1password-cli-amd64-latest.deb
+          sudo dpkg -i 1pass.deb 
+
       - name: Retrieve VPN Config
         run: |
           scripts/createVPNConfig.sh production 2> /dev/null   

--- a/.github/workflows/helmfile_production_apply.yaml
+++ b/.github/workflows/helmfile_production_apply.yaml
@@ -12,6 +12,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   HELMFILE_FILE_PATH: ${{ github.workspace }}/helmfile
   PRODUCTION_AWS_ACCOUNT: ${{ secrets.PRODUCTION_AWS_ACCOUNT }}
+  OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.PRODUCTION_OP_SERVICE_ACCOUNT_TOKEN }}
 
 jobs:
   helmfile-apply:

--- a/.github/workflows/helmfile_production_plan.yaml
+++ b/.github/workflows/helmfile_production_plan.yaml
@@ -57,10 +57,10 @@ jobs:
       - name: Setup Terraform tools
         uses: cds-snc/terraform-tools-setup@v1
         env: # In case you want to override default versions
-            CONFTEST_VERSION: 0.30.0 
-            TERRAFORM_VERSION: 1.6.2
-            TERRAGRUNT_VERSION: 0.44.4
-            TF_SUMMARIZE_VERSION: 0.2.3      
+          CONFTEST_VERSION: 0.30.0 
+          TERRAFORM_VERSION: 1.9.5
+          TERRAGRUNT_VERSION: 0.66.9
+          TF_SUMMARIZE_VERSION: 0.2.3                      
 
       - name: Retrieve VPN Config
         run: |

--- a/.github/workflows/helmfile_production_plan.yaml
+++ b/.github/workflows/helmfile_production_plan.yaml
@@ -44,6 +44,11 @@ jobs:
           install-helm: yes
           helmfile-version: "v0.151.0"
 
+      - name: Install 1Pass CLI
+        run: |
+          curl -o 1pass.deb https://downloads.1password.com/linux/debian/amd64/stable/1password-cli-amd64-latest.deb
+          sudo dpkg -i 1pass.deb 
+
       - name: Install OpenVPN
         run: |
           sudo apt update

--- a/.github/workflows/helmfile_staging_apply.yaml
+++ b/.github/workflows/helmfile_staging_apply.yaml
@@ -55,10 +55,10 @@ jobs:
       - name: Setup Terraform tools
         uses: cds-snc/terraform-tools-setup@v1
         env: # In case you want to override default versions
-            CONFTEST_VERSION: 0.30.0 
-            TERRAFORM_VERSION: 1.6.2
-            TERRAGRUNT_VERSION: 0.44.4
-            TF_SUMMARIZE_VERSION: 0.2.3    
+          CONFTEST_VERSION: 0.30.0 
+          TERRAFORM_VERSION: 1.9.5
+          TERRAGRUNT_VERSION: 0.66.9
+          TF_SUMMARIZE_VERSION: 0.2.3                    
 
       - name: Retrieve VPN Config
         run: |

--- a/.github/workflows/helmfile_staging_apply.yaml
+++ b/.github/workflows/helmfile_staging_apply.yaml
@@ -10,6 +10,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   HELMFILE_FILE_PATH: ${{ github.workspace }}/helmfile
   STAGING_AWS_ACCOUNT: ${{ secrets.STAGING_AWS_ACCOUNT }}
+  OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
 
 jobs:
   helmfile-apply:

--- a/.github/workflows/helmfile_staging_apply.yaml
+++ b/.github/workflows/helmfile_staging_apply.yaml
@@ -46,6 +46,11 @@ jobs:
           sudo apt update
           sudo apt install -y openvpn openvpn-systemd-resolved
 
+      - name: Install 1Pass CLI
+        run: |
+          curl -o 1pass.deb https://downloads.1password.com/linux/debian/amd64/stable/1password-cli-amd64-latest.deb
+          sudo dpkg -i 1pass.deb 
+
       - name: Setup Terraform tools
         uses: cds-snc/terraform-tools-setup@v1
         env: # In case you want to override default versions

--- a/.github/workflows/helmfile_staging_apply_specific_app.yaml
+++ b/.github/workflows/helmfile_staging_apply_specific_app.yaml
@@ -72,6 +72,11 @@ jobs:
             TERRAGRUNT_VERSION: 0.44.4
             TF_SUMMARIZE_VERSION: 0.2.3                    
 
+      - name: Install 1Pass CLI
+        run: |
+          curl -o 1pass.deb https://downloads.1password.com/linux/debian/amd64/stable/1password-cli-amd64-latest.deb
+          sudo dpkg -i 1pass.deb 
+
       - name: Retrieve VPN Config
         run: |
           scripts/createVPNConfig.sh staging 2> /dev/null     

--- a/.github/workflows/helmfile_staging_apply_specific_app.yaml
+++ b/.github/workflows/helmfile_staging_apply_specific_app.yaml
@@ -32,6 +32,7 @@ env:
   HELMFILE_FILE_PATH: ${{ github.workspace }}/helmfile
   STAGING_AWS_ACCOUNT: ${{ secrets.STAGING_AWS_ACCOUNT }}
   DOCKER_TAG: ${{ github.event.inputs.tag }}
+  OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
 
 jobs:
   rollout:

--- a/.github/workflows/helmfile_staging_apply_specific_app.yaml
+++ b/.github/workflows/helmfile_staging_apply_specific_app.yaml
@@ -68,10 +68,10 @@ jobs:
       - name: Setup Terraform tools
         uses: cds-snc/terraform-tools-setup@v1
         env: # In case you want to override default versions
-            CONFTEST_VERSION: 0.30.0 
-            TERRAFORM_VERSION: 1.6.2
-            TERRAGRUNT_VERSION: 0.44.4
-            TF_SUMMARIZE_VERSION: 0.2.3                    
+          CONFTEST_VERSION: 0.30.0 
+          TERRAFORM_VERSION: 1.9.5
+          TERRAGRUNT_VERSION: 0.66.9
+          TF_SUMMARIZE_VERSION: 0.2.3                                  
 
       - name: Install 1Pass CLI
         run: |

--- a/.github/workflows/helmfile_staging_plan.yaml
+++ b/.github/workflows/helmfile_staging_plan.yaml
@@ -38,6 +38,11 @@ jobs:
           sudo apt update
           sudo apt install -y openvpn openvpn-systemd-resolved
 
+      - name: Install 1Pass CLI
+        run: |
+          curl -o 1pass.deb https://downloads.1password.com/linux/debian/amd64/stable/1password-cli-amd64-latest.deb
+          sudo dpkg -i 1pass.deb 
+
       - name: Setup Terraform tools
         uses: cds-snc/terraform-tools-setup@v1
         env: # In case you want to override default versions

--- a/.github/workflows/helmfile_staging_plan.yaml
+++ b/.github/workflows/helmfile_staging_plan.yaml
@@ -47,11 +47,11 @@ jobs:
       - name: Setup Terraform tools
         uses: cds-snc/terraform-tools-setup@v1
         env: # In case you want to override default versions
-            CONFTEST_VERSION: 0.30.0 
-            TERRAFORM_VERSION: 1.6.2
-            TERRAGRUNT_VERSION: 0.44.4
-            TF_SUMMARIZE_VERSION: 0.2.3                    
-
+          CONFTEST_VERSION: 0.30.0 
+          TERRAFORM_VERSION: 1.9.5
+          TERRAGRUNT_VERSION: 0.66.9
+          TF_SUMMARIZE_VERSION: 0.2.3                    
+       
       - name: Retrieve VPN Config
         run: |
           scripts/createVPNConfig.sh staging

--- a/.github/workflows/helmfile_staging_plan.yaml
+++ b/.github/workflows/helmfile_staging_plan.yaml
@@ -8,7 +8,8 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   HELMFILE_FILE_PATH: ${{ github.workspace }}/helmfile
   STAGING_AWS_ACCOUNT: ${{ secrets.STAGING_AWS_ACCOUNT }}
-  
+  OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+
 
 jobs:
   helmfile-diff:

--- a/.github/workflows/helmfile_staging_plan.yaml
+++ b/.github/workflows/helmfile_staging_plan.yaml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Retrieve VPN Config
         run: |
-          scripts/createVPNConfig.sh staging 2> /dev/null
+          scripts/createVPNConfig.sh staging
 
       - name: Connect to VPN
         uses: "kota65535/github-openvpn-connect-action@cd2ed8a90cc7b060dc4e001143e811b5f7ea0af5" # v3.1.0

--- a/.github/workflows/helmfile_staging_plan.yaml
+++ b/.github/workflows/helmfile_staging_plan.yaml
@@ -51,10 +51,10 @@ jobs:
           TERRAFORM_VERSION: 1.9.5
           TERRAGRUNT_VERSION: 0.66.9
           TF_SUMMARIZE_VERSION: 0.2.3                    
-       
+          
       - name: Retrieve VPN Config
         run: |
-          scripts/createVPNConfig.sh staging
+          scripts/createVPNConfig.sh staging 2> /dev/null
 
       - name: Connect to VPN
         uses: "kota65535/github-openvpn-connect-action@cd2ed8a90cc7b060dc4e001143e811b5f7ea0af5" # v3.1.0

--- a/.github/workflows/merge_to_main_production.yaml
+++ b/.github/workflows/merge_to_main_production.yaml
@@ -56,10 +56,10 @@ jobs:
       - name: Setup Terraform tools
         uses: cds-snc/terraform-tools-setup@v1
         env: # In case you want to override default versions
-            CONFTEST_VERSION: 0.30.0 
-            TERRAFORM_VERSION: 1.6.2
-            TERRAGRUNT_VERSION: 0.44.4
-            TF_SUMMARIZE_VERSION: 0.2.3            
+          CONFTEST_VERSION: 0.30.0 
+          TERRAFORM_VERSION: 1.9.5
+          TERRAGRUNT_VERSION: 0.66.9
+          TF_SUMMARIZE_VERSION: 0.2.3                    
 
       - name: Install 1Pass CLI
         run: |

--- a/.github/workflows/merge_to_main_production.yaml
+++ b/.github/workflows/merge_to_main_production.yaml
@@ -61,6 +61,11 @@ jobs:
             TERRAGRUNT_VERSION: 0.44.4
             TF_SUMMARIZE_VERSION: 0.2.3            
 
+      - name: Install 1Pass CLI
+        run: |
+          curl -o 1pass.deb https://downloads.1password.com/linux/debian/amd64/stable/1password-cli-amd64-latest.deb
+          sudo dpkg -i 1pass.deb 
+
       - name: Retrieve VPN Config
         run: |
           scripts/createVPNConfig.sh production 2> /dev/null

--- a/.github/workflows/merge_to_main_staging.yaml
+++ b/.github/workflows/merge_to_main_staging.yaml
@@ -49,10 +49,10 @@ jobs:
       - name: Setup Terraform tools
         uses: cds-snc/terraform-tools-setup@v1
         env: # In case you want to override default versions
-            CONFTEST_VERSION: 0.30.0 
-            TERRAFORM_VERSION: 1.6.2
-            TERRAGRUNT_VERSION: 0.44.4
-            TF_SUMMARIZE_VERSION: 0.2.3                    
+          CONFTEST_VERSION: 0.30.0 
+          TERRAFORM_VERSION: 1.9.5
+          TERRAGRUNT_VERSION: 0.66.9
+          TF_SUMMARIZE_VERSION: 0.2.3                                  
 
       - name: Install 1Pass CLI
         run: |

--- a/.github/workflows/merge_to_main_staging.yaml
+++ b/.github/workflows/merge_to_main_staging.yaml
@@ -54,6 +54,11 @@ jobs:
             TERRAGRUNT_VERSION: 0.44.4
             TF_SUMMARIZE_VERSION: 0.2.3                    
 
+      - name: Install 1Pass CLI
+        run: |
+          curl -o 1pass.deb https://downloads.1password.com/linux/debian/amd64/stable/1password-cli-amd64-latest.deb
+          sudo dpkg -i 1pass.deb 
+
       - name: Retrieve VPN Config
         run: |
           scripts/createVPNConfig.sh staging 2> /dev/null

--- a/scripts/createVPNConfig.sh
+++ b/scripts/createVPNConfig.sh
@@ -4,6 +4,7 @@
 # Example: ./createVPNConfig.sh staging
 ENVIRONMENT=$1
 git clone https://github.com/cds-snc/notification-terraform.git /var/tmp/notification-terraform
+op read op://4eyyuwddp6w4vxlabrr2i2duxm/"TFVars - $ENVIRONMENT"/notesPlain > /var/tmp/notification-terraform/aws/$ENVIRONMENT.tfvars   
 cd /var/tmp/notification-terraform/env/$ENVIRONMENT/eks
 export INFRASTRUCTURE_VERSION=$(cat ../../../.github/workflows/infrastructure_version.txt)
 ENDPOINT_ID=$(terragrunt output --raw gha_vpn_id)

--- a/scripts/createVPNConfig.sh
+++ b/scripts/createVPNConfig.sh
@@ -3,6 +3,12 @@
 # Usage: ./createVPNConfig.sh <environment>
 # Example: ./createVPNConfig.sh staging
 ENVIRONMENT=$1
+if [ "$ENVIRONMENT" == "production" ]; then
+  VAULT=ppnxsriom3alsxj4ogikyjxlzi
+else
+  VAULT=4eyyuwddp6w4vxlabrr2i2duxm
+fi
+echo $VAULT
 git clone https://github.com/cds-snc/notification-terraform.git /var/tmp/notification-terraform
 op read op://4eyyuwddp6w4vxlabrr2i2duxm/"TFVars - $ENVIRONMENT"/notesPlain > /var/tmp/notification-terraform/aws/$ENVIRONMENT.tfvars   
 cd /var/tmp/notification-terraform/env/$ENVIRONMENT/eks

--- a/scripts/createVPNConfig.sh
+++ b/scripts/createVPNConfig.sh
@@ -10,7 +10,7 @@ else
 fi
 echo $VAULT
 git clone https://github.com/cds-snc/notification-terraform.git /var/tmp/notification-terraform
-op read op://4eyyuwddp6w4vxlabrr2i2duxm/"TFVars - $ENVIRONMENT"/notesPlain > /var/tmp/notification-terraform/aws/$ENVIRONMENT.tfvars   
+op read op://$VAULT/"TFVars - $ENVIRONMENT"/notesPlain > /var/tmp/notification-terraform/aws/$ENVIRONMENT.tfvars   
 cd /var/tmp/notification-terraform/env/$ENVIRONMENT/eks
 export INFRASTRUCTURE_VERSION=$(cat ../../../.github/workflows/infrastructure_version.txt)
 ENDPOINT_ID=$(terragrunt output --raw gha_vpn_id)

--- a/scripts/createVPNConfig.sh
+++ b/scripts/createVPNConfig.sh
@@ -8,7 +8,6 @@ if [ "$ENVIRONMENT" == "production" ]; then
 else
   VAULT=4eyyuwddp6w4vxlabrr2i2duxm
 fi
-echo $VAULT
 git clone https://github.com/cds-snc/notification-terraform.git /var/tmp/notification-terraform
 op read op://$VAULT/"TFVars - $ENVIRONMENT"/notesPlain > /var/tmp/notification-terraform/aws/$ENVIRONMENT.tfvars   
 cd /var/tmp/notification-terraform/env/$ENVIRONMENT/eks

--- a/scripts/createVPNConfig.sh
+++ b/scripts/createVPNConfig.sh
@@ -2,7 +2,7 @@
 # This script will create a VPN configuration file for the specified environment
 # Usage: ./createVPNConfig.sh <environment>
 # Example: ./createVPNConfig.sh staging
-ENVIRONMENT=$1
+export ENVIRONMENT=$1
 if [ "$ENVIRONMENT" == "production" ]; then
   VAULT=ppnxsriom3alsxj4ogikyjxlzi
 else


### PR DESCRIPTION
## What happens when your PR merges?

The "old" way of deploying our Terraform code did not require the TFVars file when fetching outputs, but the new way does. This PR install 1Pass CLI on workflow runs and fetches the TFVars file.

## What are you changing?

- [ ] Releasing a new version of Notify
- [ ] Changing kubernetes configuration
- [x] Github Workflows


## Provide some background on the changes

Re: TF Environment variable consolidation

## Checklist if making changes to Kubernetes

- [x] I know how to get kubectl credentials in case it catches on fire

## After merging this PR

- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.
