### PR TITLE
Updating Reference to 1password variable note

### DIFF
--- a/scripts/createVPNConfig.sh
+++ b/scripts/createVPNConfig.sh
@@ -9,7 +9,7 @@ else
   VAULT=4eyyuwddp6w4vxlabrr2i2duxm
 fi
 git clone https://github.com/cds-snc/notification-terraform.git /var/tmp/notification-terraform
-op read op://$VAULT/"TFVars - $ENVIRONMENT"/notesPlain > /var/tmp/notification-terraform/aws/$ENVIRONMENT.tfvars   
+op read op://$VAULT/"TERRAFORM_SECRETS_$ENVIRONMENT"/notesPlain > /var/tmp/notification-terraform/aws/$ENVIRONMENT.tfvars   
 cd /var/tmp/notification-terraform/env/$ENVIRONMENT/eks
 export INFRASTRUCTURE_VERSION=$(cat ../../../.github/workflows/infrastructure_version.txt)
 ENDPOINT_ID=$(terragrunt output --raw gha_vpn_id)


### PR DESCRIPTION
## What happens when your PR merges?

a script will reference the proper variable file in 1pass (fixing an error where it was referencing an old archived note)

## What are you changing?

just changing the name of a file reference

## Provide some background on the changes

This was breaking the CI for manifests because it was still trying to pull variables from an old archived 1pass note
## After merging this PR

- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.
