### PR TITLE
Pass FF_ANNUAL_LIMIT to celery

### DIFF
--- a/base/notify-celery-email-send-primary/celery-email-send-deployment.yaml
+++ b/base/notify-celery-email-send-primary/celery-email-send-deployment.yaml
@@ -118,6 +118,8 @@ spec:
               value: '$(NEW_RELIC_MONITOR_MODE)'
             - name: FF_CLOUDWATCH_METRICS_ENABLED
               value: 'True'
+            - name: FF_ANNUAL_LIMIT
+              value: '$(FF_ANNUAL_LIMIT)'
           lifecycle:
             preStop:
               exec:

--- a/base/notify-celery-email-send-scalable/celery-email-send-deployment.yaml
+++ b/base/notify-celery-email-send-scalable/celery-email-send-deployment.yaml
@@ -118,6 +118,8 @@ spec:
               value: '$(NEW_RELIC_MONITOR_MODE)'
             - name: FF_CLOUDWATCH_METRICS_ENABLED
               value: 'True'
+            - name: FF_ANNUAL_LIMIT
+              value: '$(FF_ANNUAL_LIMIT)'
           lifecycle:
             preStop:
               exec:

--- a/base/notify-celery-email-send/celery-email-send-deployment.yaml
+++ b/base/notify-celery-email-send/celery-email-send-deployment.yaml
@@ -118,6 +118,8 @@ spec:
               value: '$(NEW_RELIC_MONITOR_MODE)'
             - name: FF_CLOUDWATCH_METRICS_ENABLED
               value: 'True'
+            - name: FF_ANNUAL_LIMIT
+              value: '$(FF_ANNUAL_LIMIT)'
           lifecycle:
             preStop:
               exec:

--- a/base/notify-celery-main-primary/celery-deployment.yaml
+++ b/base/notify-celery-main-primary/celery-deployment.yaml
@@ -118,6 +118,8 @@ spec:
               value: '$(NEW_RELIC_MONITOR_MODE)'
             - name: FF_CLOUDWATCH_METRICS_ENABLED
               value: 'True'
+            - name: FF_ANNUAL_LIMIT
+              value: '$(FF_ANNUAL_LIMIT)'
           lifecycle:
             preStop:
               exec:

--- a/base/notify-celery-main-scalable/celery-deployment.yaml
+++ b/base/notify-celery-main-scalable/celery-deployment.yaml
@@ -118,6 +118,8 @@ spec:
               value: '$(NEW_RELIC_MONITOR_MODE)'
             - name: FF_CLOUDWATCH_METRICS_ENABLED
               value: 'True'
+            - name: FF_ANNUAL_LIMIT
+              value: '$(FF_ANNUAL_LIMIT)'
           lifecycle:
             preStop:
               exec:

--- a/base/notify-celery-main/celery-deployment.yaml
+++ b/base/notify-celery-main/celery-deployment.yaml
@@ -118,6 +118,8 @@ spec:
               value: '$(NEW_RELIC_MONITOR_MODE)'
             - name: FF_CLOUDWATCH_METRICS_ENABLED
               value: 'True'
+            - name: FF_ANNUAL_LIMIT
+              value: '$(FF_ANNUAL_LIMIT)'
           lifecycle:
             preStop:
               exec:

--- a/base/notify-celery-other/celery-beat-deployment.yaml
+++ b/base/notify-celery-other/celery-beat-deployment.yaml
@@ -90,6 +90,8 @@ spec:
               value: '$(NEW_RELIC_LICENSE_KEY)'
             - name: NEW_RELIC_MONITOR_MODE
               value: '$(NEW_RELIC_MONITOR_MODE)'
+            - name: FF_ANNUAL_LIMIT
+              value: '$(FF_ANNUAL_LIMIT)'
           command: ["/bin/sh"]
           args: ["-c", "sh /app/scripts/run_celery_beat.sh"]
           resources: {}

--- a/base/notify-celery-other/celery-sms-deployment.yaml
+++ b/base/notify-celery-other/celery-sms-deployment.yaml
@@ -107,6 +107,8 @@ spec:
               value: '$(NEW_RELIC_LICENSE_KEY)'
             - name: NEW_RELIC_MONITOR_MODE
               value: '$(NEW_RELIC_MONITOR_MODE)'
+            - name: FF_ANNUAL_LIMIT
+              value: '$(FF_ANNUAL_LIMIT)'
           command: ["/bin/sh"]
           args: ["-c", "sh /app/scripts/run_celery_sms.sh"]
       dnsPolicy: ClusterFirst

--- a/base/notify-celery-sms-send-primary/celery-sms-send-deployment.yaml
+++ b/base/notify-celery-sms-send-primary/celery-sms-send-deployment.yaml
@@ -124,6 +124,8 @@ spec:
             value: '$(AWS_PINPOINT_SC_TEMPLATE_IDS)'
           - name: AWS_PINPOINT_DEFAULT_POOL_ID
             value: '$(AWS_PINPOINT_DEFAULT_POOL_ID)'
+          - name: FF_ANNUAL_LIMIT
+            value: '$(FF_ANNUAL_LIMIT)'
         lifecycle:
           preStop:
             exec:

--- a/base/notify-celery-sms-send-scalable/celery-sms-send-deployment.yaml
+++ b/base/notify-celery-sms-send-scalable/celery-sms-send-deployment.yaml
@@ -124,6 +124,8 @@ spec:
             value: '$(AWS_PINPOINT_SC_TEMPLATE_IDS)'
           - name: AWS_PINPOINT_DEFAULT_POOL_ID
             value: '$(AWS_PINPOINT_DEFAULT_POOL_ID)'
+          - name: FF_ANNUAL_LIMIT
+            value: '$(FF_ANNUAL_LIMIT)'
         lifecycle:
           preStop:
             exec:

--- a/base/notify-celery-sms-send/celery-sms-send-deployment.yaml
+++ b/base/notify-celery-sms-send/celery-sms-send-deployment.yaml
@@ -124,6 +124,8 @@ spec:
             value: '$(AWS_PINPOINT_SC_TEMPLATE_IDS)'
           - name: AWS_PINPOINT_DEFAULT_POOL_ID
             value: '$(AWS_PINPOINT_DEFAULT_POOL_ID)'
+          - name: FF_ANNUAL_LIMIT
+            value: '$(FF_ANNUAL_LIMIT)'
         lifecycle:
           preStop:
             exec:


### PR DESCRIPTION
## What happens when your PR merges?

`FF_ANNUAL_LIMIT` is exposed in celery.

- Prefix the title of your PR:
  - `fix:` - tag `main` as a new patch release
  - `feat:` - tag `main` as a new minor release
  - `BREAKING CHANGE:` - tag `main` as a new major release
  - `[MANIFEST]` or `[AUTO-PR]` - tag `main` as a new patch release and deploy to production
  - `chore:` - use for changes to non-app code (ex: GitHub actions)
- Alternatively, change the [VERSION file](https://github.com/cds-snc/notification-manifests/blob/main/VERSION) - this will not create a new tag, but rather will release the tag in `VERSION` to production.

## What are you changing?

- [ ] Releasing a new version of Notify
- [x] Changing kubernetes configuration

## Provide some background on the changes

> Give details ex. Security patching, content update, more API pods etc

## If you are releasing a new version of Notify, what components are you updating

- [ ] API
- [ ] Admin
- [ ] Documentation
- [ ] Document download API

## Checklist if releasing new version

- [ ] I made sure that the changes are as expected in [Notify staging](https://staging.notification.cdssandbox.xyz/)
- [ ] I have checked if the docker images I am referencing exist
  - [ ] [api lambda](https://ca-central-1.console.aws.amazon.com/ecr/repositories/private/296255494825/notify/api-lambda?region=ca-central-1) (requires Notification-Production / AdministratorAccess login)
  - [ ] [api k8s](https://gallery.ecr.aws/v6b8u5o6/notify-api)
  - [ ] [admin](https://gallery.ecr.aws/v6b8u5o6/notify-admin)
  - [ ] [documentation](https://gallery.ecr.aws/v6b8u5o6/notify-documentation)
  - [ ] [document download API](https://gallery.ecr.aws/v6b8u5o6/notify-document-download-api)

## Checklist if making changes to Kubernetes

- [x] I know how to get kubectl credentials in case it catches on fire

## After merging this PR

- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.
