### PR TITLE
Adding cypress secrets on migrate-db init container

### DIFF
--- a/base/notify-api/api-deployment.yaml
+++ b/base/notify-api/api-deployment.yaml
@@ -63,6 +63,10 @@ spec:
               value: '$(CRM_ORG_LIST_URL)'
             - name: CSV_UPLOAD_BUCKET_NAME
               value: '$(CSV_UPLOAD_BUCKET_NAME)'
+            - name: CYPRESS_USER_PW_SECRET
+              value: '$(CYPRESS_USER_PW_SECRET)'
+            - name: CYPRESS_AUTH_CLIENT_SECRET
+              value: '$(CYPRESS_AUTH_CLIENT_SECRET)'              
             - name: DEBUG_KEY
               value: '$(DEBUG_KEY)'
             - name: DANGEROUS_SALT


### PR DESCRIPTION
## What happens when your PR merges?

The newly added cypress secrets needed to also be added to the migrate-db init container. 

## What are you changing?

- [ ] Releasing a new version of Notify
- [x] Changing kubernetes configuration

## Provide some background on the changes

https://gcdigital.slack.com/archives/CV38DBNVA/p1731431934125009

## If you are releasing a new version of Notify, what components are you updating

- [ ] API
- [ ] Admin
- [ ] Documentation
- [ ] Document download API

## Checklist if making changes to Kubernetes

- [x] I know how to get kubectl credentials in case it catches on fire

## After merging this PR

- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.
