### PR TITLE
smoke test secrets removed

### DIFF
--- a/.github/workflows/clear-notify-cache.yaml
+++ b/.github/workflows/clear-notify-cache.yaml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Call API to clear cache
         env:
-          CACHE_CLEAR_USER_NAME: ${{ secrets.CACHE_CLEAR_USER_NAME }}
+          CACHE_CLEAR_USER_NAME: CACHE_CLEAR_USER
           CACHE_CLEAR_CLIENT_SECRET: ${{ secrets.CACHE_CLEAR_CLIENT_SECRET }}
-          API_URL: ${{ secrets.API_URL }}
+          API_URL: https://api.notification.canada.ca
         run: node scripts/clear-cache.js

--- a/.github/workflows/merge_to_main_production.yaml
+++ b/.github/workflows/merge_to_main_production.yaml
@@ -172,6 +172,6 @@ jobs:
     with:
       environment: production
     secrets:
-      CACHE_CLEAR_USER_NAME: ${{ secrets.PRODUCTION_CACHE_CLEAR_USER_NAME }}
+      CACHE_CLEAR_USER_NAME: CACHE_CLEAR_USER
       CACHE_CLEAR_CLIENT_SECRET: ${{ secrets.PRODUCTION_CACHE_CLEAR_CLIENT_SECRET }}
-      API_URL: ${{ secrets.PRODUCTION_API_URL }}
+      API_URL: https://api.notification.canada.ca

--- a/.github/workflows/merge_to_main_staging.yaml
+++ b/.github/workflows/merge_to_main_staging.yaml
@@ -144,4 +144,4 @@ jobs:
     secrets:
       CACHE_CLEAR_USER_NAME: ${{ secrets.STAGING_CACHE_CLEAR_USER_NAME }}
       CACHE_CLEAR_CLIENT_SECRET: ${{ secrets.STAGING_CACHE_CLEAR_CLIENT_SECRET }}
-      API_URL: ${{ secrets.STAGING_API_URL }}
+      API_URL: https://api.staging.notification.cdssandbox.xyz

--- a/.github/workflows/merge_to_main_staging.yaml
+++ b/.github/workflows/merge_to_main_staging.yaml
@@ -142,6 +142,6 @@ jobs:
     with:
       environment: staging
     secrets:
-      CACHE_CLEAR_USER_NAME: ${{ secrets.STAGING_CACHE_CLEAR_USER_NAME }}
+      CACHE_CLEAR_USER_NAME: CACHE_CLEAR_USER
       CACHE_CLEAR_CLIENT_SECRET: ${{ secrets.STAGING_CACHE_CLEAR_CLIENT_SECRET }}
       API_URL: https://api.staging.notification.cdssandbox.xyz

--- a/.github/workflows/smoke_test.yaml
+++ b/.github/workflows/smoke_test.yaml
@@ -49,18 +49,18 @@ jobs:
       - name: Run smoke tests on staging
         env:
           SMOKE_ADMIN_CLIENT_SECRET: ${{ secrets.SMOKE_ADMIN_CLIENT_SECRET}}
-          SMOKE_API_HOST_NAME: ${{ secrets.SMOKE_API_HOST_NAME}}
           SMOKE_API_KEY: ${{ secrets.SMOKE_API_KEY}}
-          SMOKE_AWS_ACCESS_KEY_ID: ${{ secrets.SMOKE_AWS_ACCESS_KEY_ID}}
-          SMOKE_AWS_SECRET_ACCESS_KEY: ${{ secrets.SMOKE_AWS_SECRET_ACCESS_KEY}}
-          SMOKE_CSV_UPLOAD_BUCKET_NAME: ${{ secrets.SMOKE_CSV_UPLOAD_BUCKET_NAME}}
-          SMOKE_EMAIL_TEMPLATE_ID: ${{ secrets.SMOKE_EMAIL_TEMPLATE_ID}}
-          SMOKE_EMAIL_TO: ${{ secrets.SMOKE_EMAIL_TO}}
-          SMOKE_SMS_TO: ${{ secrets.SMOKE_SMS_TO}}
-          SMOKE_SERVICE_ID: ${{ secrets.SMOKE_SERVICE_ID}}
-          SMOKE_SMS_TEMPLATE_ID: ${{ secrets.SMOKE_SMS_TEMPLATE_ID}}
-          SMOKE_USER_ID: ${{ secrets.SMOKE_USER_ID}}
-          SMOKE_POLL_TIMEOUT: ${{ secrets.SMOKE_POLL_TIMEOUT}}
+          SMOKE_AWS_ACCESS_KEY_ID: ${{ secrets.STAGING_AWS_ACCESS_KEY_ID}}
+          SMOKE_AWS_SECRET_ACCESS_KEY: ${{ secrets.STAGING_AWS_SECRET_ACCESS_KEY}}
+          SMOKE_API_HOST_NAME: https://api.staging.notification.cdssandbox.xyz
+          SMOKE_CSV_UPLOAD_BUCKET_NAME: notification-canada-ca-staging-csv-upload
+          SMOKE_EMAIL_TEMPLATE_ID: 9544dc32-9d23-4bdd-a8d8-81b4ec9e0485
+          SMOKE_EMAIL_TO: success@simulator.amazonses.com
+          SMOKE_SMS_TO: 16135550123
+          SMOKE_SERVICE_ID: f316aa6b-38dd-4d9e-83f8-b6ee3e1d428f
+          SMOKE_SMS_TEMPLATE_ID: d8234b4d-4def-4ad6-aafe-526a24ee5f19
+          SMOKE_USER_ID: f8763157-9c67-44f1-aaec-5d2564b41c8e
+          SMOKE_POLL_TIMEOUT: 120
         run: poetry run make smoke-test
       - name: Notify Slack channel if this job failed
         if: ${{ failure() }}


### PR DESCRIPTION
## What happens when your PR merges?

Removing the smoke test secrets since they aren't secret. Also switching the smoke access key and access key secret to be the normal ones for staging. They would have been this anyway since there is only one access key/secret in staging AWS.

## What are you changing?

- [ ] Releasing a new version of Notify
- [ ] Changing kubernetes configuration
- [x] Github Config

## Provide some background on the changes

In preparation for cleaning up github secrets.

## After merging this PR

- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.
