### PR TITLE
Removing non specific OP SA Token

### DIFF
--- a/.github/workflows/helmfile_production_apply.yaml
+++ b/.github/workflows/helmfile_production_apply.yaml
@@ -74,8 +74,7 @@ jobs:
 
       - name: Configure kubeconfig
         run: |
-          aws eks update-kubeconfig --name notification-canada-ca-production-eks-cluster   
-          kubectl config rename-context arn:aws:eks:ca-central-1:$PRODUCTION_AWS_ACCOUNT:cluster/notification-canada-ca-production-eks-cluster production
+          aws eks update-kubeconfig --name notification-canada-ca-production-eks-cluster --alias production
 
       - name: Load EnvVars
         run: |

--- a/.github/workflows/helmfile_production_plan.yaml
+++ b/.github/workflows/helmfile_production_plan.yaml
@@ -74,8 +74,7 @@ jobs:
 
       - name: Configure kubeconfig
         run: |
-          aws eks update-kubeconfig --name notification-canada-ca-production-eks-cluster   
-          kubectl config rename-context arn:aws:eks:ca-central-1:$PRODUCTION_AWS_ACCOUNT:cluster/notification-canada-ca-production-eks-cluster production
+          aws eks update-kubeconfig --name notification-canada-ca-production-eks-cluster --alias production  
 
       - name: Load EnvVars
         run: |

--- a/.github/workflows/helmfile_staging_apply.yaml
+++ b/.github/workflows/helmfile_staging_apply.yaml
@@ -9,7 +9,7 @@ on:
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   HELMFILE_FILE_PATH: ${{ github.workspace }}/helmfile
-  STAGING_AWS_ACCOUNT: ${{ secrets.STAGING_AWS_ACCOUNT }}
+  STAGING_AWS_ACCOUNT: ${{ secrets.STAGING_ACCOUNT_ID }}
   OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN_STAGING }}
 
 jobs:
@@ -73,7 +73,7 @@ jobs:
       - name: Configure kubeconfig
         run: |
           aws eks update-kubeconfig --name notification-canada-ca-staging-eks-cluster     
-          kubectl config rename-context arn:aws:eks:ca-central-1:$STAGING_AWS_ACCOUNT:cluster/notification-canada-ca-staging-eks-cluster staging   
+          kubectl config rename-context arn:aws:eks:ca-central-1:$STAGING_ACCOUNT_ID:cluster/notification-canada-ca-staging-eks-cluster staging   
 
       - name: Load EnvVars
         run: |

--- a/.github/workflows/helmfile_staging_apply.yaml
+++ b/.github/workflows/helmfile_staging_apply.yaml
@@ -72,8 +72,7 @@ jobs:
 
       - name: Configure kubeconfig
         run: |
-          aws eks update-kubeconfig --name notification-canada-ca-staging-eks-cluster     
-          kubectl config rename-context arn:aws:eks:ca-central-1:$STAGING_ACCOUNT_ID:cluster/notification-canada-ca-staging-eks-cluster staging   
+          aws eks update-kubeconfig --name notification-canada-ca-staging-eks-cluster --alias staging 
 
       - name: Load EnvVars
         run: |

--- a/.github/workflows/helmfile_staging_apply.yaml
+++ b/.github/workflows/helmfile_staging_apply.yaml
@@ -10,7 +10,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   HELMFILE_FILE_PATH: ${{ github.workspace }}/helmfile
   STAGING_AWS_ACCOUNT: ${{ secrets.STAGING_AWS_ACCOUNT }}
-  OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+  OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN_STAGING }}
 
 jobs:
   helmfile-apply:

--- a/.github/workflows/helmfile_staging_apply_specific_app.yaml
+++ b/.github/workflows/helmfile_staging_apply_specific_app.yaml
@@ -30,7 +30,7 @@ on:
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   HELMFILE_FILE_PATH: ${{ github.workspace }}/helmfile
-  STAGING_AWS_ACCOUNT: ${{ secrets.STAGING_AWS_ACCOUNT }}
+  STAGING_AWS_ACCOUNT: ${{ secrets.STAGING_ACCOUNT_ID }}
   DOCKER_TAG: ${{ github.event.inputs.tag }}
   OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN_STAGING }}
 
@@ -91,7 +91,7 @@ jobs:
       - name: Configure kubeconfig
         run: |
           aws eks update-kubeconfig --name notification-canada-ca-staging-eks-cluster   
-          kubectl config rename-context arn:aws:eks:ca-central-1:$STAGING_AWS_ACCOUNT:cluster/notification-canada-ca-staging-eks-cluster staging
+          kubectl config rename-context arn:aws:eks:ca-central-1:$STAGING_ACCOUNT_ID:cluster/notification-canada-ca-staging-eks-cluster staging
 
       - name: Load EnvVars
         run: |

--- a/.github/workflows/helmfile_staging_apply_specific_app.yaml
+++ b/.github/workflows/helmfile_staging_apply_specific_app.yaml
@@ -30,7 +30,6 @@ on:
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   HELMFILE_FILE_PATH: ${{ github.workspace }}/helmfile
-  STAGING_AWS_ACCOUNT: ${{ secrets.STAGING_ACCOUNT_ID }}
   DOCKER_TAG: ${{ github.event.inputs.tag }}
   OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN_STAGING }}
 
@@ -90,8 +89,7 @@ jobs:
 
       - name: Configure kubeconfig
         run: |
-          aws eks update-kubeconfig --name notification-canada-ca-staging-eks-cluster   
-          kubectl config rename-context arn:aws:eks:ca-central-1:$STAGING_ACCOUNT_ID:cluster/notification-canada-ca-staging-eks-cluster staging
+          aws eks update-kubeconfig --name notification-canada-ca-staging-eks-cluster --alias staging   
 
       - name: Load EnvVars
         run: |

--- a/.github/workflows/helmfile_staging_apply_specific_app.yaml
+++ b/.github/workflows/helmfile_staging_apply_specific_app.yaml
@@ -32,7 +32,7 @@ env:
   HELMFILE_FILE_PATH: ${{ github.workspace }}/helmfile
   STAGING_AWS_ACCOUNT: ${{ secrets.STAGING_AWS_ACCOUNT }}
   DOCKER_TAG: ${{ github.event.inputs.tag }}
-  OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+  OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN_STAGING }}
 
 jobs:
   rollout:

--- a/.github/workflows/helmfile_staging_plan.yaml
+++ b/.github/workflows/helmfile_staging_plan.yaml
@@ -7,7 +7,6 @@ on:
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   HELMFILE_FILE_PATH: ${{ github.workspace }}/helmfile
-  STAGING_AWS_ACCOUNT: ${{ secrets.STAGING_ACCOUNT_ID }}
   OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN_STAGING }}
 
 
@@ -64,8 +63,7 @@ jobs:
 
       - name: Configure kubeconfig
         run: |
-          aws eks update-kubeconfig --name notification-canada-ca-staging-eks-cluster   
-          kubectl config rename-context arn:aws:eks:ca-central-1:$STAGING_ACCOUNT_ID:cluster/notification-canada-ca-staging-eks-cluster staging
+          aws eks update-kubeconfig --name notification-canada-ca-staging-eks-cluster --alias staging  
       - name: Load EnvVars
         run: |
             ./helmfile/getContext.sh -g

--- a/.github/workflows/helmfile_staging_plan.yaml
+++ b/.github/workflows/helmfile_staging_plan.yaml
@@ -8,7 +8,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   HELMFILE_FILE_PATH: ${{ github.workspace }}/helmfile
   STAGING_AWS_ACCOUNT: ${{ secrets.STAGING_AWS_ACCOUNT }}
-  OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+  OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN_STAGING }}
 
 
 jobs:

--- a/.github/workflows/helmfile_staging_plan.yaml
+++ b/.github/workflows/helmfile_staging_plan.yaml
@@ -7,7 +7,7 @@ on:
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   HELMFILE_FILE_PATH: ${{ github.workspace }}/helmfile
-  STAGING_AWS_ACCOUNT: ${{ secrets.STAGING_AWS_ACCOUNT }}
+  STAGING_AWS_ACCOUNT: ${{ secrets.STAGING_ACCOUNT_ID }}
   OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN_STAGING }}
 
 
@@ -65,7 +65,7 @@ jobs:
       - name: Configure kubeconfig
         run: |
           aws eks update-kubeconfig --name notification-canada-ca-staging-eks-cluster   
-          kubectl config rename-context arn:aws:eks:ca-central-1:$STAGING_AWS_ACCOUNT:cluster/notification-canada-ca-staging-eks-cluster staging
+          kubectl config rename-context arn:aws:eks:ca-central-1:$STAGING_ACCOUNT_ID:cluster/notification-canada-ca-staging-eks-cluster staging
       - name: Load EnvVars
         run: |
             ./helmfile/getContext.sh -g

--- a/.github/workflows/merge_to_main_staging.yaml
+++ b/.github/workflows/merge_to_main_staging.yaml
@@ -11,7 +11,7 @@ on:
       - "env/staging/**"
 
 env:
-  OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+  OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN_STAGING }}
 
 defaults:
   run:


### PR DESCRIPTION
## What happens when your PR merges?

Switch to using the OP SA token secret that has the environment name in it

Also cleaning up kubeconfig code to use aliases instead of context renaming

Also Also normalizing the staging secret for aws account id


## After merging this PR

- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.
