### PR TITLE
Adding step label to kube state metrics

### DIFF
--- a/helmfile/helmfile.yaml
+++ b/helmfile/helmfile.yaml
@@ -177,6 +177,7 @@ releases:
       app: kube-state-metrics
       tier: full
       category: system
+      step: 2
     chart: prometheus-community/kube-state-metrics
     version: 5.18.1
     values:


### PR DESCRIPTION
## What happens when your PR merges?

The step label has been added to kube state metrics to make sure it gets applied in the helmfile apply's on a new environment.

## What are you changing?

- [ ] Releasing a new version of Notify
- [x] Changing kubernetes configuration

## Provide some background on the changes

Debugging the gerd derm dashboards in dev

## Checklist if making changes to Kubernetes

- [x] I know how to get kubectl credentials in case it catches on fire

## After merging this PR

- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.
