### PR TITLE
fix initial delay for dd

### DIFF
--- a/helmfile/charts/karpenter-nodepool/values.yaml
+++ b/helmfile/charts/karpenter-nodepool/values.yaml
@@ -5,8 +5,8 @@ nodePool:
   annotations: {}
   zones: "['ca-central-1a', 'ca-central-1b', 'ca-central-1c', 'ca-central-1d']"
   instanceCategories: "['m', 'r']"
-  instanceFamily: "['m5', 'r5', 'm4', 'r4']"
-  instanceCPU: "['2', '4', '6']"
+  instanceFamily: "['m5', 'r5']"
+  instanceCPU: "['2', '4']"
   capacityTypes: ["spot"]
   disruption:
     consolidationPolicy: WhenEmpty

--- a/helmfile/charts/karpenter-nodepool/values.yaml
+++ b/helmfile/charts/karpenter-nodepool/values.yaml
@@ -5,8 +5,8 @@ nodePool:
   annotations: {}
   zones: "['ca-central-1a', 'ca-central-1b', 'ca-central-1c', 'ca-central-1d']"
   instanceCategories: "['m', 'r']"
-  instanceFamily: "['m5', 'r5']"
-  instanceCPU: "['2', '4']"
+  instanceFamily: "['m5', 'r5', 'm4', 'r4']"
+  instanceCPU: "['2', '4', '6']"
   capacityTypes: ["spot"]
   disruption:
     consolidationPolicy: WhenEmpty

--- a/helmfile/charts/notify-document-download/values.yaml
+++ b/helmfile/charts/notify-document-download/values.yaml
@@ -70,11 +70,13 @@ resources:
     memory: "800Mi"
 
 livenessProbe:
+  initialDelaySeconds: 30
   httpGet:
     path: /_status
     port: 7000
 
 readinessProbe:
+  initialDelaySeconds: 30
   httpGet:
     path: /_status
     port: 7000


### PR DESCRIPTION
## What happens when your PR merges?

Doc download is slow to launch on 3.12 w/ NR

Adding an initial delay of 30s to probes.

## What are you changing?

- [ ] Releasing a new version of Notify
- [x] Changing kubernetes configuration

## Checklist if making changes to Kubernetes

- [x] I know how to get kubectl credentials in case it catches on fire

## After merging this PR

- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.
