### PR TITLE
Fixed dd api URL everywhere

### DIFF
--- a/helmfile/charts/notify-celery/values.yaml
+++ b/helmfile/charts/notify-celery/values.yaml
@@ -8,7 +8,7 @@ celeryCommon:
   AWS_REGION: "ca-central-1"
   BULK_SEND_TEST_SERVICE_ID: "ea608120-148a-4eba-a64c-4d9a8010e7b0"
   CSV_UPLOAD_BUCKET_NAME: "notification-canada-ca-dev-csv-upload"
-  DOCUMENT_DOWNLOAD_API_HOST: "http://document-download-api.notification-canada-ca.svc.cluster.local:7000"
+  DOCUMENT_DOWNLOAD_API_HOST: "http://notify-document-download.notification-canada-ca.svc.cluster.local:7000"
   FIDO2_DOMAIN: "dev.notification.cdssandbox.xyz"
   HC_EN_SERVICE_ID: "changeme"
   HC_FR_SERVICE_ID: "changeme"

--- a/helmfile/overrides/notify/api.yaml.gotmpl
+++ b/helmfile/overrides/notify/api.yaml.gotmpl
@@ -7,7 +7,7 @@ api:
   BASE_DOMAIN: "{{ requiredEnv "BASE_DOMAIN" }}"
   ASSET_DOMAIN: "https://assets.{{ requiredEnv "BASE_DOMAIN" }}"
   DOCUMENTATION_DOMAIN: "documentation.{{ requiredEnv "BASE_DOMAIN" }}"
-  DOCUMENT_DOWNLOAD_API_HOST: "http://document-download-api.{{ .Release.Namespace }}.svc.cluster.local:7000"
+  DOCUMENT_DOWNLOAD_API_HOST: "http://notify-document-download.{{ .Release.Namespace }}.svc.cluster.local:7000"
   API_HOST_NAME: "https://{{ .StateValues.API_HOST_NAME_PREFIX }}.{{ requiredEnv "BASE_DOMAIN" }}"
   HC_EN_SERVICE_ID: "{{ .StateValues.HC_EN_SERVICE_ID }}"
   HC_FR_SERVICE_ID: "{{ .StateValues.HC_FR_SERVICE_ID }}"

--- a/helmfile/overrides/notify/celery.yaml.gotmpl
+++ b/helmfile/overrides/notify/celery.yaml.gotmpl
@@ -7,7 +7,7 @@ celeryCommon:
   AWS_REGION: "{{ requiredEnv "AWS_REGION" }}"
   BULK_SEND_TEST_SERVICE_ID: "{{ .StateValues.BULK_SEND_TEST_SERVICE_ID }}"
   CSV_UPLOAD_BUCKET_NAME: "notification-canada-ca-{{ .Environment.Name }}-csv-upload"
-  DOCUMENT_DOWNLOAD_API_HOST: "http://document-download-api.{{ .Release.Namespace }}.svc.cluster.local:7000"
+  DOCUMENT_DOWNLOAD_API_HOST: "http://notify-document-download.{{ .Release.Namespace }}.svc.cluster.local:7000"
   FIDO2_DOMAIN: "{{ requiredEnv "BASE_DOMAIN" }}"
   HC_EN_SERVICE_ID: "{{ .StateValues.HC_EN_SERVICE_ID }}"
   HC_FR_SERVICE_ID: "{{ .StateValues.HC_FR_SERVICE_ID }}"


### PR DESCRIPTION
## What happens when your PR merges?

Fixed dd api url everywhere it was specified.

## What are you changing?

- [ ] Releasing a new version of Notify
- [x] Changing kubernetes configuration

## Checklist if making changes to Kubernetes

- [x] I know how to get kubectl credentials in case it catches on fire

## After merging this PR

- [x] I have verified that the tests / deployment actions succeeded
- [x] I have verified that any affected pods were restarted successfully
- [x] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [x] I have verified that the smoke tests still pass on production
- [x] I have communicated the release in the #notify Slack channel.
