### PR TITLE
Turning Kustomize back on for DEV

### DIFF
--- a/env/dev/kustomization.yaml
+++ b/env/dev/kustomization.yaml
@@ -5,23 +5,23 @@ resources:
   - fluentbit.yaml
   - cwagent.yaml
   - cwagent-configmap.yaml
-  # - notification-service-account.yaml
-  # - api-target-group.yaml
-  # - admin-target-group.yaml
-  # - document-download-api-target-group.yaml
-  # - documentation-target-group.yaml
+  - notification-service-account.yaml
+  - api-target-group.yaml
+  - admin-target-group.yaml
+  - document-download-api-target-group.yaml
+  - documentation-target-group.yaml
   - ../../base/prometheus-cloudwatch
-  # - ../../base/notify-admin
-  # - ../../base/notify-api
-  # - ../../base/notify-celery-other
-  # - ../../base/notify-celery-main-primary
-  # - ../../base/notify-celery-sms-send-primary
-  # - ../../base/notify-celery-email-send-primary
-  # - ../../base/notify-celery-main-scalable
-  # - ../../base/notify-celery-sms-send-scalable
-  # - ../../base/notify-celery-email-send-scalable
-  # - ../../base/notify-document-download
-  # - ../../base/notify-documentation
+  - ../../base/notify-admin
+  - ../../base/notify-api
+  - ../../base/notify-celery-other
+  - ../../base/notify-celery-main-primary
+  - ../../base/notify-celery-sms-send-primary
+  - ../../base/notify-celery-email-send-primary
+  - ../../base/notify-celery-main-scalable
+  - ../../base/notify-celery-sms-send-scalable
+  - ../../base/notify-celery-email-send-scalable
+  - ../../base/notify-document-download
+  - ../../base/notify-documentation
   - ../../base/notify-system
 
 images:
@@ -34,45 +34,45 @@ images:
   - name: documentation
     newName: public.ecr.aws/cds-snc/notify-documentation:latest
 
-# patches:
-#   - path: performance/admin-hpa-patch.yaml
-#   - path: performance/api-hpa-patch.yaml
-#   - path: performance/celery-email-send-primary-deployment-patch.yaml
-#   - path: performance/celery-email-send-scalable-deployment-patch.yaml
-#   - path: performance/celery-email-send-scalable-hpa-patch.yaml
-#   - path: performance/celery-primary-deployment-patch.yaml
-#   - path: performance/celery-scalable-deployment-patch.yaml
-#   - path: performance/celery-scalable-hpa-patch.yaml
-#   - path: performance/celery-sms-send-primary-deployment-patch.yaml
-#   - path: performance/celery-sms-send-scalable-deployment-patch.yaml
-#   - path: performance/celery-sms-send-scalable-hpa-patch.yaml
+patches:
+  - path: performance/admin-hpa-patch.yaml
+  - path: performance/api-hpa-patch.yaml
+  - path: performance/celery-email-send-primary-deployment-patch.yaml
+  - path: performance/celery-email-send-scalable-deployment-patch.yaml
+  - path: performance/celery-email-send-scalable-hpa-patch.yaml
+  - path: performance/celery-primary-deployment-patch.yaml
+  - path: performance/celery-scalable-deployment-patch.yaml
+  - path: performance/celery-scalable-hpa-patch.yaml
+  - path: performance/celery-sms-send-primary-deployment-patch.yaml
+  - path: performance/celery-sms-send-scalable-deployment-patch.yaml
+  - path: performance/celery-sms-send-scalable-hpa-patch.yaml
 
-#   - path: services/admin-service-patch.yaml
-#   - path: services/api-service-patch.yaml
-#   - path: services/document-download-api-service-patch.yaml
-#   - path: services/documentation-service-patch.yaml
+  - path: services/admin-service-patch.yaml
+  - path: services/api-service-patch.yaml
+  - path: services/document-download-api-service-patch.yaml
+  - path: services/documentation-service-patch.yaml
 
   - path: cwagent/cwagent-deployment-patch.yaml
 
-#   - path: nodeselectors/admin-node-selector-patch.yaml
-#   - path: nodeselectors/celery-api-node-selector-patch.yaml
-#   - path: nodeselectors/celery-beat-node-selector-patch.yaml
-#   - path: nodeselectors/celery-email-send-node-selector-patch.yaml
-#   - path: nodeselectors/celery-email-send-scalable-node-selector-patch.yaml
-#   - path: nodeselectors/celery-primary-node-selector-patch.yaml
-#   - path: nodeselectors/celery-scalable-node-selector-patch.yaml
-#   - path: nodeselectors/celery-sms-node-selector-patch.yaml
-#   - path: nodeselectors/celery-sms-send-node-selector-patch.yaml
-#   - path: nodeselectors/celery-sms-send-scalable-node-selector-patch.yaml
-#   - path: nodeselectors/document-download-api-node-selector-patch.yaml
-#   - path: nodeselectors/documentation-node-selector-patch.yaml
+  - path: nodeselectors/admin-node-selector-patch.yaml
+  - path: nodeselectors/celery-api-node-selector-patch.yaml
+  - path: nodeselectors/celery-beat-node-selector-patch.yaml
+  - path: nodeselectors/celery-email-send-node-selector-patch.yaml
+  - path: nodeselectors/celery-email-send-scalable-node-selector-patch.yaml
+  - path: nodeselectors/celery-primary-node-selector-patch.yaml
+  - path: nodeselectors/celery-scalable-node-selector-patch.yaml
+  - path: nodeselectors/celery-sms-node-selector-patch.yaml
+  - path: nodeselectors/celery-sms-send-node-selector-patch.yaml
+  - path: nodeselectors/celery-sms-send-scalable-node-selector-patch.yaml
+  - path: nodeselectors/document-download-api-node-selector-patch.yaml
+  - path: nodeselectors/documentation-node-selector-patch.yaml
 
-#   - path: celery-init-delete/celery-email-send-primary-init-delete-patch.yaml
-#   - path: celery-init-delete/celery-email-send-scalable-init-delete-patch.yaml
-#   - path: celery-init-delete/celery-primary-init-delete-patch.yaml
-#   - path: celery-init-delete/celery-scalable-init-delete-patch.yaml
-#   - path: celery-init-delete/celery-sms-send-primary-init-delete-patch.yaml
-#   - path: celery-init-delete/celery-sms-send-scalable-init-delete-patch.yaml
+  - path: celery-init-delete/celery-email-send-primary-init-delete-patch.yaml
+  - path: celery-init-delete/celery-email-send-scalable-init-delete-patch.yaml
+  - path: celery-init-delete/celery-primary-init-delete-patch.yaml
+  - path: celery-init-delete/celery-scalable-init-delete-patch.yaml
+  - path: celery-init-delete/celery-sms-send-primary-init-delete-patch.yaml
+  - path: celery-init-delete/celery-sms-send-scalable-init-delete-patch.yaml
 
 configMapGenerator:
   - envs:


### PR DESCRIPTION
## What happens when your PR merges?

Our weekend CRON job that recreates dev is still on Kustomize.  We need this to be turned on so that we our environment gets created properly until we adjust it to use Helm.

## What are you changing?

Just uncommenting some kustomize stuff for the dev environment

## Provide some background on the changes

We are in the middle of a migration to Helmfile and this file was modified, but didn't need to be.

## If you are releasing a new version of Notify, what components are you updating

- [ ] API
- [ ] Admin
- [ ] Documentation
- [ ] Document download API

## Checklist if releasing new version

- [ ] I made sure that the changes are as expected in [Notify staging](https://staging.notification.cdssandbox.xyz/)
- [ ] I have checked if the docker images I am referencing exist
  - [ ] [api lambda](https://ca-central-1.console.aws.amazon.com/ecr/repositories/private/296255494825/notify/api-lambda?region=ca-central-1) (requires Notification-Production / AdministratorAccess login)
  - [ ] [api k8s](https://gallery.ecr.aws/v6b8u5o6/notify-api)
  - [ ] [admin](https://gallery.ecr.aws/v6b8u5o6/notify-admin)
  - [ ] [documentation](https://gallery.ecr.aws/v6b8u5o6/notify-documentation)
  - [ ] [document download API](https://gallery.ecr.aws/v6b8u5o6/notify-document-download-api)

## Checklist if making changes to Kubernetes

- [ ] I know how to get kubectl credentials in case it catches on fire

## After merging this PR

- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.
