### PR TITLE
Production Helm Migration TGB Enabled

### DIFF
--- a/helmfile/helmfile.yaml
+++ b/helmfile/helmfile.yaml
@@ -34,7 +34,7 @@ repositories:
   url: https://okgolove.github.io/helm-charts
 
 releases:
-{{ if or (eq .Environment.Name "dev") (eq .Environment.Name "staging") }}
+
   - name: notify-documentation
     namespace: notification-canada-ca
     labels:
@@ -89,8 +89,6 @@ releases:
     chart: charts/notify-celery
     values:
     - ./overrides/notify/celery.yaml.gotmpl
-
-{{ end }}
 
   - name: k8s-event-logger
     namespace: amazon-cloudwatch


### PR DESCRIPTION
## What happens when your PR merges?

Our migration for Notify API, Admin, Doc Download, Documentation and Celery are fully migrated off of Kustomize and onto Helmfile, and deployed on production.

## What are you changing?

- Changing our deployments to use Helmfile rather than Kustomize on Production for the above components
- 
## Provide some background on the changes

TBD

## Checklist if making changes to Kubernetes

- [ X ] I know how to get kubectl credentials in case it catches on fire

## After merging this PR

- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.
