### PR TITLE
Switching test env vars credentials to prod not staging

### DIFF
--- a/.github/workflows/test_env_vars.yaml
+++ b/.github/workflows/test_env_vars.yaml
@@ -29,11 +29,11 @@ jobs:
           echo "::add-mask::$ENV_KEYS_EXAMPLE"
           echo "ENV_KEYS_EXAMPLE=$ENV_KEYS_EXAMPLE" >> $GITHUB_ENV
 
-      - name: Configure AWS staging credentials
+      - name: Configure AWS production credentials
         uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
         with:
-          aws-access-key-id: ${{ secrets.STAGING_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.STAGING_AWS_SECRET_ACCESS_KEY }}
+          aws-access-key-id: ${{ secrets.PRODUCTION_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.PRODUCTION_AWS_SECRET_ACCESS_KEY }}
           aws-region: ca-central-1
 
       - name: Get production env var keys


### PR DESCRIPTION
## What happens when your PR merges?

When we removed staging from the test env vars job, I accidentally removed the production login instead of the staging.

## What are you changing?

- [ ] Releasing a new version of Notify
- [ ] Changing kubernetes configuration
- [x] Github workflows

## Provide some background on the changes

Helm migration

## If you are releasing a new version of Notify, what components are you updating

- [ ] API
- [ ] Admin
- [ ] Documentation
- [ ] Document download API

## Checklist if releasing new version

- [ ] I made sure that the changes are as expected in [Notify staging](https://staging.notification.cdssandbox.xyz/)
- [ ] I have checked if the docker images I am referencing exist
  - [ ] [api lambda](https://ca-central-1.console.aws.amazon.com/ecr/repositories/private/296255494825/notify/api-lambda?region=ca-central-1) (requires Notification-Production / AdministratorAccess login)
  - [ ] [api k8s](https://gallery.ecr.aws/v6b8u5o6/notify-api)
  - [ ] [admin](https://gallery.ecr.aws/v6b8u5o6/notify-admin)
  - [ ] [documentation](https://gallery.ecr.aws/v6b8u5o6/notify-documentation)
  - [ ] [document download API](https://gallery.ecr.aws/v6b8u5o6/notify-document-download-api)

## Checklist if making changes to Kubernetes

- [ ] I know how to get kubectl credentials in case it catches on fire

## After merging this PR

- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.
