### PR TITLE
set probe timeoutes

### DIFF
--- a/helmfile/charts/notify-api/templates/deployment.yaml
+++ b/helmfile/charts/notify-api/templates/deployment.yaml
@@ -116,7 +116,7 @@ spec:
             httpGet:
               path: /_status?simple=true
               port: 6011
-            initialDelaySeconds: 10
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds}}
             periodSeconds: 3
             timeoutSeconds: 1
             successThreshold: 3
@@ -125,7 +125,7 @@ spec:
             httpGet:
               path: "/_status?simple=true"
               port: 6011
-            initialDelaySeconds: 30
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds}}
             periodSeconds: 3
             timeoutSeconds: 1
             successThreshold: 1

--- a/helmfile/charts/notify-api/values.yaml
+++ b/helmfile/charts/notify-api/values.yaml
@@ -84,11 +84,13 @@ updateStrategy:
 priorityClassName: high-priority
 
 readinessProbe:
+  initialDelaySeconds: 45
   httpGet:
     path: /_status?simple=true
     port: 6011
 
 livenessProbe:
+  initialDelaySeconds: 45
   httpGet:
     path: "/_status?simple=true"
     port: 6011


### PR DESCRIPTION
## What happens when your PR merges?

Setting API initial delays to 45 seconds instead of 30/10 - lets see if that's enough.

## What are you changing?

- [ ] Releasing a new version of Notify
- [x] Changing kubernetes configuration

## Provide some background on the changes

API Timeouts

## If you are releasing a new version of Notify, what components are you updating

- [ ] API
- [ ] Admin
- [ ] Documentation
- [ ] Document download API

## Checklist if releasing new version

- [ ] I made sure that the changes are as expected in [Notify staging](https://staging.notification.cdssandbox.xyz/)
- [ ] I have checked if the docker images I am referencing exist
  - [ ] [api lambda](https://ca-central-1.console.aws.amazon.com/ecr/repositories/private/296255494825/notify/api-lambda?region=ca-central-1) (requires Notification-Production / AdministratorAccess login)
  - [ ] [api k8s](https://gallery.ecr.aws/v6b8u5o6/notify-api)
  - [ ] [admin](https://gallery.ecr.aws/v6b8u5o6/notify-admin)
  - [ ] [documentation](https://gallery.ecr.aws/v6b8u5o6/notify-documentation)
  - [ ] [document download API](https://gallery.ecr.aws/v6b8u5o6/notify-document-download-api)

## Checklist if making changes to Kubernetes

- [ ] I know how to get kubectl credentials in case it catches on fire

## After merging this PR

- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.
