### PR TITLE
don't plan staging on prod release

### DIFF
--- a/.github/workflows/helmfile_production_plan.yaml
+++ b/.github/workflows/helmfile_production_plan.yaml
@@ -15,7 +15,7 @@ env:
   OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN_PRODUCTION }}  
 
 jobs:
-  if: github.event.pull_request.base.ref == 'main' && github.event.pull_request.merged && (contains(github.event.pull_request.title, '[AUTO-PR]') || contains(github.event.pull_request.title, '[MANIFEST]'))
+  if: github.event.pull_request.base.ref == 'main' && (contains(github.event.pull_request.title, '[AUTO-PR]') || contains(github.event.pull_request.title, '[MANIFEST]'))
   helmfile-diff:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/helmfile_production_plan.yaml
+++ b/.github/workflows/helmfile_production_plan.yaml
@@ -15,6 +15,7 @@ env:
   OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN_PRODUCTION }}  
 
 jobs:
+  if: github.event.pull_request.base.ref == 'main' && github.event.pull_request.merged && (contains(github.event.pull_request.title, '[AUTO-PR]') || contains(github.event.pull_request.title, '[MANIFEST]'))
   helmfile-diff:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/helmfile_production_plan.yaml
+++ b/.github/workflows/helmfile_production_plan.yaml
@@ -15,8 +15,8 @@ env:
   OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN_PRODUCTION }}  
 
 jobs:
-  if: github.event.pull_request.base.ref == 'main' && (contains(github.event.pull_request.title, '[AUTO-PR]') || contains(github.event.pull_request.title, '[MANIFEST]'))
   helmfile-diff:
+    if: github.event.pull_request.base.ref == 'main' && (contains(github.event.pull_request.title, '[AUTO-PR]') || contains(github.event.pull_request.title, '[MANIFEST]'))
     runs-on: ubuntu-latest
     steps:
 

--- a/.github/workflows/helmfile_staging_plan.yaml
+++ b/.github/workflows/helmfile_staging_plan.yaml
@@ -15,7 +15,7 @@ env:
 jobs:
   helmfile-diff:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.base.ref == 'main' && (! contains(github.event.pull_request.title, '[AUTO-PR]') || ! contains(github.event.pull_request.title, '[MANIFEST]'))
+    if: github.event.pull_request.base.ref == 'main' && (! contains(github.event.pull_request.title, '[AUTO-PR]') && ! contains(github.event.pull_request.title, '[MANIFEST]'))
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0

--- a/.github/workflows/helmfile_staging_plan.yaml
+++ b/.github/workflows/helmfile_staging_plan.yaml
@@ -10,9 +10,12 @@ env:
   OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN_STAGING }}
 
 
+
+
 jobs:
   helmfile-diff:
     runs-on: ubuntu-latest
+    if: github.event.pull_request.base.ref == 'main' && github.event.pull_request.merged && (! contains(github.event.pull_request.title, '[AUTO-PR]') || ! contains(github.event.pull_request.title, '[MANIFEST]'))
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
@@ -82,3 +85,4 @@ jobs:
             ```shell 
             ${{join(steps.helmfile_diff.outputs.*, '\n')}}
             ```
+            

--- a/.github/workflows/helmfile_staging_plan.yaml
+++ b/.github/workflows/helmfile_staging_plan.yaml
@@ -15,7 +15,7 @@ env:
 jobs:
   helmfile-diff:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.base.ref == 'main' && github.event.pull_request.merged && (! contains(github.event.pull_request.title, '[AUTO-PR]') || ! contains(github.event.pull_request.title, '[MANIFEST]'))
+    if: github.event.pull_request.base.ref == 'main' && (! contains(github.event.pull_request.title, '[AUTO-PR]') || ! contains(github.event.pull_request.title, '[MANIFEST]'))
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0


### PR DESCRIPTION
## What happens when your PR merges?

We were running a helmfile diff against staging on [AUTO-PR] and [MANIFEST] PRs which we don't want - we want prod diff on that.

## What are you changing?

- [ ] Releasing a new version of Notify
- [ ] Changing kubernetes configuration
- [x] Github workflow

## Provide some background on the changes

Helmfile release

## Checklist if making changes to Kubernetes

- [x] I know how to get kubectl credentials in case it catches on fire

## After merging this PR

- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.
