### PR TITLE
fix: increase smoke test timeout

### DIFF
--- a/.github/workflows/smoke_test.yaml
+++ b/.github/workflows/smoke_test.yaml
@@ -60,7 +60,7 @@ jobs:
           SMOKE_SERVICE_ID: f316aa6b-38dd-4d9e-83f8-b6ee3e1d428f
           SMOKE_SMS_TEMPLATE_ID: d8234b4d-4def-4ad6-aafe-526a24ee5f19
           SMOKE_USER_ID: f8763157-9c67-44f1-aaec-5d2564b41c8e
-          SMOKE_POLL_TIMEOUT: 320
+          SMOKE_POLL_TIMEOUT: 450
         run: poetry run make smoke-test
       - name: Notify Slack channel if this job failed
         if: ${{ failure() }}


### PR DESCRIPTION
## What happens when your PR merges?

- Prefix the title of your PR:
  - `fix:` - tag `main` as a new patch release
  
## What are you changing?

- [ ] Releasing a new version of Notify
- [ ] Changing kubernetes configuration

## Provide some background on the changes

Smoke test is timing out waiting for delivery receipts to be retried.
Here we bump up the timeout to larger than what would have been needed in the latest timeout.
