### PR TITLE
[MANIFEST] Upping celery memory requests to 800

### DIFF
--- a/helmfile/charts/notify-celery/values.yaml
+++ b/helmfile/charts/notify-celery/values.yaml
@@ -76,7 +76,7 @@ nodes:
       resources:
         requests:
           cpu: "100m"
-          memory: "500Mi"
+          memory: "800Mi"
         limits:
           cpu: "550m"
           memory: "1024Mi"
@@ -102,7 +102,7 @@ nodes:
       resources:
         requests:
           cpu: "100m"
-          memory: "500Mi"
+          memory: "800Mi"
         limits:
           cpu: "550m"
           memory: "1024Mi"
@@ -128,7 +128,7 @@ nodes:
       resources:
         requests:
           cpu: "100m"
-          memory: "500Mi"
+          memory: "800Mi"
         limits:
           cpu: "550m"
           memory: "1024Mi"
@@ -176,7 +176,7 @@ nodes:
       resources:
         requests:
           cpu: "100m"
-          memory: "500Mi"
+          memory: "800Mi"
         limits:
           cpu: "550m"
           memory: "1024Mi"
@@ -207,7 +207,7 @@ nodes:
       resources:
         requests:
           cpu: "100m"
-          memory: "500Mi"
+          memory: "800Mi"
         limits:
           cpu: "550m"
           memory: "1024Mi"
@@ -238,7 +238,7 @@ nodes:
       resources:
         requests:
           cpu: "100m"
-          memory: "500Mi"
+          memory: "800Mi"
         limits:
           cpu: "550m"
           memory: "1024Mi"
@@ -269,7 +269,7 @@ nodes:
       resources:
         requests:
           cpu: "100m"
-          memory: "500Mi"
+          memory: "800Mi"
         limits:
           cpu: "550m"
           memory: "1024Mi"


### PR DESCRIPTION
## What happens when your PR merges?

We're seeing pod eviction due to running out of memory on staging Nodes. Lets up the request to something higher so that K8s doesn't try and put too many celery pods on the same nodes.

## What are you changing?

- [ ] Releasing a new version of Notify
- [x] Changing kubernetes configuration

## Provide some background on the changes

Incident debugging

## Checklist if making changes to Kubernetes

- [ ] I know how to get kubectl credentials in case it catches on fire

## After merging this PR

- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.
