### PR TITLE
remove https from documentation domain

### DIFF
--- a/helmfile/charts/notify-admin/values.yaml
+++ b/helmfile/charts/notify-admin/values.yaml
@@ -13,7 +13,7 @@ admin:
   IP_GEOLOCATE_SERVICE: "http://ipv4.notification-canada-ca.svc.cluster.local:8080"
   BULK_SEND_TEST_SERVICE_ID: "123456789"
   CONTACT_EMAIL: "notification-ops@cds-snc.ca"
-  DOCUMENTATION_DOMAIN: "https://documentation.notification.canada.ca"
+  DOCUMENTATION_DOMAIN: "documentation.notification.canada.ca"
   HC_EN_SERVICE_ID: "123456789"
   HC_FR_SERVICE_ID: "123456789"
   REDIS_ENABLED: "1"

--- a/helmfile/overrides/notify/admin.yaml.gotmpl
+++ b/helmfile/overrides/notify/admin.yaml.gotmpl
@@ -12,7 +12,7 @@ admin:
   ALLOW_DEBUG_ROUTE: "{{ .StateValues.ALLOW_DEBUG_ROUTE }}"
   BULK_SEND_TEST_SERVICE_ID: "{{ .StateValues.BULK_SEND_TEST_SERVICE_ID }}"
   CONTACT_EMAIL: "{{ .StateValues.CONTACT_EMAIL }}"
-  DOCUMENTATION_DOMAIN: "https://documentation.{{ requiredEnv "BASE_DOMAIN" }}"
+  DOCUMENTATION_DOMAIN: "documentation.{{ requiredEnv "BASE_DOMAIN" }}"
   HC_EN_SERVICE_ID: "{{ .StateValues.HC_EN_SERVICE_ID }}"
   HC_FR_SERVICE_ID: "{{ .StateValues.HC_FR_SERVICE_ID }}"
   REDIS_ENABLED: "{{ .StateValues.REDIS_ENABLED }}"


### PR DESCRIPTION
## What happens when your PR merges?

Remove the https prefix from documentation_domain

## What are you changing?

- [ ] Releasing a new version of Notify
- [x] Changing kubernetes configuration

## Provide some background on the changes

Bug introduced from helmfile migration

## After merging this PR

- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.
