### PR TITLE
[MANIFEST] remove https from asset domain

### DIFF
--- a/helmfile/overrides/notify/api.yaml.gotmpl
+++ b/helmfile/overrides/notify/api.yaml.gotmpl
@@ -5,7 +5,7 @@ api:
   CSV_UPLOAD_BUCKET_NAME: "{{ .Release.Namespace }}-{{ .Environment.Name }}-csv-upload"
   NEW_RELIC_APP_NAME: "notification-api-{{ .Environment.Name }}"
   BASE_DOMAIN: "{{ requiredEnv "BASE_DOMAIN" }}"
-  ASSET_DOMAIN: "https://assets.{{ requiredEnv "BASE_DOMAIN" }}"
+  ASSET_DOMAIN: "assets.{{ requiredEnv "BASE_DOMAIN" }}"
   DOCUMENTATION_DOMAIN: "documentation.{{ requiredEnv "BASE_DOMAIN" }}"
   DOCUMENT_DOWNLOAD_API_HOST: "http://notify-document-download.{{ .Release.Namespace }}.svc.cluster.local:7000"
   API_HOST_NAME: "https://{{ .StateValues.API_HOST_NAME_PREFIX }}.{{ requiredEnv "BASE_DOMAIN" }}"

--- a/helmfile/overrides/notify/celery.yaml.gotmpl
+++ b/helmfile/overrides/notify/celery.yaml.gotmpl
@@ -19,7 +19,7 @@ celeryCommon:
   NEW_RELIC_MONITOR_MODE: "{{ .StateValues.NEW_RELIC_MONITOR_MODE }}"
   AWS_XRAY_CONTEXT_MISSING: "{{ .StateValues.AWS_XRAY_CONTEXT_MISSING }}"
   AWS_XRAY_SDK_ENABLED: {{ .StateValues.AWS_XRAY_SDK_ENABLED }}
-  ASSET_DOMAIN: "https://assets.{{ requiredEnv "BASE_DOMAIN" }}"
+  ASSET_DOMAIN: "assets.{{ requiredEnv "BASE_DOMAIN" }}"
   FF_ANNUAL_LIMIT: "{{ .StateValues.FF_ANNUAL_LIMIT }}"
   AWS_PINPOINT_SC_POOL_ID: "{{ .StateValues.AWS_PINPOINT_SC_POOL_ID }}"
   AWS_PINPOINT_SC_TEMPLATE_IDS: "{{ .StateValues.AWS_PINPOINT_SC_TEMPLATE_IDS }}"


### PR DESCRIPTION
## What happens when your PR merges?

Remove https from asset domain

## What are you changing?

- [ ] Releasing a new version of Notify
- [x] Changing kubernetes configuration

## Provide some background on the changes

Helmfile bug

## After merging this PR

- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.
