### PR TITLE
attempting to fix branch protection

### DIFF
--- a/.github/workflows/autopr_merged.yaml
+++ b/.github/workflows/autopr_merged.yaml
@@ -83,6 +83,8 @@ jobs:
           repository: ${{ github.repository }}
           required_status_checks: | 
             strict: true
+            checks:
+              - context: testing_manifest
           required_linear_history: |
             true
           enforce_admins: |

--- a/.github/workflows/autopr_merged.yaml
+++ b/.github/workflows/autopr_merged.yaml
@@ -1,6 +1,7 @@
 name: "Tag and release to production"
 
 on: 
+  workflow_dispatch:
   pull_request:
     types: [closed]
 

--- a/.github/workflows/update_image_tags_staging.yaml
+++ b/.github/workflows/update_image_tags_staging.yaml
@@ -69,6 +69,8 @@ jobs:
           repository: ${{ github.repository }}
           required_status_checks: | 
             strict: true
+            checks:
+              - context: testing_manifest
           required_linear_history: |
             true
           enforce_admins: |
@@ -79,3 +81,4 @@ jobs:
             null 
         env:
           GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}
+


### PR DESCRIPTION
## What happens when your PR merges?

Trying to fix branch protection which is failing on the workflows

## What are you changing?

- [ ] Releasing a new version of Notify
- [ ] Changing kubernetes configuration
- [x] Github workflows

## Provide some background on the changes

Issues w/ helmfile migration

## After merging this PR

- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.
