### PR TITLE
remove if condition on staging helmfile diff

### DIFF
--- a/.github/workflows/helmfile_staging_plan.yaml
+++ b/.github/workflows/helmfile_staging_plan.yaml
@@ -15,7 +15,6 @@ env:
 jobs:
   helmfile-diff:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.base.ref == 'main' && (! contains(github.event.pull_request.title, '[AUTO-PR]') && ! contains(github.event.pull_request.title, '[MANIFEST]'))
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0


### PR DESCRIPTION
## What happens when your PR merges?

We'll need to run staging diff even on prod-prs for the time being. I have an idea on how to fix this properly but it will require an overhaul of the workflows.

## What are you changing?

- [ ] Releasing a new version of Notify
- [ ] Changing kubernetes configuration
- [x] Github workflows


## After merging this PR

- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.
