### PR TITLE
[MANIFEST] Removing the default since it seems to not be working as expected

### DIFF
--- a/helmfile/overrides/notify/admin.yaml.gotmpl
+++ b/helmfile/overrides/notify/admin.yaml.gotmpl
@@ -29,7 +29,7 @@ admin:
   GC_ORGANISATIONS_BUCKET_NAME: "{{ .StateValues.GC_ORGANISATIONS_BUCKET_NAME }}"
 
 image:
-  tag: {{ .StateValues.ADMIN_DOCKER_TAG | default "latest" }}
+  tag: "{{ .StateValues.ADMIN_DOCKER_TAG }}"
 
 serviceAccount:
   annotations:

--- a/helmfile/overrides/notify/api.yaml.gotmpl
+++ b/helmfile/overrides/notify/api.yaml.gotmpl
@@ -24,7 +24,7 @@ api:
   GC_ORGANISATIONS_BUCKET_NAME: "{{ .StateValues.GC_ORGANISATIONS_BUCKET_NAME }}"
 
 image: 
-  tag: {{ .StateValues.API_DOCKER_TAG | default "latest" }}
+  tag: {{ .StateValues.API_DOCKER_TAG }}
 
 serviceAccount:
   annotations:

--- a/helmfile/overrides/notify/celery.yaml.gotmpl
+++ b/helmfile/overrides/notify/celery.yaml.gotmpl
@@ -26,7 +26,7 @@ celeryCommon:
   AWS_PINPOINT_DEFAULT_POOL_ID: "{{ .StateValues.AWS_PINPOINT_DEFAULT_POOL_ID }}"
 
 image: 
-  tag: {{ .StateValues.API_DOCKER_TAG | default "latest" }}
+  tag: {{ .StateValues.API_DOCKER_TAG }}
 
 serviceAccount:
   annotations:

--- a/helmfile/overrides/notify/document-download.yaml.gotmpl
+++ b/helmfile/overrides/notify/document-download.yaml.gotmpl
@@ -14,7 +14,7 @@ documentDownload:
   EXTRA_MIME_TYPES: "{{ .StateValues.EXTRA_MIME_TYPES }}"
 
 image: 
-  tag: {{ .StateValues.DOCUMENT_DOWNLOAD_DOCKER_TAG | default "latest" }}
+  tag: {{ .StateValues.DOCUMENT_DOWNLOAD_DOCKER_TAG }}
   
 serviceAccount:
   annotations:

--- a/helmfile/overrides/notify/documentation.yaml.gotmpl
+++ b/helmfile/overrides/notify/documentation.yaml.gotmpl
@@ -1,5 +1,5 @@
 image: 
-  tag: {{ .StateValues.DOCUMENTATION_DOCKER_TAG | default "latest" }}
+  tag: {{ .StateValues.DOCUMENTATION_DOCKER_TAG }}
 
 targetGroupBinding:
   enabled: true


### PR DESCRIPTION
## What happens when your PR merges?

The default latest seems to be behaving weirdly. Removing that.

## What are you changing?

- [ ] Releasing a new version of Notify
- [x] Changing kubernetes configuration


## After merging this PR

- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.
