### PR TITLE
[MANIFEST] manual release of api lambda to bb33743

### DIFF
--- a/.github/workflows/merge_to_main_production.yaml
+++ b/.github/workflows/merge_to_main_production.yaml
@@ -9,7 +9,7 @@ on:
 
 env:
   PRIVATE_ECR: ${{ secrets.PRODUCTION_AWS_ACCOUNT_ID }}.dkr.ecr.ca-central-1.amazonaws.com/notify
-  API_LAMBDA_IMAGE: api-lambda:5c216bb
+  API_LAMBDA_IMAGE: api-lambda:bb33743
   HEARTBEAT_IMAGE: heartbeat:5c8da95
   SYSTEM_STATUS_IMAGE: system_status:078cf82
   OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN_PRODUCTION }}


### PR DESCRIPTION
## What happens when your PR merges?

- Prefix the title of your PR:
  - `[MANIFEST]` or `[AUTO-PR]` - tag `main` as a new patch release and deploy to production

## What are you changing?

- [x] Releasing a new version of Notify

## Provide some background on the changes

pr-bot isn't changing the api lambda tag, this PR does it manually. We will fix the pr-bot soon but there's recent bugfixes we should release asap.

## If you are releasing a new version of Notify, what components are you updating

- [x] API

## Checklist if releasing new version

- [x] I made sure that the changes are as expected in [Notify staging](https://staging.notification.cdssandbox.xyz/)
- [x] I have checked if the docker images I am referencing exist
  - [x] [api lambda](https://ca-central-1.console.aws.amazon.com/ecr/repositories/private/296255494825/notify/api-lambda?region=ca-central-1) (requires Notification-Production / AdministratorAccess login)
  - [ ] [api k8s](https://gallery.ecr.aws/v6b8u5o6/notify-api)
  - [ ] [admin](https://gallery.ecr.aws/v6b8u5o6/notify-admin)
  - [ ] [documentation](https://gallery.ecr.aws/v6b8u5o6/notify-documentation)
  - [ ] [document download API](https://gallery.ecr.aws/v6b8u5o6/notify-document-download-api)


## After merging this PR

- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.
