### PR TITLE
asdding back missing asset_domain variable

### DIFF
--- a/helmfile/overrides/notify/admin.yaml.gotmpl
+++ b/helmfile/overrides/notify/admin.yaml.gotmpl
@@ -4,6 +4,7 @@ admin:
   BASE_DOMAIN: "{{ requiredEnv "BASE_DOMAIN"}}"
   ALLOW_HTML_SERVICE_IDS: "{{ .StateValues.ALLOW_HTML_SERVICE_IDS }}"
   ASSET_UPLOAD_BUCKET_NAME: "{{ .Release.Namespace }}-{{ .Environment.Name }}-asset-upload"
+  ASSET_DOMAIN: "assets.{{ requiredEnv "BASE_DOMAIN" }}"
   BULK_SEND_AWS_BUCKET: "{{ .Release.Namespace }}-{{ .Environment.Name }}-bulk-send"
   CSV_UPLOAD_BUCKET_NAME: "{{ .Release.Namespace }}-{{ .Environment.Name }}-csv-upload"
   IP_GEOLOCATE_SERVICE: "http://ipv4-geolocate.{{ .Release.Namespace }}.svc.cluster.local:8080"


### PR DESCRIPTION
## What happens when your PR merges?

adding missing asset domain variable!

## What are you changing?

- [ ] Releasing a new version of Notify
- [ ] Changing kubernetes configuration

## Checklist if releasing new version

- [ ] I made sure that the changes are as expected in [Notify staging](https://staging.notification.cdssandbox.xyz/)
- [ ] I have checked if the docker images I am referencing exist
  - [ ] [api lambda](https://ca-central-1.console.aws.amazon.com/ecr/repositories/private/296255494825/notify/api-lambda?region=ca-central-1) (requires Notification-Production / AdministratorAccess login)
  - [ ] [api k8s](https://gallery.ecr.aws/v6b8u5o6/notify-api)
  - [ ] [admin](https://gallery.ecr.aws/v6b8u5o6/notify-admin)
  - [ ] [documentation](https://gallery.ecr.aws/v6b8u5o6/notify-documentation)
  - [ ] [document download API](https://gallery.ecr.aws/v6b8u5o6/notify-document-download-api)

## Checklist if making changes to Kubernetes

- [ ] I know how to get kubectl credentials in case it catches on fire

## After merging this PR

- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.
