### PR TITLE
removing DD and Celery variables beacause of all the duplicates

### DIFF
--- a/.github/workflows/helmfile_staging_apply.yaml
+++ b/.github/workflows/helmfile_staging_apply.yaml
@@ -91,6 +91,8 @@ jobs:
 
       - name: Save ENV vars and secrets to AWS Param Store
         run: |
+          # wait for the secrets and env vars to be available
+          sleep 20
           source ./scripts/lambdaParamStoreUpdates.sh -g
           echo DIFF=$DIFF
           echo "ENV_DIFF=$DIFF" >> $GITHUB_ENV

--- a/scripts/lambdaParamStoreUpdates.sh
+++ b/scripts/lambdaParamStoreUpdates.sh
@@ -16,10 +16,7 @@ params=""
 get_env_and_secrets "notify-api"
 # ADMIN
 get_env_and_secrets "notify-admin"
-# DOCUMENT DOWNLOAD
-get_env_and_secrets "notify-document-download" "document-download"
-# CELERY
-get_env_and_secrets "notify-celery-primary" "notify-celery"
+
 params=$(echo -e "$params" | sort -u)
 aws ssm get-parameters --region ca-central-1 --with-decryption --names ENVIRONMENT_VARIABLES --query 'Parameters[*].Value' --output text > .previous.env
 aws ssm put-parameter --region ca-central-1 --name ENVIRONMENT_VARIABLES --type SecureString --key-id alias/aws/ssm --value "$params" --tier "Intelligent-Tiering" --overwrite


### PR DESCRIPTION
## What happens when your PR merges?

removing some env vars from our param store because they are not needed and are creating duplicate keys

## What are you changing?

changing our workflow to no longer pull secrets from celery and DD. Also adding a timer to give helm 20 seconds to finish updating its secrets before we pull them for the parm store.

## Provide some background on the changes

changing our workflow to no longer pull secrets from celery and DD. Also adding a timer to give helm 20 seconds to finish updating its secrets before we pull them for the parm store.

https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/514

## After merging this PR

- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.
