### PR TITLE
Parameterize cluster name in logs

### DIFF
--- a/helmfile/overrides/system/fluentbit-agent.yaml.gotmpl
+++ b/helmfile/overrides/system/fluentbit-agent.yaml.gotmpl
@@ -136,7 +136,7 @@ config:
         Match application.*
         region ${AWS_REGION} 
         log_stream_prefix fallback-stream
-        log_group_name /aws/containerinsights/notification-canada-ca-dev-eks-cluster/application
+        log_group_name /aws/containerinsights/${CLUSTER_NAME}/application
         log_stream_template $kubernetes['container_name']
         auto_create_group on
 
@@ -234,7 +234,7 @@ config:
           Match celery.*
           region ${AWS_REGION} 
           log_stream_prefix fallback-stream
-          log_group_name /aws/containerinsights/notification-canada-ca-dev-eks-cluster/application
+          log_group_name /aws/containerinsights/${CLUSTER_NAME}/application
           log_stream_template $kubernetes['container_name']
           auto_create_group on
 


### PR DESCRIPTION
## What happens when your PR merges?

Change the log group name to ${CLUSTER_NAME}

## What are you changing?

- [ ] Releasing a new version of Notify
- [x] Changing kubernetes configuration

## Provide some background on the changes

Helmfile migration

## After merging this PR

- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.
