### PR TITLE
[MANIFEST] FIX Adding FIDO2_DOMAIN Var to API

### DIFF
--- a/helmfile/charts/notify-api/values.yaml
+++ b/helmfile/charts/notify-api/values.yaml
@@ -37,6 +37,7 @@ api:
   GC_ORGANISATIONS_BUCKET_NAME: "notification-canada-ca-default-gc-organisations"
   HELM_TEST_API: "HELM-IS-RADICAL!-API"
   FIDO2_DOMAIN: "dev.notification.cdssandbox.xyz"
+  BASE_DOMAIN: "dev.notification.cdssandbox.xyz"
 
 apiSecrets:
   ADMIN_CLIENT_SECRET: MANIFEST_ADMIN_CLIENT_SECRET

--- a/helmfile/charts/notify-api/values.yaml
+++ b/helmfile/charts/notify-api/values.yaml
@@ -36,6 +36,7 @@ api:
   FF_PT_SERVICE_SKIP_FRESHDESK: false
   GC_ORGANISATIONS_BUCKET_NAME: "notification-canada-ca-default-gc-organisations"
   HELM_TEST_API: "HELM-IS-RADICAL!-API"
+  FIDO2_DOMAIN: "dev.notification.cdssandbox.xyz"
 
 apiSecrets:
   ADMIN_CLIENT_SECRET: MANIFEST_ADMIN_CLIENT_SECRET

--- a/helmfile/overrides/notify/api.yaml.gotmpl
+++ b/helmfile/overrides/notify/api.yaml.gotmpl
@@ -25,6 +25,7 @@ api:
   FF_PT_SERVICE_SKIP_FRESHDESK: "{{ .StateValues.FF_PT_SERVICE_SKIP_FRESHDESK }}"
   SALESFORCE_DOMAIN: "{{ .StateValues.SALESFORCE_DOMAIN }}"
   GC_ORGANISATIONS_BUCKET_NAME: "{{ .StateValues.GC_ORGANISATIONS_BUCKET_NAME }}"
+  FIDO2_DOMAIN: "{{ requiredEnv "BASE_DOMAIN" }}"
 
 image: 
   tag: "{{ .StateValues.API_DOCKER_TAG }}"


### PR DESCRIPTION
## What happens when your PR merges?

Adding FIDO2_DOMAIN variable to the API. This will fix some errors we have with yubikey and passkey for 2fa in production

## What are you changing?

FIDO2_DOMAIN: "dev.notification.cdssandbox.xyz" (setting this as required by environment)

## Provide some background on the changes

https://docs.google.com/document/d/1055vlAcC2sXZCka1ogH7zU9QeJzASUhQuWJ_yGd3WPk/edit

## Checklist if making changes to Kubernetes

- [x] I know how to get kubectl credentials in case it catches on fire

## After merging this PR

- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.
