### PR TITLE
[MANIFEST] add lambda images to prod helm apply

### DIFF
--- a/.github/workflows/helmfile_production_apply.yaml
+++ b/.github/workflows/helmfile_production_apply.yaml
@@ -13,6 +13,10 @@ env:
   HELMFILE_FILE_PATH: ${{ github.workspace }}/helmfile
   PRODUCTION_AWS_ACCOUNT: ${{ secrets.PRODUCTION_AWS_ACCOUNT_ID }}
   OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN_PRODUCTION }}
+  PRIVATE_ECR: ${{ secrets.PRODUCTION_AWS_ACCOUNT_ID }}.dkr.ecr.ca-central-1.amazonaws.com/notify
+  API_LAMBDA_IMAGE: api-lambda:d901ebf
+  HEARTBEAT_IMAGE: heartbeat:d4082e9
+  SYSTEM_STATUS_IMAGE: system_status:feaaf98
 
 jobs:
   helmfile-apply:
@@ -101,18 +105,21 @@ jobs:
         with:
           alias-name: latest
           function-name: api-lambda
+          image-uri: $PRIVATE_ECR/$API_LAMBDA_IMAGE
 
       - name: Force heartbeat lambda to redeploy on environment changes
         uses: ./.github/actions/update-lambda-function
         with:
           alias-name: latest
           function-name: heartbeat
+          image-uri: $PRIVATE_ECR/$HEARTBEAT_IMAGE
 
       - name: Force system_status to redeploy on environment changes
         uses: ./.github/actions/update-lambda-function
         with:
           alias-name: latest
           function-name: system_status
+          image-uri: $PRIVATE_ECR/$SYSTEM_STATUS_IMAGE
 
       - name: Notify Slack channel if this job failed
         if: ${{ failure() }}


### PR DESCRIPTION
## What happens when your PR merges?


- Prefix the title of your PR:
  - `[MANIFEST]` or `[AUTO-PR]` - tag `main` as a new patch release and deploy to production

## What are you changing?

- [x] Releasing a new version of Notify
- [ ] Changing kubernetes configuration

## Provide some background on the changes

The image tags to release to prod got left behind in #3577 

## If you are releasing a new version of Notify, what components are you updating

- [x] API
- [ ] Admin
- [ ] Documentation
- [ ] Document download API

## Checklist if releasing new version

- [ ] I made sure that the changes are as expected in [Notify staging](https://staging.notification.cdssandbox.xyz/)
- [x] I have checked if the docker images I am referencing exist
  - [x] [api lambda](https://ca-central-1.console.aws.amazon.com/ecr/repositories/private/296255494825/notify/api-lambda?region=ca-central-1) (requires Notification-Production / AdministratorAccess login)
  - [ ] [api k8s](https://gallery.ecr.aws/v6b8u5o6/notify-api)
  - [ ] [admin](https://gallery.ecr.aws/v6b8u5o6/notify-admin)
  - [ ] [documentation](https://gallery.ecr.aws/v6b8u5o6/notify-documentation)
  - [ ] [document download API](https://gallery.ecr.aws/v6b8u5o6/notify-document-download-api)

## Checklist if making changes to Kubernetes

- [ ] I know how to get kubectl credentials in case it catches on fire

## After merging this PR

- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.
