### PR TITLE
Truncate long helmfile diffs

### DIFF
--- a/.github/workflows/helmfile_production_plan.yaml
+++ b/.github/workflows/helmfile_production_plan.yaml
@@ -91,11 +91,10 @@ jobs:
               cat helm_diff.txt
           fi
 
-          echo 'var<<EOF' >> $GITHUB_OUTPUT
+          echo 'diff<<EOF' >> $GITHUB_OUTPUT
           echo $PAYLOAD >> $GITHUB_OUTPUT
           echo 'EOF' >> $GITHUB_OUTPUT
           popd
-    
 
       - name: Production Helmfile Diff Comment
         uses: mshick/add-pr-comment@b8f338c590a895d50bcbfa6c5859251edc8952fc # v2.8.2
@@ -103,6 +102,4 @@ jobs:
           message-id: prod_helmfile_diff
           message: |
             # PRODUCTION HELMFILE DIFF:  
-            ```shell
-            ${{join(steps.helmfile_diff.outputs.*, '\n')}}
-            ```
+            ${{join(steps.helmfile_diff.outputs.diff, '\n')}}

--- a/.github/workflows/helmfile_production_plan.yaml
+++ b/.github/workflows/helmfile_production_plan.yaml
@@ -82,10 +82,19 @@ jobs:
         id: helmfile_diff
         run: |
           pushd helmfile
+          helmfile --environment staging diff >> helm_diff.txt
+          LENGTH=$(wc -m helm_diff.txt | awk '{print $1}')
+          if (( $LENGTH < 65000 )); then
+              PAYLOAD=$(cat helm_diff.txt)
+          else
+              PAYLOAD="Helmfile diff too large to display"
+          fi
+
           echo 'var<<EOF' >> $GITHUB_OUTPUT
-          helmfile --environment production diff >> $GITHUB_OUTPUT
+          echo $PAYLOAD >> $GITHUB_OUTPUT
           echo 'EOF' >> $GITHUB_OUTPUT
           popd
+    
 
       - name: Production Helmfile Diff Comment
         uses: mshick/add-pr-comment@b8f338c590a895d50bcbfa6c5859251edc8952fc # v2.8.2

--- a/.github/workflows/helmfile_production_plan.yaml
+++ b/.github/workflows/helmfile_production_plan.yaml
@@ -87,7 +87,8 @@ jobs:
           if (( $LENGTH < 65000 )); then
               PAYLOAD=$(cat helm_diff.txt)
           else
-              PAYLOAD="Helmfile diff too large to display"
+              PAYLOAD="Helmfile diff too large to display. Check the github actions logs for more details."
+              cat helm_diff.txt
           fi
 
           echo 'var<<EOF' >> $GITHUB_OUTPUT

--- a/.github/workflows/helmfile_production_plan.yaml
+++ b/.github/workflows/helmfile_production_plan.yaml
@@ -82,7 +82,7 @@ jobs:
         id: helmfile_diff
         run: |
           pushd helmfile
-          helmfile --environment staging diff >> helm_diff.txt
+          helmfile --environment production diff >> helm_diff.txt
           LENGTH=$(wc -m helm_diff.txt | awk '{print $1}')
           if (( $LENGTH < 65000 )); then
               PAYLOAD=$(cat helm_diff.txt)

--- a/.github/workflows/helmfile_staging_plan.yaml
+++ b/.github/workflows/helmfile_staging_plan.yaml
@@ -84,7 +84,9 @@ jobs:
               cat helm_diff.txt
           fi
 
-          echo "diff=$PAYLOAD" >> $GITHUB_OUTPUT
+          echo 'diff<<EOF' >> $GITHUB_OUTPUT
+          echo $PAYLOAD >> $GITHUB_OUTPUT
+          echo 'EOF' >> $GITHUB_OUTPUT
           popd
 
       - name: Staging Helmfile Diff Comment

--- a/.github/workflows/helmfile_staging_plan.yaml
+++ b/.github/workflows/helmfile_staging_plan.yaml
@@ -95,6 +95,7 @@ jobs:
           message-id: staging_helmfile_diff
           message: |
             # STAGING HELMFILE DIFF:  
+            ```shell
             ${{join(steps.helmfile_diff.outputs.diff, '\n')}}
-
+            ```
             

--- a/.github/workflows/helmfile_staging_plan.yaml
+++ b/.github/workflows/helmfile_staging_plan.yaml
@@ -84,11 +84,7 @@ jobs:
               cat helm_diff.txt
           fi
 
-          echo 'var<<EOF' >> results.txt
-          echo $PAYLOAD >> results.txt
-          echo 'EOF' >> results.txt
-
-          echo "diff=$(cat results.txt)" >> $GITHUB_OUTPUT
+          echo "diff=$PAYLOAD" >> $GITHUB_OUTPUT
           popd
 
       - name: Staging Helmfile Diff Comment

--- a/.github/workflows/helmfile_staging_plan.yaml
+++ b/.github/workflows/helmfile_staging_plan.yaml
@@ -80,7 +80,8 @@ jobs:
           if (( $LENGTH < 65000 )); then
               PAYLOAD=$(cat helm_diff.txt)
           else
-              PAYLOAD="Helmfile diff too large to display"
+              PAYLOAD="Helmfile diff too large to display. Check the github actions logs for more details."
+              cat helm_diff.txt
           fi
 
           echo 'var<<EOF' >> $GITHUB_OUTPUT

--- a/.github/workflows/helmfile_staging_plan.yaml
+++ b/.github/workflows/helmfile_staging_plan.yaml
@@ -84,9 +84,11 @@ jobs:
               cat helm_diff.txt
           fi
 
-          echo 'var<<EOF' >> $GITHUB_OUTPUT
-          echo $PAYLOAD >> $GITHUB_OUTPUT
-          echo 'EOF' >> $GITHUB_OUTPUT
+          echo 'var<<EOF' >> results.txt
+          echo $PAYLOAD >> results.txt
+          echo 'EOF' >> results.txt
+
+          echo "diff=$(cat results.txt)" >> $GITHUB_OUTPUT
           popd
 
       - name: Staging Helmfile Diff Comment
@@ -95,6 +97,6 @@ jobs:
           message-id: staging_helmfile_diff
           message: |
             # STAGING HELMFILE DIFF:  
-            ${{steps.helmfile_diff.outputs.*}}
+            ${{steps.helmfile_diff.outputs.diff}}
 
             

--- a/.github/workflows/helmfile_staging_plan.yaml
+++ b/.github/workflows/helmfile_staging_plan.yaml
@@ -70,14 +70,24 @@ jobs:
       - name: Load EnvVars
         run: |
             ./helmfile/getContext.sh -g
+
       - name: Helmfile Diff
         id: helmfile_diff
         run: |
           pushd helmfile
+          helmfile --environment staging diff >> helm_diff.txt
+          LENGTH=$(wc -m helm_diff.txt | awk '{print $1}')
+          if (( $LENGTH < 65000 )); then
+              PAYLOAD=$(cat helm_diff.txt)
+          else
+              PAYLOAD="Helmfile diff too large to display"
+          fi
+
           echo 'var<<EOF' >> $GITHUB_OUTPUT
-          helmfile --environment staging diff >> $GITHUB_OUTPUT
+          echo $PAYLOAD >> $GITHUB_OUTPUT
           echo 'EOF' >> $GITHUB_OUTPUT
           popd
+
       - name: Staging Helmfile Diff Comment
         uses: mshick/add-pr-comment@b8f338c590a895d50bcbfa6c5859251edc8952fc # v2.8.2
         with:

--- a/.github/workflows/helmfile_staging_plan.yaml
+++ b/.github/workflows/helmfile_staging_plan.yaml
@@ -95,7 +95,6 @@ jobs:
           message-id: staging_helmfile_diff
           message: |
             # STAGING HELMFILE DIFF:  
-            ```shell
-            ${{join(steps.helmfile_diff.outputs.*, '\n')}}
-            ```
+            ${{steps.helmfile_diff.outputs.*}}
+
             

--- a/.github/workflows/helmfile_staging_plan.yaml
+++ b/.github/workflows/helmfile_staging_plan.yaml
@@ -95,7 +95,6 @@ jobs:
           message-id: staging_helmfile_diff
           message: |
             # STAGING HELMFILE DIFF:  
-            ```shell
             ${{join(steps.helmfile_diff.outputs.diff, '\n')}}
-            ```
+
             

--- a/.github/workflows/helmfile_staging_plan.yaml
+++ b/.github/workflows/helmfile_staging_plan.yaml
@@ -95,6 +95,6 @@ jobs:
           message-id: staging_helmfile_diff
           message: |
             # STAGING HELMFILE DIFF:  
-            ${{steps.helmfile_diff.outputs.diff}}
+            ${{join(steps.helmfile_diff.outputs.diff, '\n')}}
 
             


### PR DESCRIPTION
## What happens when your PR merges?

This will hopefully prevent long helmfile diffs from crashing PRs.

## What are you changing?

- [ ] Releasing a new version of Notify
- [ ] Changing kubernetes configuration
- [x] Github actions

## After merging this PR

- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.
