### PR TITLE
Helmfile diff multiline fix

### DIFF
--- a/.github/workflows/helmfile_production_plan.yaml
+++ b/.github/workflows/helmfile_production_plan.yaml
@@ -92,7 +92,7 @@ jobs:
           fi
 
           echo 'diff<<EOF' >> $GITHUB_OUTPUT
-          echo $PAYLOAD >> $GITHUB_OUTPUT
+          echo "$PAYLOAD" >> $GITHUB_OUTPUT
           echo 'EOF' >> $GITHUB_OUTPUT
           popd
 
@@ -102,4 +102,6 @@ jobs:
           message-id: prod_helmfile_diff
           message: |
             # PRODUCTION HELMFILE DIFF:  
+            ```shell
             ${{join(steps.helmfile_diff.outputs.diff, '\n')}}
+            ```

--- a/.github/workflows/helmfile_staging_plan.yaml
+++ b/.github/workflows/helmfile_staging_plan.yaml
@@ -95,6 +95,7 @@ jobs:
           message-id: staging_helmfile_diff
           message: |
             # STAGING HELMFILE DIFF:  
+            ```shell
             ${{join(steps.helmfile_diff.outputs.diff, '\n')}}
-
+            ```
             

--- a/.github/workflows/helmfile_staging_plan.yaml
+++ b/.github/workflows/helmfile_staging_plan.yaml
@@ -85,7 +85,7 @@ jobs:
           fi
 
           echo 'diff<<EOF' >> $GITHUB_OUTPUT
-          echo $PAYLOAD >> $GITHUB_OUTPUT
+          echo "$PAYLOAD" >> $GITHUB_OUTPUT
           echo 'EOF' >> $GITHUB_OUTPUT
           popd
 
@@ -95,6 +95,6 @@ jobs:
           message-id: staging_helmfile_diff
           message: |
             # STAGING HELMFILE DIFF:  
-            "${{join(steps.helmfile_diff.outputs.diff, '\n')}}"
+            ${{join(steps.helmfile_diff.outputs.diff, '\n')}}
 
             

--- a/.github/workflows/helmfile_staging_plan.yaml
+++ b/.github/workflows/helmfile_staging_plan.yaml
@@ -95,6 +95,6 @@ jobs:
           message-id: staging_helmfile_diff
           message: |
             # STAGING HELMFILE DIFF:  
-            ${{join(steps.helmfile_diff.outputs.diff, '\n')}}
+            "${{join(steps.helmfile_diff.outputs.diff, '\n')}}"
 
             


### PR DESCRIPTION
## What happens when your PR merges?

When adding the logic to detect helmfile diff comments that were too long, I broke multi-line comments. This fixes that while keeping the too long logic.


- [ ] Releasing a new version of Notify
- [ ] Changing kubernetes configuration
- [x] Github actions

## After merging this PR

- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.
