### PR TITLE
removing reference to alb ingress controller for kustomize

### DIFF
--- a/base/notify-system/kustomization.yaml
+++ b/base/notify-system/kustomization.yaml
@@ -1,6 +1,5 @@
 resources:
   - namespace.yaml
-  - alb-ingress-controller.yaml
   - metrics-server.yaml
   - priority-classes.yaml
   


### PR DESCRIPTION
## What happens when your PR merges?

Removing the reference to the alb ingress controller in kustomize.yaml 
Still need the actual file for the migration.

This will not do anything in staging/prod since Kustomize doesn't delete resources.

## What are you changing?

- [ ] Releasing a new version of Notify
- [x] Changing kubernetes configuration

## Provide some background on the changes

Helmfile migration

## After merging this PR

- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.
