### PR TITLE
Cloudwatch agent in prod

### DIFF
--- a/helmfile/helmfile.yaml
+++ b/helmfile/helmfile.yaml
@@ -266,6 +266,19 @@ releases:
     values:
     - ./overrides/system/cert-manager.yaml.gotmpl
 
+  - name: aws-cloudwatch-agent
+    namespace: amazon-cloudwatch
+    disableValidationOnInstall: true
+    disableValidation: true 
+    labels:
+      app: aws-cloudwatch-agent
+      tier: backend
+      category: system
+      step: 1
+    chart: charts/aws-cloudwatch
+    values:
+    - ./overrides/system/aws-cloudwatch-agent.yaml.gotmpl
+
 {{- if or (eq .Environment.Name "dev") (eq .Environment.Name "staging") }}
 
   - name: target-group-crds
@@ -291,19 +304,6 @@ releases:
     values:
     - ./overrides/system/aws-lb-controller.yaml.gotmpl
  
-  - name: aws-cloudwatch-agent
-    namespace: amazon-cloudwatch
-    disableValidationOnInstall: true
-    disableValidation: true 
-    labels:
-      app: aws-cloudwatch-agent
-      tier: backend
-      category: system
-      step: 1
-    chart: charts/aws-cloudwatch
-    values:
-    - ./overrides/system/aws-cloudwatch-agent.yaml.gotmpl
-
   - name: metrics-server
     namespace: kube-system
     labels:


### PR DESCRIPTION
## What happens when your PR merges?

Moving cloudwatch agent to helmfile in prod.

## What are you changing?

- [ ] Releasing a new version of Notify
- [x] Changing kubernetes configuration

## Provide some background on the changes

Helmfile migration

## Release instructions
Delete the cwagent yaml from kustomize in prod before merging.

## After merging this PR

- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.
