### PR TITLE
[MANIFEST] metrics server prod

### DIFF
--- a/helmfile/helmfile.yaml
+++ b/helmfile/helmfile.yaml
@@ -301,8 +301,6 @@ releases:
     chart: eks/aws-load-balancer-controller
     values:
     - ./overrides/system/aws-lb-controller.yaml.gotmpl    
-
-{{- if or (eq .Environment.Name "dev") (eq .Environment.Name "staging") }}
  
   - name: metrics-server
     namespace: kube-system
@@ -313,5 +311,3 @@ releases:
       step: 1
     chart: metrics-server/metrics-server
     version: 3.12.2
-
-{{- end }}


### PR DESCRIPTION
## What happens when your PR merges?

Metrics server moved to helmfile for prod

## What are you changing?

- [ ] Releasing a new version of Notify
- [x] Changing kubernetes configuration

## Provide some background on the changes

Helmfile migration

## After merging this PR

- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.
