### PR TITLE
changing the job to linger for 24 hours

### DIFF
--- a/helmfile/charts/notify-database/templates/upgrade-database-job.yaml
+++ b/helmfile/charts/notify-database/templates/upgrade-database-job.yaml
@@ -9,7 +9,7 @@ metadata:
     release: {{ .Release.Name }}
 spec:
   backoffLimit: 3
-  ttlSecondsAfterFinished: 34560
+  ttlSecondsAfterFinished: {{ .Values.ttlSecondsAfterFinished }}
   template:
     metadata:
       labels:

--- a/helmfile/charts/notify-database/templates/upgrade-database-job.yaml
+++ b/helmfile/charts/notify-database/templates/upgrade-database-job.yaml
@@ -9,7 +9,7 @@ metadata:
     release: {{ .Release.Name }}
 spec:
   backoffLimit: 3
-  ttlSecondsAfterFinished: 100
+  ttlSecondsAfterFinished: 34560
   template:
     metadata:
       labels:

--- a/helmfile/charts/notify-database/values.yaml
+++ b/helmfile/charts/notify-database/values.yaml
@@ -4,6 +4,8 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   tag: "latest"
 
+ttlSecondsAfterFinished: 34560
+
 serviceAccount:
   create: true
   serviceAccountName: "notify-api"


### PR DESCRIPTION
## What happens when your PR merges?

DB upgrade jobs will linger for 24 hours in case we want to easily debug the job.

## What are you changing?

helm configuration for the notify-database helm chart

## Provide some background on the changes

We are running the DB upgrade in a K8s job now and we wanted to have the job linger for 24 hours after running.  This PR sets that configuration.


## Checklist if making changes to Kubernetes

- [x] I know how to get kubectl credentials in case it catches on fire

## After merging this PR

- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.
