### PR TITLE
Removing old DB Upgrade from Production API Pod

### DIFF
--- a/helmfile/charts/notify-api/templates/deployment.yaml
+++ b/helmfile/charts/notify-api/templates/deployment.yaml
@@ -33,53 +33,6 @@ spec:
       terminationGracePeriodSeconds: 60
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
-      {{- if eq .Values.environment "production" }}
-      initContainers:
-        - name: init-postgres
-          image: alpine
-          command:
-            [
-              "sh",
-              "-c",
-              "until nslookup $POSTGRES_HOST; do echo waiting for postgres; sleep 2; done;",
-            ]
-          env:
-            - name: POSTGRES_HOST
-              valueFrom:
-                secretKeyRef:
-                  name: notify-api
-                  key: POSTGRES_HOST   
-        - name: migrate-db
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          volumeMounts:
-            - name: secrets-store-inline
-              mountPath: "/mnt/secrets-store"
-              readOnly: true   
-          env:
-            # Includes common ENV Variables
-            {{- range $key, $val := .Values.api }}
-            - name: {{ $key }}
-              value: {{ $val | quote }}
-            {{- end }}
-            # Includes secret ENV Variables
-            {{- range $key, $val := .Values.apiSecrets }}
-            - name: {{ $key }}
-              valueFrom:
-                secretKeyRef:
-                  name: notify-api
-                  key: {{ $key }}
-            {{- end }}
-            - name: STATSD_HOST
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
-          command:
-            [
-              "sh",
-              "-c",
-              "flask db upgrade || echo 'ERROR: database migration failed'",
-            ]
-      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:

--- a/helmfile/overrides/notify/api.yaml.gotmpl
+++ b/helmfile/overrides/notify/api.yaml.gotmpl
@@ -110,4 +110,3 @@ pdb:
   enabled: {{ if eq .Environment.Name "production" }} true {{ else if eq .Environment.Name "staging" }} true {{ else }} true {{ end }}
   minAvailable: {{ if eq .Environment.Name "production" }} 1 {{ else if eq .Environment.Name "staging" }} 1 {{ else }} 1 {{ end }}
 
-environment: "{{ .Environment.Name }}"


### PR DESCRIPTION
## What happens when your PR merges?

The K8s API Pod will no longer have the DB upgrade code run during its deployment.  This is now done in a separate step/pod prior to deploying the API.  The Lambda API and K8s API  deployments will both now be independent of the API K8s deployment.

## What are you changing?

Updating the API K8s deployment (Helmfile) file to remove the DB upgrade scripts.

## Provide some background on the changes

https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/20

## Checklist if making changes to Kubernetes

- [x] I know how to get kubectl credentials in case it catches on fire

## After merging this PR

- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.
