### PR TITLE
adding step label to db upgrade job for new env creation

### DIFF
--- a/helmfile/helmfile.yaml
+++ b/helmfile/helmfile.yaml
@@ -49,6 +49,7 @@ releases:
       app: notify-database
       tier: database
       category: deliverable
+      step: 4
     chart: charts/notify-database
     values:
     - ./overrides/notify/api.yaml.gotmpl 


### PR DESCRIPTION
## What happens when your PR merges?

We need the database upgrade job to run before API fires up on new environment creation. Setting the helmfile label as step 4 so that it gets run as a pre-req.

## What are you changing?

- [ ] Releasing a new version of Notify
- [x] Changing kubernetes configuration

## Provide some background on the changes

Dev env creation

## After merging this PR

- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.
