### PR TITLE
adding node selectors to system critical apps

### DIFF
--- a/helmfile/helmfile.yaml
+++ b/helmfile/helmfile.yaml
@@ -118,6 +118,8 @@ releases:
       step: 2
     chart: oci://ghcr.io/deliveryhero/helm-charts/k8s-event-logger
     version: 1.1.8
+    values:
+      - ./overrides/system/k8s-event-logger.yaml.gotmpl
 
   - name: karpenter-crd
     namespace: karpenter
@@ -322,3 +324,5 @@ releases:
       step: 1
     chart: metrics-server/metrics-server
     version: 3.12.2
+    values:
+    - ./overrides/system/metrics-server.yaml.gotmpl

--- a/helmfile/overrides/system/aws-lb-controller.yaml.gotmpl
+++ b/helmfile/overrides/system/aws-lb-controller.yaml.gotmpl
@@ -3,3 +3,6 @@ serviceAccount:
     create: true
     name: aws-load-balancer-controller
 enableCertManager: true
+
+nodeSelector:  
+  eks.amazonaws.com/capacityType: ON_DEMAND

--- a/helmfile/overrides/system/k8s-event-logger.yaml.gotmpl
+++ b/helmfile/overrides/system/k8s-event-logger.yaml.gotmpl
@@ -1,5 +1,2 @@
-crds:
-    enabled: true
-
 nodeSelector:  
   eks.amazonaws.com/capacityType: ON_DEMAND

--- a/helmfile/overrides/system/karpenter.yaml.gotmpl
+++ b/helmfile/overrides/system/karpenter.yaml.gotmpl
@@ -8,3 +8,6 @@ settings:
 nodeClass:
   amiSelectorTerms:
     - id: {{ requiredEnv "EKS_KARPENTER_AMI_ID" }}
+
+nodeSelector:  
+  eks.amazonaws.com/capacityType: ON_DEMAND

--- a/helmfile/overrides/system/kube-state-metrics.yaml.gotmpl
+++ b/helmfile/overrides/system/kube-state-metrics.yaml.gotmpl
@@ -12,3 +12,6 @@ selfMonitor:
   # telemetryHost: 0.0.0.0
   # telemetryPort: 8081
   # telemetryNodePort: 0
+
+nodeSelector:  
+  eks.amazonaws.com/capacityType: ON_DEMAND

--- a/helmfile/overrides/system/metrics-server.yaml.gotmpl
+++ b/helmfile/overrides/system/metrics-server.yaml.gotmpl
@@ -1,5 +1,2 @@
-crds:
-    enabled: true
-
 nodeSelector:  
   eks.amazonaws.com/capacityType: ON_DEMAND


### PR DESCRIPTION
## What happens when your PR merges?

Trying to investigate the 504 gateway timeouts. I can sometimes correlate a node being recycled around the time the 504 appears. When we switched from Kustomize to Helmfile we didn't always add the node selector for system critical apps to be ON_DEMAND. Adding that here. Not 100% sure this will fix anything but it should be there anyway.

## What are you changing?

- [ ] Releasing a new version of Notify
- [x] Changing kubernetes configuration

## Provide some background on the changes

Investigating 504 errors in prod

## After merging this PR

- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.
