### PR TITLE
adding workflows to run latest db upgrade manually

### DIFF
--- a/.github/workflows/db_production_upgrade_manual.yaml
+++ b/.github/workflows/db_production_upgrade_manual.yaml
@@ -1,0 +1,86 @@
+name: Production - Manual DB Upgrade
+
+on:
+  workflow_dispatch:
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  HELMFILE_FILE_PATH: ${{ github.workspace }}/helmfile
+  PRODUCTION_AWS_ACCOUNT: ${{ secrets.PRODUCTION_AWS_ACCOUNT_ID }}
+  OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN_PRODUCTION }}
+  
+jobs:
+  helmfile-apply:
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Inject token authentication
+        run: |
+          git config --global url."https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/".insteadOf "https://github.com/"
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
+        id: awsconfig
+        with:
+          aws-access-key-id: ${{ secrets.PRODUCTION_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.PRODUCTION_AWS_SECRET_ACCESS_KEY }}
+          aws-region: ca-central-1
+
+      - name: Checkout
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+        with:
+          # Fetches entire history, so we can analyze commits since last tag
+          fetch-depth: 0
+
+      - name: Setup helmfile
+        uses: mamezou-tech/setup-helmfile@03233e1cd9b19b2ba320e431f7bcc0618db4248d # v2.0.0
+        with:
+          install-kubectl: yes
+          install-helm: yes       
+          helmfile-version: "v0.151.0"
+          helm-s3-plugin-version: "v0.16.2"
+
+      - name: Install OpenVPN
+        run: |
+          sudo apt update
+          sudo apt install -y openvpn openvpn-systemd-resolved
+
+      - name: Setup Terraform tools
+        uses: cds-snc/terraform-tools-setup@v1
+        env: # In case you want to override default versions
+          CONFTEST_VERSION: 0.30.0 
+          TERRAFORM_VERSION: 1.9.5
+          TERRAGRUNT_VERSION: 0.66.9
+          TF_SUMMARIZE_VERSION: 0.2.3                           
+
+      - name: Install 1Pass CLI
+        run: |
+          curl -o 1pass.deb https://downloads.1password.com/linux/debian/amd64/stable/1password-cli-amd64-latest.deb
+          sudo dpkg -i 1pass.deb 
+
+      - name: Retrieve VPN Config
+        run: |
+          scripts/createVPNConfig.sh production 2> /dev/null   
+
+      - name: Connect to VPN
+        uses: "kota65535/github-openvpn-connect-action@cd2ed8a90cc7b060dc4e001143e811b5f7ea0af5" # v3.1.0
+        with:
+          config_file: /var/tmp/production.ovpn
+          echo_config: false            
+
+      - name: Configure kubeconfig
+        run: |
+          aws eks update-kubeconfig --name notification-canada-ca-production-eks-cluster --alias production
+
+      - name: Load Context Variables
+        run: |
+            ./helmfile/getContext.sh -g
+
+      - name: Run Database Upgrade Helmfile Sync
+        uses: ./.github/actions/db-upgrade
+        with:
+          environment: "production"
+          namespace: "notification-canada-ca"
+          app_label: "notify-database"
+          timeout: "400s"
+

--- a/.github/workflows/db_staging_upgrade_manual.yaml
+++ b/.github/workflows/db_staging_upgrade_manual.yaml
@@ -1,0 +1,85 @@
+name: Staging - Manual DB Upgrade
+
+on:
+  workflow_dispatch:
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  HELMFILE_FILE_PATH: ${{ github.workspace }}/helmfile
+  STAGING_AWS_ACCOUNT: ${{ secrets.STAGING_AWS_ACCOUNT_ID }}
+  OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN_STAGING }}
+
+jobs:
+  helmfile-apply:
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Inject token authentication
+        run: |
+          git config --global url."https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/".insteadOf "https://github.com/"
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
+        id: awsconfig
+        with:
+          aws-access-key-id: ${{ secrets.STAGING_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.STAGING_AWS_SECRET_ACCESS_KEY }}
+          aws-region: ca-central-1
+
+      - name: Checkout
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+        with:
+          # Fetches entire history, so we can analyze commits since last tag
+          fetch-depth: 0        
+
+      - name: Setup helmfile
+        uses: mamezou-tech/setup-helmfile@03233e1cd9b19b2ba320e431f7bcc0618db4248d # v2.0.0
+        with:
+          install-kubectl: yes
+          install-helm: yes        
+          helmfile-version: "v0.151.0"
+          helm-s3-plugin-version: "v0.16.2"
+
+      - name: Install OpenVPN
+        run: |
+          sudo apt update
+          sudo apt install -y openvpn openvpn-systemd-resolved
+
+      - name: Install 1Pass CLI
+        run: |
+          curl -o 1pass.deb https://downloads.1password.com/linux/debian/amd64/stable/1password-cli-amd64-latest.deb
+          sudo dpkg -i 1pass.deb 
+
+      - name: Setup Terraform tools
+        uses: cds-snc/terraform-tools-setup@v1
+        env: # In case you want to override default versions
+          CONFTEST_VERSION: 0.30.0 
+          TERRAFORM_VERSION: 1.9.5
+          TERRAGRUNT_VERSION: 0.66.9
+          TF_SUMMARIZE_VERSION: 0.2.3                    
+
+      - name: Retrieve VPN Config
+        run: |
+          scripts/createVPNConfig.sh staging 2> /dev/null  
+
+      - name: Connect to VPN
+        uses: "kota65535/github-openvpn-connect-action@cd2ed8a90cc7b060dc4e001143e811b5f7ea0af5" # v3.1.0
+        with:
+          config_file: /var/tmp/staging.ovpn
+          echo_config: false            
+
+      - name: Configure kubeconfig
+        run: |
+          aws eks update-kubeconfig --name notification-canada-ca-staging-eks-cluster --alias staging 
+
+      - name: Load Context Variables
+        run: |
+            ./helmfile/getContext.sh -g
+             
+      - name: Run Database Upgrade Helmfile Sync
+        uses: ./.github/actions/db-upgrade
+        with:
+          environment: "staging"
+          namespace: "notification-canada-ca"
+          app_label: "notify-database"
+          timeout: "400s"


### PR DESCRIPTION
## What happens when your PR merges?

Nothing, this will only run if manually triggered

## What are you changing?

Updates to our Github Workflows (adding two) for Prod and Staging to run the latest API tag DB upgrade script.

## Checklist if making changes to Kubernetes

- [x] I know how to get kubectl credentials in case it catches on fire

## After merging this PR

- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.
