### PR TITLE
Enabled cwagent logging for environments, lowered flush value for dev.

### DIFF
--- a/env/dev/cwagent-configmap.yaml
+++ b/env/dev/cwagent-configmap.yaml
@@ -1,0 +1,73 @@
+kind: ConfigMap
+metadata:
+  name: prometheus-cwagentconfig
+  namespace: amazon-cloudwatch
+apiVersion: v1
+data:
+  # cwagent json config
+  cwagentconfig.json: |
+    {
+      "agent": {
+        "region": "ca-central-1",
+        "debug": true,
+        "aws_sdk_log_level": "LogDebug",
+        "metrics_collection_interval": 15
+      },
+      "logs": {
+        "metrics_collected": {
+          "prometheus": {
+            "cluster_name": "notification-canada-ca-dev-eks-cluster",
+            "log_group_name": "/aws/containerinsights/notification-canada-ca-dev-eks-cluster/prometheus",
+            "prometheus_config_path": "/etc/prometheusconfig/prometheus.yaml",
+            "emf_processor": {
+              "metric_declaration": [
+                {"source_labels": ["job", "resource"],
+                  "label_matcher": "^kubernetes-apiservers;(services|daemonsets.apps|deployments.apps|configmaps|endpoints|secrets|serviceaccounts|replicasets.apps)",
+                  "dimensions": [["ClusterName","Service","resource"]],
+                  "metric_selectors": [
+                  ".*"
+                  ]
+                },
+                {"source_labels": ["job", "name"],
+                  "label_matcher": "^kubernetes-apiservers;APIServiceRegistrationController$",
+                  "dimensions": [["ClusterName","Service","name"]],
+                  "metric_selectors": [
+                  ".*"
+                  ]
+                },
+                {"source_labels": ["job","code"],
+                  "label_matcher": "^kubernetes-apiservers;2[0-9]{2}$",
+                  "dimensions": [["ClusterName","Service","code"]],
+                  "metric_selectors": [
+                  ".*"
+                  ]
+                },
+                {"source_labels": ["job"],
+                  "label_matcher": "^kubernetes-apiservers",
+                  "dimensions": [["ClusterName","Service"]],
+                  "metric_selectors": [
+                  ".*"
+                  ]
+                },
+                {"source_labels": ["job", "resource"],
+                  "label_matcher": ".*kube-state-metrics.*",
+                  "dimensions": [["ClusterName","namespace", "deployment"]],
+                  "metric_selectors": [
+                  "^kube_deployment_.*"
+                  ]
+                },
+                {"source_labels": ["job", "resource"],
+                  "label_matcher": ".*kube-state-metrics.*",
+                  "dimensions": [["ClusterName","namespace", "pod"]],
+                  "metric_selectors": [
+                  "^kube_pod_.*"
+                  ]
+                }
+              ]
+            }
+          }
+        },
+        "force_flush_interval": 5
+      }
+    }
+

--- a/helmfile/charts/aws-cloudwatch/templates/cwagent-configmap.yaml
+++ b/helmfile/charts/aws-cloudwatch/templates/cwagent-configmap.yaml
@@ -8,7 +8,9 @@ data:
   cwagentconfig.json: |
     {	
       "agent":{	
-          "region":"ca-central-1"	
+          "region": "ca-central-1",
+          "debug": true,
+          "aws_sdk_log_level": "LogDebug"
       },	
       "logs":{	
           "metrics_collected":{	


### PR DESCRIPTION
## What happens when your PR merges?

- Prefix the title of your PR:
  - `fix:` - tag `main` as a new patch release
  - `feat:` - tag `main` as a new minor release
  - `BREAKING CHANGE:` - tag `main` as a new major release
  - `[MANIFEST]` or `[AUTO-PR]` - tag `main` as a new patch release and deploy to production
  - `chore:` - use for changes to non-app code (ex: GitHub actions)
- Alternatively, change the [VERSION file](https://github.com/cds-snc/notification-manifests/blob/main/VERSION) - this will not create a new tag, but rather will release the tag in `VERSION` to production.

## What are you changing?

- [ ] Releasing a new version of Notify
- [ ] Changing kubernetes configuration

## Provide some background on the changes

We need debug enabled as we are investigating connection issues between our Celery pods and the cwagent daemons.

## If you are releasing a new version of Notify, what components are you updating

- [ ] API
- [ ] Admin
- [ ] Documentation
- [ ] Document download API

## Checklist if releasing new version

- [ ] I made sure that the changes are as expected in [Notify staging](https://staging.notification.cdssandbox.xyz/)
- [ ] I have checked if the docker images I am referencing exist
  - [ ] [api lambda](https://ca-central-1.console.aws.amazon.com/ecr/repositories/private/296255494825/notify/api-lambda?region=ca-central-1) (requires Notification-Production / AdministratorAccess login)
  - [ ] [api k8s](https://gallery.ecr.aws/v6b8u5o6/notify-api)
  - [ ] [admin](https://gallery.ecr.aws/v6b8u5o6/notify-admin)
  - [ ] [documentation](https://gallery.ecr.aws/v6b8u5o6/notify-documentation)
  - [ ] [document download API](https://gallery.ecr.aws/v6b8u5o6/notify-document-download-api)

## Checklist if making changes to Kubernetes

- [ ] I know how to get kubectl credentials in case it catches on fire

## After merging this PR

- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.
