### PR TITLE
[MANIFEST] fix cw agent config for prod

### DIFF
--- a/helmfile/charts/aws-cloudwatch/templates/cwagent-configmap.yaml
+++ b/helmfile/charts/aws-cloudwatch/templates/cwagent-configmap.yaml
@@ -8,10 +8,12 @@ data:
   cwagentconfig.json: |
     {	
       "agent":{	
-          "region": "ca-central-1",
           {{ if .Values.debug}}
+          "region": "ca-central-1",
           "debug": true,
           "aws_sdk_log_level": "LogDebug"
+          {{ else }}
+          "region": "ca-central-1"
           {{ end }}
       },	
       "logs":{	


### PR DESCRIPTION
## What happens when your PR merges?

Cloudwatch agent config was breaking in prod due to additional comma.

## What are you changing?

- [ ] Releasing a new version of Notify
- [x] Changing kubernetes configuration

## Provide some background on the changes

Broken release

## After merging this PR

- [x] I have verified that the tests / deployment actions succeeded
- [x] I have verified that any affected pods were restarted successfully
- [x] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.
