### PR TITLE
Karpenter IMDSv2 fix

### DIFF
--- a/helmfile/charts/karpenter-nodepool/templates/nodeclass.yaml
+++ b/helmfile/charts/karpenter-nodepool/templates/nodeclass.yaml
@@ -16,6 +16,11 @@ spec:
         karpenter.sh/discovery: "{{ .Values.settings.clusterName }}" # replace with your cluster name
   amiSelectorTerms:
     - alias: al2023@latest # Amazon Linux 2023
+  metadataOptions:
+    httpEndpoint: enabled
+    httpProtocolIPv6: disabled
+    httpPutResponseHopLimit: 2 # This is changed to disable IMDS access from containers not on the host network
+    httpTokens: required
 
 {{ else }}
 

--- a/helmfile/charts/karpenter-nodepool/templates/nodeclass.yaml
+++ b/helmfile/charts/karpenter-nodepool/templates/nodeclass.yaml
@@ -19,7 +19,7 @@ spec:
   metadataOptions:
     httpEndpoint: enabled
     httpProtocolIPv6: disabled
-    httpPutResponseHopLimit: 2 # This is changed to disable IMDS access from containers not on the host network
+    httpPutResponseHopLimit: 2
     httpTokens: required
 
 {{ else }}


### PR DESCRIPTION
## What happens when your PR merges?

Cloudwatch agents running on karpenter spot nodes were not able to read IMDSv2 metadata and that seemed to cause a significant delay in startup. I've fixed this by adding maxhops 2, which will allow the cloudwatch agent to read the VM metadata.

## What are you changing?

- [ ] Releasing a new version of Notify
- [x] Changing kubernetes configuration

## Provide some background on the changes

Karpenter upgrade

## After merging this PR

- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.
