### PR TITLE
Docker Image Pull Secrets Fix

### DIFF
--- a/helmfile/charts/notify-admin/templates/imagePullSecret.yaml
+++ b/helmfile/charts/notify-admin/templates/imagePullSecret.yaml
@@ -5,5 +5,5 @@ metadata:
   namespace: {{ .Release.Namespace }}
 type:  kubernetes.io/dockerconfigjson
 stringData:
-  .dockerconfigjson: '{"auths":{"https://index.docker.io/v1/":{"username":"{ .Values.dockerhub.username }","password":"{ .Values.dockerhub.pat }"}}}'
+  .dockerconfigjson: "{\"auths\":{\"https://index.docker.io/v1/\":{\"username\":\"{{ .Values.dockerhub.username }}\",\"password\":\"{{ .Values.dockerhub.pat }}\"}}}"
     

--- a/helmfile/charts/notify-admin/templates/serviceaccount.yaml
+++ b/helmfile/charts/notify-admin/templates/serviceaccount.yaml
@@ -12,9 +12,9 @@ metadata:
   {{- with .Values.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
-  imagePullSecrets:
-    - name: admin-image-pull-secret
   {{- end }}
+imagePullSecrets:
+  - name: admin-image-pull-secret
 {{- end }}
 
   

--- a/helmfile/charts/notify-api/templates/imagePullSecret.yaml
+++ b/helmfile/charts/notify-api/templates/imagePullSecret.yaml
@@ -5,5 +5,5 @@ metadata:
   namespace: {{ .Release.Namespace }}
 type:  kubernetes.io/dockerconfigjson
 stringData:
-  .dockerconfigjson: '{"auths":{"https://index.docker.io/v1/":{"username":"{ .Values.dockerhub.username }","password":"{ .Values.dockerhub.pat }"}}}'
+  .dockerconfigjson: "{\"auths\":{\"https://index.docker.io/v1/\":{\"username\":\"{{ .Values.dockerhub.username }}\",\"password\":\"{{ .Values.dockerhub.pat }}\"}}}"
     

--- a/helmfile/charts/notify-api/templates/serviceaccount.yaml
+++ b/helmfile/charts/notify-api/templates/serviceaccount.yaml
@@ -8,7 +8,7 @@ metadata:
   {{- with .Values.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
-  imagePullSecrets:
-    - name: admin-image-pull-secret
   {{- end }}
+imagePullSecrets:
+  - name: api-image-pull-secret
 {{- end }}

--- a/helmfile/charts/notify-celery/templates/imagePullSecret.yaml
+++ b/helmfile/charts/notify-celery/templates/imagePullSecret.yaml
@@ -5,5 +5,5 @@ metadata:
   namespace: {{ .Release.Namespace }}
 type:  kubernetes.io/dockerconfigjson
 stringData:
-  .dockerconfigjson: '{"auths":{"https://index.docker.io/v1/":{"username":"{ .Values.dockerhub.username }","password":"{ .Values.dockerhub.pat }"}}}'
+  .dockerconfigjson: "{\"auths\":{\"https://index.docker.io/v1/\":{\"username\":\"{{ .Values.dockerhub.username }}\",\"password\":\"{{ .Values.dockerhub.pat }}\"}}}"
     

--- a/helmfile/charts/notify-celery/templates/serviceaccount.yaml
+++ b/helmfile/charts/notify-celery/templates/serviceaccount.yaml
@@ -8,7 +8,7 @@ metadata:
   {{- with .Values.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
-  imagePullSecrets:
-    - name: admin-image-pull-secret    
   {{- end }}
+imagePullSecrets:
+  - name: celery-image-pull-secret
 {{- end }}

--- a/helmfile/charts/notify-document-download/templates/imagePullSecret.yaml
+++ b/helmfile/charts/notify-document-download/templates/imagePullSecret.yaml
@@ -5,5 +5,5 @@ metadata:
   namespace: {{ .Release.Namespace }}
 type:  kubernetes.io/dockerconfigjson
 stringData:
-  .dockerconfigjson: '{"auths":{"https://index.docker.io/v1/":{"username":"{ .Values.dockerhub.username }","password":"{ .Values.dockerhub.pat }"}}}'
+  .dockerconfigjson: "{\"auths\":{\"https://index.docker.io/v1/\":{\"username\":\"{{ .Values.dockerhub.username }}\",\"password\":\"{{ .Values.dockerhub.pat }}\"}}}"
     

--- a/helmfile/charts/notify-document-download/templates/serviceaccount.yaml
+++ b/helmfile/charts/notify-document-download/templates/serviceaccount.yaml
@@ -9,6 +9,7 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  imagePullSecrets:
-    - name: admin-image-pull-secret  
+imagePullSecrets:
+  - name: document-download-image-pull-secret
 {{- end }}
+

--- a/helmfile/overrides/notify/admin.yaml.gotmpl
+++ b/helmfile/overrides/notify/admin.yaml.gotmpl
@@ -64,7 +64,7 @@ image:
 
 dockerhub:
   username: {{ requiredEnv "MANIFEST_DOCKER_HUB_USERNAME" }}
-  password: {{ requiredEnv "MANIFEST_DOCKER_HUB_PAT" }}
+  pat: {{ requiredEnv "MANIFEST_DOCKER_HUB_PAT" }}
 
 serviceAccount:
   annotations:

--- a/helmfile/overrides/notify/api.yaml.gotmpl
+++ b/helmfile/overrides/notify/api.yaml.gotmpl
@@ -92,7 +92,7 @@ image:
 
 dockerhub:
   username: {{ requiredEnv "MANIFEST_DOCKER_HUB_USERNAME" }}
-  password: {{ requiredEnv "MANIFEST_DOCKER_HUB_PAT" }}
+  pat: {{ requiredEnv "MANIFEST_DOCKER_HUB_PAT" }}
 
 serviceAccount:
   annotations:

--- a/helmfile/overrides/notify/celery.yaml.gotmpl
+++ b/helmfile/overrides/notify/celery.yaml.gotmpl
@@ -58,7 +58,7 @@ image:
 
 dockerhub:
   username: {{ requiredEnv "MANIFEST_DOCKER_HUB_USERNAME" }}
-  password: {{ requiredEnv "MANIFEST_DOCKER_HUB_PAT" }}
+  pat: {{ requiredEnv "MANIFEST_DOCKER_HUB_PAT" }}
 
 serviceAccount:
   annotations:

--- a/helmfile/overrides/notify/document-download.yaml.gotmpl
+++ b/helmfile/overrides/notify/document-download.yaml.gotmpl
@@ -31,7 +31,7 @@ image:
 
 dockerhub:
   username: {{ requiredEnv "MANIFEST_DOCKER_HUB_USERNAME" }}
-  password: {{ requiredEnv "MANIFEST_DOCKER_HUB_PAT" }}
+  pat: {{ requiredEnv "MANIFEST_DOCKER_HUB_PAT" }}
 
 serviceAccount:
   annotations:


### PR DESCRIPTION
## What happens when your PR merges?

I had the docker image pull secret in the wrong place and also screwed up the naming. All in all,  a complete failure on my part. I've verified this fixes it.

## What are you changing?

- [ ] Releasing a new version of Notify
- [x] Changing kubernetes configuration

## Provide some background on the changes

Docker 429 rate limit

## After merging this PR

- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.
