### PR TITLE
Submitted a newly crafted github action to test the pw protected gh action workflow

### DIFF
--- a/.github/workflows/database_migration_staging_manual_pwprotected.yaml
+++ b/.github/workflows/database_migration_staging_manual_pwprotected.yaml
@@ -1,0 +1,106 @@
+name: Staging - Database Migration Manual (password protected / TEST)
+
+on:
+  workflow_dispatch:
+    inputs:
+      password:
+        description: "Enter the password - [1Password link](https://start.1password.com/open/i?a=BZ4RYZZICJEKNOF4Z6ASRX2XXI&v=ppnxsriom3alsxj4ogikyjxlzi&i=i5kfypu7grhf5lc2bu4mi4yque&h=cds-snc.1password.ca)"
+        required: true
+        default: ""
+      flask_command:
+        description: "Select the Flask command to run"
+        required: true
+        type: choice
+        options:
+          - upgrade
+          - downgrade
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  HELMFILE_FILE_PATH: ${{ github.workspace }}/helmfile
+  STAGING_AWS_ACCOUNT: ${{ secrets.STAGING_AWS_ACCOUNT_ID }}
+  OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN_STAGING }}
+  
+jobs:
+  helmfile-database-job:
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Inject token authentication
+        run: |
+          git config --global url."https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/".insteadOf "https://github.com/"
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
+        id: awsconfig
+        with:
+          aws-access-key-id: ${{ secrets.STAGING_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.STAGING_AWS_SECRET_ACCESS_KEY }}
+          aws-region: ca-central-1
+
+      - name: Validate Password
+        run: |
+          if [ "${{ inputs.password }}" != "${{ secrets.PRODUCTION_MANUAL_MIGRATION }}" ]; then
+            echo "Invalid password provided. Exiting."
+            exit 1
+          fi
+
+      - name: Checkout
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+        with:
+          # Fetches entire history, so we can analyze commits since last tag
+          fetch-depth: 0
+
+      - name: Setup helmfile
+        uses: mamezou-tech/setup-helmfile@03233e1cd9b19b2ba320e431f7bcc0618db4248d # v2.0.0
+        with:
+          install-kubectl: yes
+          install-helm: yes       
+          helmfile-version: "v0.151.0"
+          helm-s3-plugin-version: "v0.16.2"
+
+      - name: Install OpenVPN
+        run: |
+          sudo apt update
+          sudo apt install -y openvpn openvpn-systemd-resolved
+
+      - name: Setup Terraform tools
+        uses: cds-snc/terraform-tools-setup@v1
+        env: # In case you want to override default versions
+          CONFTEST_VERSION: 0.30.0 
+          TERRAFORM_VERSION: 1.9.5
+          TERRAGRUNT_VERSION: 0.66.9
+          TF_SUMMARIZE_VERSION: 0.2.3                           
+
+      - name: Install 1Pass CLI
+        run: |
+          curl -o 1pass.deb https://downloads.1password.com/linux/debian/amd64/stable/1password-cli-amd64-latest.deb
+          sudo dpkg -i 1pass.deb 
+
+      - name: Retrieve VPN Config
+        run: |
+          scripts/createVPNConfig.sh staging 2> /dev/null   
+
+      - name: Connect to VPN
+        uses: "kota65535/github-openvpn-connect-action@cd2ed8a90cc7b060dc4e001143e811b5f7ea0af5" # v3.1.0
+        with:
+          config_file: /var/tmp/staging.ovpn
+          echo_config: false            
+
+      - name: Configure kubeconfig
+        run: |
+          aws eks update-kubeconfig --name notification-canada-ca-staging-eks-cluster --alias staging
+
+      - name: Load Context Variables
+        run: |
+            ./helmfile/getContext.sh -g
+
+      - name: Run Database Downgrade Helmfile Sync
+        uses: ./.github/actions/db-migration
+        with:
+          environment: "staging"
+          namespace: "notification-canada-ca"
+          app_label: "notify-database"
+          timeout: "400s"
+          db_args: "${{ inputs.flask_command }}"
+


### PR DESCRIPTION
## What happens when your PR merges?

- Prefix the title of your PR:
  - `fix:` - tag `main` as a new patch release
  - `feat:` - tag `main` as a new minor release
  - `BREAKING CHANGE:` - tag `main` as a new major release
  - `[MANIFEST]` or `[AUTO-PR]` - tag `main` as a new patch release and deploy to production
  - `chore:` - use for changes to non-app code (ex: GitHub actions)
- Alternatively, change the [VERSION file](https://github.com/cds-snc/notification-manifests/blob/main/VERSION) - this will not create a new tag, but rather will release the tag in `VERSION` to production.

## What are you changing?

- [ ] Releasing a new version of Notify
- [ ] Changing kubernetes configuration

## Provide some background on the changes

This is a duplicate of the production equivalent of the data migration workflow, but happening in the staging environment. The code is the same except for references to the environment has been switched to staging. Only one production reference remains and that is for the password itself that we need to test, but with a staging db downgrade/upgrade.

## If you are releasing a new version of Notify, what components are you updating

- [ ] API
- [ ] Admin
- [ ] Documentation
- [ ] Document download API

## Checklist if releasing new version

- [ ] I made sure that the changes are as expected in [Notify staging](https://staging.notification.cdssandbox.xyz/)
- [ ] I have checked if the docker images I am referencing exist
  - [ ] [api lambda](https://ca-central-1.console.aws.amazon.com/ecr/repositories/private/296255494825/notify/api-lambda?region=ca-central-1) (requires Notification-Production / AdministratorAccess login)
  - [ ] [api k8s](https://gallery.ecr.aws/v6b8u5o6/notify-api)
  - [ ] [admin](https://gallery.ecr.aws/v6b8u5o6/notify-admin)
  - [ ] [documentation](https://gallery.ecr.aws/v6b8u5o6/notify-documentation)
  - [ ] [document download API](https://gallery.ecr.aws/v6b8u5o6/notify-document-download-api)

## Checklist if making changes to Kubernetes

- [ ] I know how to get kubectl credentials in case it catches on fire

## After merging this PR

- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.
