### PR TITLE
Fixing Step Name from "Downgrade"

### DIFF
--- a/.github/workflows/database_migration_production_manual.yaml
+++ b/.github/workflows/database_migration_production_manual.yaml
@@ -95,7 +95,7 @@ jobs:
         run: |
             ./helmfile/getContext.sh -g
 
-      - name: Run Database Downgrade Helmfile Sync
+      - name: Run Database ${{ inputs.flask_command }} Helmfile Sync
         uses: ./.github/actions/db-migration
         with:
           environment: "production"


### PR DESCRIPTION
## What happens when your PR merges?

Nothing until this workflow is run.  When it's run it will now display a title that's more indicative of what the job is doing rather than the hardcoded "Downgrade" it had before.

## What are you changing?

adding a variable to the title of one of the workflow steps

## Provide some background on the changes

https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/558

## Checklist if making changes to Kubernetes

- [x] I know how to get kubectl credentials in case it catches on fire

## After merging this PR

- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.
