### PR TITLE
Fixing Duplicate Step Names

### DIFF
--- a/.github/workflows/helmfile_production_apply.yaml
+++ b/.github/workflows/helmfile_production_apply.yaml
@@ -94,7 +94,7 @@ jobs:
           timeout: "400s"
 
       - name: Helmfile apply CRDs
-        id: helmfile_apply
+        id: helmfile_apply_crd
         if: ${{ success() }}
         run: |
           pushd helmfile

--- a/.github/workflows/helmfile_staging_apply.yaml
+++ b/.github/workflows/helmfile_staging_apply.yaml
@@ -91,7 +91,7 @@ jobs:
           timeout: "400s"
 
       - name: Helmfile apply CRDs
-        id: helmfile_apply
+        id: helmfile_apply_crd
         if: ${{ success() }}
         run: |
           pushd helmfile


### PR DESCRIPTION
fixing duplicate step names in my workflows

## What are you changing?
Making helmfile apply work

## Checklist if making changes to Kubernetes

- [x] I know how to get kubectl credentials in case it catches on fire

## After merging this PR

- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.
