### PR TITLE
Enable nr staging and shorten diff

### DIFF
--- a/.github/workflows/helmfile_staging_plan.yaml
+++ b/.github/workflows/helmfile_staging_plan.yaml
@@ -75,7 +75,7 @@ jobs:
         id: helmfile_diff
         run: |
           pushd helmfile
-          helmfile --environment staging -l 'app!=notify-database' diff >> helm_diff.txt
+          helmfile --environment staging -l 'app!=notify-database' diff --context 2 >> helm_diff.txt
           LENGTH=$(wc -m helm_diff.txt | awk '{print $1}')
           if (( $LENGTH < 65000 )); then
               PAYLOAD=$(cat helm_diff.txt)

--- a/helmfile/helmfile.yaml
+++ b/helmfile/helmfile.yaml
@@ -329,7 +329,7 @@ releases:
     values:
     - ./overrides/system/metrics-server.yaml.gotmpl
 
-  {{ if eq .Environment.Name "dev" }}
+  {{ if ne .Environment.Name "production" }}
   - name: newrelic
     namespace: newrelic
     disableValidationOnInstall: true


### PR DESCRIPTION
## What happens when your PR merges?

We will try adding New Relic back to staging since it's working fine on dev 🤷 

Also add --context 2 to the helmfile diffs which will show only the changes and not the whole yaml.

## What are you changing?

- [ ] Releasing a new version of Notify
- [x] Changing kubernetes configuration

## Provide some background on the changes

New Relic debugging

## After merging this PR

- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.
