### PR TITLE
[MANIFEST] remove startup taings on prod

### DIFF
--- a/helmfile/overrides/system/karpenter.yaml.gotmpl
+++ b/helmfile/overrides/system/karpenter.yaml.gotmpl
@@ -8,6 +8,7 @@ settings:
 nodeSelector:  
   eks.amazonaws.com/capacityType: ON_DEMAND
 
+{{ if ne .Environment.Name "production" }}
 startupTaints:
   - key: nidhogg.uswitch.com/amazon-cloudwatch.aws-cloudwatch-agent
     effect: NoSchedule
@@ -17,6 +18,7 @@ startupTaints:
     effect: NoSchedule
   - key: nidhogg.uswitch.com/amazon-cloudwatch.secrets-store-csi-driver
     effect: NoSchedule   
+{{ end }}
 nodeClass:
   amiId: {{ requiredEnv "EKS_KARPENTER_AMI_ID" }}
 


### PR DESCRIPTION
## What happens when your PR merges?

When I implemented nidhogg on staging and dev, I forgot to wrap the startup taints on Karpenter nodes with an if statement so that they don't apply on prod. As it stands now, all of the nodes karpenter spins up are unusable in prod because these taints are never removed (since Nidhogg isn't in prod).

## What are you changing?

- [ ] Releasing a new version of Notify
- [x] Changing kubernetes configuration

## Provide some background on the changes

Nidhogg

## After merging this PR

- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.
