### PR TITLE
disable NR in staging

### DIFF
--- a/helmfile/helmfile.yaml
+++ b/helmfile/helmfile.yaml
@@ -356,7 +356,7 @@ releases:
     - ./overrides/system/nidhogg.yaml.gotmpl
 {{ end }}
 
-{{ if not (eq .Environment.Name "production") }}
+{{ if eq .Environment.Name "dev" }}
   - name: newrelic
     namespace: newrelic
     disableValidationOnInstall: true


### PR DESCRIPTION
## What happens when your PR merges?

New relic keeps intermittently failing on helmfile apply. Removing for now.

## What are you changing?

- [ ] Releasing a new version of Notify
- [x] Changing kubernetes configuration

## Provide some background on the changes

Adding new relic to EKS.

## After merging this PR

- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.
