### PR TITLE
Helmfile Apply Updates to fix CRDs and New Relic

### DIFF
--- a/.github/workflows/helmfile_production_apply.yaml
+++ b/.github/workflows/helmfile_production_apply.yaml
@@ -93,20 +93,13 @@ jobs:
           app_label: "notify-database"
           timeout: "400s"
 
-      - name: Helmfile apply CRDs
-        id: helmfile_apply_crd
-        if: ${{ success() }}
-        run: |
-          pushd helmfile
-          helmfile --environment production -l 'tier=crd' sync
-          popd          
-
       - name: Helmfile apply
         if: ${{ success() }}
         id: helmfile_apply
         run: |
           pushd helmfile
-          helmfile --environment production -l 'app!=notify-database,tier!=crd' sync
+          helmfile --environment production -l 'tier=crd' apply
+          helmfile --environment production -l 'app!=notify-database,tier!=crd' apply
           popd
 
       - name: Save ENV vars and secrets to AWS Param Store

--- a/.github/workflows/helmfile_staging_apply.yaml
+++ b/.github/workflows/helmfile_staging_apply.yaml
@@ -90,20 +90,13 @@ jobs:
           app_label: "notify-database"
           timeout: "400s"
 
-      - name: Helmfile apply CRDs
-        id: helmfile_apply_crd
-        if: ${{ success() }}
-        run: |
-          pushd helmfile
-          helmfile --environment staging -l 'tier=crd' sync
-          popd
-
       - name: Helmfile apply
-        id: helmfile_apply
         if: ${{ success() }}
+        id: helmfile_apply
         run: |
           pushd helmfile
-          helmfile --environment staging -l 'app!=notify-database,tier!=crd' sync
+          helmfile --environment staging -l 'tier=crd' apply
+          helmfile --environment staging -l 'app!=notify-database,tier!=crd' apply
           popd
 
       - name: Save ENV vars and secrets to AWS Param Store

--- a/helmfile/helmfile.yaml
+++ b/helmfile/helmfile.yaml
@@ -356,7 +356,7 @@ releases:
     - ./overrides/system/nidhogg.yaml.gotmpl
 {{ end }}
 
-{{ if eq .Environment.Name "dev" }}
+{{ if or (eq .Environment.Name "dev") (eq .Environment.Name "staging") }}
   - name: newrelic
     namespace: newrelic
     disableValidationOnInstall: true


### PR DESCRIPTION
## What are you changing?

Turning on New Relic K8s dashboards for staging, and updating our workflows to use apply rather than sync for helmfile (plus doing the crds in a step prior to everything else

## Provide some background on the changes
https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/568

## Checklist if making changes to Kubernetes

- [x] I know how to get kubectl credentials in case it catches on fire

## After merging this PR

- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.
