### PR TITLE
Fixing location of disruption

### DIFF
--- a/helmfile/charts/karpenter-nodepool/templates/nodepool.yaml
+++ b/helmfile/charts/karpenter-nodepool/templates/nodepool.yaml
@@ -6,6 +6,12 @@ metadata:
     kubernetes.io/description: "NodePool for provisioning spot capacity"
 spec:
   template:
+    disruption:
+      consolidationPolicy: WhenEmpty
+      consolidateAfter: 30m
+      expireAfter: 24h
+      budgets:
+        - nodes: 10%
     spec:
       requirements:
         - key: karpenter.sh/capacity-type
@@ -37,9 +43,3 @@ spec:
         group: karpenter.k8s.aws
         kind: EC2NodeClass
         name: {{ .Values.nodeClass.name}}
-      disruption:
-        consolidationPolicy: WhenEmpty
-        consolidateAfter: 30m
-        expireAfter: 24h
-        budgets:
-          - nodes: 10%


### PR DESCRIPTION
## What happens when your PR merges?

Karpenter disruption config was in the wrong spot and wasn't taking effect. Fixed.


## What are you changing?

- [ ] Releasing a new version of Notify
- [x] Changing kubernetes configuration

## Provide some background on the changes

HPA and karpenter tuning

## After merging this PR

- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.
