### PR TITLE
staging karpenter to new node sizes

### DIFF
--- a/helmfile/overrides/system/karpenter.yaml.gotmpl
+++ b/helmfile/overrides/system/karpenter.yaml.gotmpl
@@ -24,3 +24,9 @@ startupTaints:
 nodeClass:
   amiId: {{ requiredEnv "EKS_KARPENTER_AMI_ID" }}
 
+{{ if ne .Environment.Name "production" }}
+nodePool:
+  instanceCategories: "['m', 'r', 'c']"
+  instanceFamily: "['m7i', 'r7i', 'c7i']"
+  instanceCPU: "['4']"
+{{ end }}

--- a/helmfile/overrides/system/newrelic.yaml.gotmpl
+++ b/helmfile/overrides/system/newrelic.yaml.gotmpl
@@ -28,6 +28,7 @@ logging:
 
 newrelic-logging:
     lowDataMode: true
+    priorityClassName: system-cluster-critical
 
 k8s-agents-operator:
     enabled: true


### PR DESCRIPTION
## What happens when your PR merges?

Staging karpenter will use new node sizes with a minimum of 4 vcpus to accommodate the additional CPU load we have with New Relic.

## What are you changing?

- [ ] Releasing a new version of Notify
- [x] Changing kubernetes configuration

## Provide some background on the changes

https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/580

## After merging this PR

- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.
