### PR TITLE
Add notification-lambdas to pr template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -23,6 +23,7 @@
 - [ ] Admin
 - [ ] Documentation
 - [ ] Document download API
+- [ ] notification-lambdas
 
 ## Checklist if releasing new version
 
@@ -33,6 +34,7 @@
   - [ ] [admin](https://gallery.ecr.aws/v6b8u5o6/notify-admin)
   - [ ] [documentation](https://gallery.ecr.aws/v6b8u5o6/notify-documentation)
   - [ ] [document download API](https://gallery.ecr.aws/v6b8u5o6/notify-document-download-api)
+  - [ ] notification-lambdas ([heartbeat](https://ca-central-1.console.aws.amazon.com/ecr/repositories/private/296255494825/notify/heartbeat?region=ca-central-1), [ses_to_sqs_email_callbacks](https://ca-central-1.console.aws.amazon.com/ecr/repositories/private/296255494825/notify/ses_to_sqs_email_callbacks?region=ca-central-1), [system-status](https://ca-central-1.console.aws.amazon.com/ecr/repositories/private/296255494825/notify/system_status?region=ca-central-1))
 
 ## Checklist if making changes to Kubernetes
 


### PR DESCRIPTION
## What are you changing?

- [ ] Releasing a new version of Notify
- [ ] Changing kubernetes configuration
- [x] updating the release pr template

## Provide some background on the changes

The changes to the notification-lambdas repo are now being populated correctly in the [release PRs](https://github.com/cds-snc/notification-manifests/pull/3871). This PR adds them to the checklist and adds links so that the OL can easily verify that the images exist.

## If you are releasing a new version of Notify, what components are you updating

- [ ] API
- [ ] Admin
- [ ] Documentation
- [ ] Document download API

## Checklist if releasing new version

- [ ] I made sure that the changes are as expected in [Notify staging](https://staging.notification.cdssandbox.xyz/)
- [ ] I have checked if the docker images I am referencing exist
  - [ ] [api lambda](https://ca-central-1.console.aws.amazon.com/ecr/repositories/private/296255494825/notify/api-lambda?region=ca-central-1) (requires Notification-Production / AdministratorAccess login)
  - [ ] [api k8s](https://gallery.ecr.aws/v6b8u5o6/notify-api)
  - [ ] [admin](https://gallery.ecr.aws/v6b8u5o6/notify-admin)
  - [ ] [documentation](https://gallery.ecr.aws/v6b8u5o6/notify-documentation)
  - [ ] [document download API](https://gallery.ecr.aws/v6b8u5o6/notify-document-download-api)

## Checklist if making changes to Kubernetes

- [ ] I know how to get kubectl credentials in case it catches on fire

## After merging this PR

- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.
