### PR TITLE
K8s/Helmfile Secrets Store for Database

### DIFF
--- a/helmfile/charts/notify-database/templates/_helpers.tpl
+++ b/helmfile/charts/notify-database/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "db.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "db.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "db.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "db.labels" -}}
+helm.sh/chart: {{ include "db.chart" . }}
+{{ include "db.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "db.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "db.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "db.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "db.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/helmfile/charts/notify-database/templates/run-database-job.yaml
+++ b/helmfile/charts/notify-database/templates/run-database-job.yaml
@@ -49,7 +49,7 @@ spec:
             - name: {{ $key }}
               valueFrom:
                 secretKeyRef:
-                  name: notify-api
+                  name: {{ $.Values.secretProviderClass.secretname }}
                   key: {{ $key }}
             {{- end }}
             # Node-specific variables

--- a/helmfile/charts/notify-database/templates/secretsproviderclass.yaml
+++ b/helmfile/charts/notify-database/templates/secretsproviderclass.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.secretProviderClass.enabled }}
+apiVersion: secrets-store.csi.x-k8s.io/v1
+kind: SecretProviderClass
+metadata:
+  name: {{ include "db.fullname" . }}
+  labels:
+    {{- include "db.labels" . | nindent 4 }}
+spec:
+  provider: {{ .Values.secretProviderClass.provider }}
+  #This is the source names from AWS Secrets Manager
+  parameters:
+    objects: |
+    
+    {{- range $key, $val := .Values.apiSecrets }}
+      - objectName: {{ $val }}
+        objectType: "secretsmanager"
+    {{- end }}
+      
+  #This is the target name in the kubernetes secret      
+  secretObjects:
+    - data:
+      {{- range $key, $val := .Values.apiSecrets }}
+      - key: {{ $key }}
+        objectName: {{ $val }}
+      {{- end }}
+      secretName: {{ .Values.secretProviderClass.secretname }}
+      type: generic
+
+{{ end }}

--- a/helmfile/charts/notify-database/values.yaml
+++ b/helmfile/charts/notify-database/values.yaml
@@ -15,3 +15,23 @@ serviceAccount:
 
 nodeSelector:
   eks.amazonaws.com/capacityType: ON_DEMAND
+
+secretProviderClass:
+  secretname: notify-database-secrets
+  enabled: true
+  provider: aws
+  parameters:
+    objects: |
+      - objectName: INTERNAL_DNS_KEY_BASE64
+        objectType: "secretsmanager"
+      - objectName: INTERNAL_DNS_CERT_BASE64
+        objectType: "secretsmanager"
+
+  secretObjects:
+    - data:
+        - key: tls.key
+          objectName: INTERNAL_DNS_KEY_BASE64
+        - key: tls.crt
+          objectName: INTERNAL_DNS_CERT_BASE64
+      secretName: nginx
+      type: kubernetes.io/tls


### PR DESCRIPTION
## What happens when your PR merges?
Ideally a new K8s secret will be added that is discretely used by the database helm job.

## What are you changing?

- [ ] Releasing a new version of Notify
- [x] Changing kubernetes configuration

## Provide some background on the changes

https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/631

## Checklist if making changes to Kubernetes

- [x] I know how to get kubectl credentials in case it catches on fire

## After merging this PR

- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.
