### PR TITLE
Update smoke_test_staging.yaml

### DIFF
--- a/.github/workflows/smoke_test_staging.yaml
+++ b/.github/workflows/smoke_test_staging.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4.9.1
         with:
-          python-version: "3.13"
+          python-version: "3.12"
 
       - name: Upgrade pip
         run: python -m pip install --upgrade pip


### PR DESCRIPTION
## What happens when your PR merges?

Rolling back the python version on the smoke test workflow.

## What are you changing?

- [ ] Releasing a new version of Notify
- [ ] Changing kubernetes configuration
- [x] Github Actions

## Provide some background on the changes

Reverting after doing a renovate update

## After merging this PR

- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.
