### PR TITLE
Updating database secret provider class name

### DIFF
--- a/helmfile/charts/notify-database/values.yaml
+++ b/helmfile/charts/notify-database/values.yaml
@@ -17,7 +17,7 @@ nodeSelector:
   eks.amazonaws.com/capacityType: ON_DEMAND
 
 secretProviderClass:
-  secretname: notify-database-secrets
+  secretname: notify-database
   enabled: true
   provider: aws
   parameters:


### PR DESCRIPTION
## What are you changing?

Bug fix so that DB job is referencing proper secret store

## Provide some background on the changes

https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/631
## Checklist if making changes to Kubernetes

- [x] I know how to get kubectl credentials in case it catches on fire

## After merging this PR

- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.
