### PR TITLE
disable newrelic in k8s

### DIFF
--- a/helmfile/helmfile.yaml
+++ b/helmfile/helmfile.yaml
@@ -357,6 +357,7 @@ releases:
 {{ if or (eq .Environment.Name "dev") (eq .Environment.Name "staging") }}
   - name: newrelic
     namespace: newrelic
+    installed: false
     disableValidationOnInstall: true
     disableValidation: true 
     labels:
@@ -370,6 +371,7 @@ releases:
 
   - name: newrelic-apm
     namespace: newrelic
+    installed: false
     disableValidationOnInstall: true
     disableValidation: true 
     labels:


### PR DESCRIPTION
## What happens when your PR merges?

We're hitting our data limits on New Relic. Disabling new relic for K8s for now.

## What are you changing?

- [ ] Releasing a new version of Notify
- [x] Changing kubernetes configuration

## Provide some background on the changes

New Relic data ingest overages

## After merging this PR

- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.
