### PR TITLE
single instances for signoz

### DIFF
--- a/helmfile/helmfile.yaml
+++ b/helmfile/helmfile.yaml
@@ -549,7 +549,7 @@ releases:
     - ./overrides/system/signoz-k8s.yaml.gotmpl 
 
   - name: signoz-telemetry
-    namespace: notification-canada-ca
+    namespace: signoz
     disableValidationOnInstall: true
     labels:
       app: signoz-telemetry

--- a/helmfile/helmfile.yaml
+++ b/helmfile/helmfile.yaml
@@ -499,7 +499,7 @@ releases:
     values:
     - ./overrides/system/goldilocks.yaml.gotmpl
 
-{{ if eq .Environment.Name "dev" }}
+{{ if ne .Environment.Name "production" }}
 
   - name: signoz
     namespace: signoz
@@ -549,7 +549,7 @@ releases:
     - ./overrides/system/signoz-k8s.yaml.gotmpl 
 
   - name: signoz-telemetry
-    namespace: signoz
+    namespace: notification-canada-ca
     disableValidationOnInstall: true
     labels:
       app: signoz-telemetry

--- a/helmfile/overrides/system/signoz.yaml.gotmpl
+++ b/helmfile/overrides/system/signoz.yaml.gotmpl
@@ -7,7 +7,7 @@ clickhouse:
   installCustomStorageClass: true
   layout:
     shardsCount: 1
-    replicasCount: 2
+    replicasCount: 1
   persistence:
     storageClass: notify
     size: 1Ti
@@ -16,7 +16,7 @@ clickhouse:
       size: 10Gi
 
 signoz:
-  replicaCount: 2
+  replicaCount: 1
   persistence:
     size: 10Gi
   env:


### PR DESCRIPTION
## What happens when your PR merges?

Signoz doesn't seem to like multiple instances running - it may be a case of having to get it fully configured before enabling multiple instances - so we can test that, but for now just setting to 1.

## What are you changing?

- [ ] Releasing a new version of Notify
- [x] Changing kubernetes configuration

## Provide some background on the changes

https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/777

## After merging this PR

- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.
