### PR TITLE
put staging back to known good

### DIFF
--- a/helmfile/overrides/notify/api.yaml.gotmpl
+++ b/helmfile/overrides/notify/api.yaml.gotmpl
@@ -123,13 +123,13 @@ resources:
     cpu: {{ if eq .Environment.Name "production" }} "250m" {{ else if eq .Environment.Name "staging" }} "250m" {{ else }} "250m" {{ end }}
     memory: {{ if eq .Environment.Name "production" }} "700Mi" {{ else if eq .Environment.Name "staging" }} "700Mi" {{ else }} "1000Mi" {{ end }}
   limits:
-    cpu: {{ if eq .Environment.Name "production" }} "1200m" {{ else if eq .Environment.Name "staging" }} "1200m" {{ else }} "1200m" {{ end }}
-    memory: {{ if eq .Environment.Name "production" }} "1200Mi" {{ else if eq .Environment.Name "staging" }} "1200Mi" {{ else }} "1200Mi" {{ end }}
+    cpu: {{ if eq .Environment.Name "production" }} "1200m" {{ else if eq .Environment.Name "staging" }} "2000m" {{ else }} "1200m" {{ end }}
+    memory: {{ if eq .Environment.Name "production" }} "1200Mi" {{ else if eq .Environment.Name "staging" }} "2000Mi" {{ else }} "1200Mi" {{ end }}
 
 autoscaling:
   enabled: {{ if eq .Environment.Name "production" }} true {{ else if eq .Environment.Name "staging" }} true {{ else }} true {{ end }}
-  minReplicas: {{ if eq .Environment.Name "production" }} 4 {{ else if eq .Environment.Name "staging" }} 4 {{ else }} 2 {{ end }}
-  maxReplicas: {{ if eq .Environment.Name "production" }} 4 {{ else if eq .Environment.Name "staging" }} 4 {{ else }} 2 {{ end }}
+  minReplicas: {{ if eq .Environment.Name "production" }} 4 {{ else if eq .Environment.Name "staging" }} 6 {{ else }} 2 {{ end }}
+  maxReplicas: {{ if eq .Environment.Name "production" }} 4 {{ else if eq .Environment.Name "staging" }} 6 {{ else }} 2 {{ end }}
   targetCPUUtilizationPercentage: {{ if eq .Environment.Name "production" }} 50 {{ else if eq .Environment.Name "staging" }} 50 {{ else }} 50 {{ end }}
 
 pdb:


### PR DESCRIPTION
## What happens when your PR merges?

I tried lowering the staging k8s api resources to what's in line with prod, but that doesn't seem to be enough for perf tests. I'm going to put the higher numbers back and leave it like that for a while. Let's see if it settles down.

## What are you changing?

- [ ] Releasing a new version of Notify
- [x] Changing kubernetes configuration

## Provide some background on the changes

https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/770

## After merging this PR

- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.
