### PR TITLE
updating roles for new least privilege TF additions

### DIFF
--- a/.github/workflows/database_migration_production_manual.yaml
+++ b/.github/workflows/database_migration_production_manual.yaml
@@ -40,7 +40,7 @@ jobs:
       - name: Configure credentials to Notify using OIDC
         uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
         with:
-          role-to-assume: arn:aws:iam::${{env.ACCOUNT_ID}}:role/notification-manifests-apply
+          role-to-assume: arn:aws:iam::${{env.ACCOUNT_ID}}:role/notification-manifests-database-migration-production
           role-session-name: NotifyManifestsApply
           aws-region: ${{ env.AWS_DEFAULT_REGION }}
 

--- a/.github/workflows/database_migration_staging_manual.yaml
+++ b/.github/workflows/database_migration_staging_manual.yaml
@@ -36,7 +36,7 @@ jobs:
       - name: Configure credentials to Notify using OIDC
         uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
         with:
-          role-to-assume: arn:aws:iam::${{env.ACCOUNT_ID}}:role/notification-manifests-apply
+          role-to-assume: arn:aws:iam::${{env.ACCOUNT_ID}}:role/notification-manifests-database-migration-staging
           role-session-name: NotifyManifestsApply
           aws-region: ${{ env.AWS_DEFAULT_REGION }}
 

--- a/.github/workflows/helmfile_production_apply.yaml
+++ b/.github/workflows/helmfile_production_apply.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Configure credentials to Notify using OIDC
         uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
         with:
-          role-to-assume: arn:aws:iam::${{env.ACCOUNT_ID}}:role/notification-manifests-apply
+          role-to-assume: arn:aws:iam::${{env.ACCOUNT_ID}}:role/notification-manifests-helmfile-production-apply
           role-session-name: NotifyManifestsApply
           aws-region: ${{ env.AWS_DEFAULT_REGION }}
 

--- a/.github/workflows/helmfile_staging_apply.yaml
+++ b/.github/workflows/helmfile_staging_apply.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Configure credentials to Notify using OIDC
         uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
         with:
-          role-to-assume: arn:aws:iam::${{env.ACCOUNT_ID}}:role/notification-manifests-apply
+          role-to-assume: arn:aws:iam::${{env.ACCOUNT_ID}}:role/notification-manifests-helmfile-staging-apply
           role-session-name: NotifyManifestsApply
           aws-region: ${{ env.AWS_DEFAULT_REGION }}
 
@@ -176,7 +176,7 @@ jobs:
       - name: Configure credentials to Notify using OIDC
         uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
         with:
-          role-to-assume: arn:aws:iam::${{env.ACCOUNT_ID}}:role/notification-manifests-apply
+          role-to-assume: arn:aws:iam::${{env.ACCOUNT_ID}}:role/notification-manifests-helmfile-staging-apply
           role-session-name: NotifyManifestsApply
           aws-region: ${{ env.AWS_DEFAULT_REGION }}
 

--- a/.github/workflows/smoke_test_production.yaml
+++ b/.github/workflows/smoke_test_production.yaml
@@ -66,7 +66,7 @@ jobs:
       - name: Configure credentials to Notify using OIDC
         uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
         with:
-          role-to-assume: arn:aws:iam::${{env.ACCOUNT_ID}}:role/notification-manifests-apply
+          role-to-assume: arn:aws:iam::${{env.ACCOUNT_ID}}:role/notification-manifests-smoke-test-production
           role-session-name: NotifyManifestsApply
           aws-region: ${{ env.AWS_DEFAULT_REGION }}
 


### PR DESCRIPTION
## What happens when your PR merges?

This pull request updates the AWS IAM roles assumed by various GitHub Actions workflows to use more specific, environment- and workflow-targeted roles instead of a generic `notification-manifests-apply` role. This change improves security and clarity by ensuring each workflow uses the least privilege necessary for its environment and purpose.

**Workflow IAM role updates:**

* **Helmfile workflows:**
  * Updated the production workflow (`helmfile_production_apply.yaml`) to use the `notification-manifests-helmfile-production-apply` role.
  * Updated the staging workflow (`helmfile_staging_apply.yaml`) to use the `notification-manifests-helmfile-staging-apply` role in both relevant job steps. [[1]](diffhunk://#diff-4b61f71b14e2e1231703d2a804473192c4fd909a0d558a336a54074705c3f564L41-R41) [[2]](diffhunk://#diff-4b61f71b14e2e1231703d2a804473192c4fd909a0d558a336a54074705c3f564L179-R179)

* **Database migration workflows:**
  * Updated the production migration workflow (`database_migration_production_manual.yaml`) to use the `notification-manifests-database-migration-production` role.
  * Updated the staging migration workflow (`database_migration_staging_manual.yaml`) to use the `notification-manifests-database-migration-staging` role.

* **Smoke test workflow:**
  * Updated the production smoke test workflow (`smoke_test_production.yaml`) to use the `notification-manifests-smoke-test-production` role.


https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/742

## Checklist if releasing new version

- [ ] I made sure that the changes are as expected in [Notify staging](https://staging.notification.cdssandbox.xyz/)
- [ ] I have checked if the docker images I am referencing exist
  - [ ] [api lambda](https://ca-central-1.console.aws.amazon.com/ecr/repositories/private/296255494825/notify/api-lambda?region=ca-central-1) (requires Notification-Production / AdministratorAccess login)
  - [ ] [api k8s](https://gallery.ecr.aws/v6b8u5o6/notify-api)
  - [ ] [admin](https://gallery.ecr.aws/v6b8u5o6/notify-admin)
  - [ ] [documentation](https://gallery.ecr.aws/v6b8u5o6/notify-documentation)
  - [ ] [document download API](https://gallery.ecr.aws/v6b8u5o6/notify-document-download-api)
  - [ ] notification-lambdas ([heartbeat](https://ca-central-1.console.aws.amazon.com/ecr/repositories/private/296255494825/notify/heartbeat?region=ca-central-1), [ses_to_sqs_email_callbacks](https://ca-central-1.console.aws.amazon.com/ecr/repositories/private/296255494825/notify/ses_to_sqs_email_callbacks?region=ca-central-1), [system-status](https://ca-central-1.console.aws.amazon.com/ecr/repositories/private/296255494825/notify/system_status?region=ca-central-1))

## Checklist if making changes to Kubernetes

- [ ] I know how to get kubectl credentials in case it catches on fire

## After merging this PR

- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.
