### PR TITLE
Api hpa tuning

### DIFF
--- a/helmfile/charts/notify-api/templates/hpa.yaml
+++ b/helmfile/charts/notify-api/templates/hpa.yaml
@@ -29,4 +29,8 @@ spec:
           averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
           type: Utilization
     {{- end }}
+  {{- if .Values.autoscaling.behavior }}
+  behavior:
+    {{- toYaml .Values.autoscaling.behavior | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/helmfile/charts/notify-api/values.yaml
+++ b/helmfile/charts/notify-api/values.yaml
@@ -81,6 +81,7 @@ autoscaling:
   minReplicas: 2
   maxReplicas: 2
   targetCPUUtilizationPercentage: 50
+  behavior: {}
 
 verticalPodAutoscaler:
   enabled: false

--- a/helmfile/overrides/notify/api.yaml.gotmpl
+++ b/helmfile/overrides/notify/api.yaml.gotmpl
@@ -132,9 +132,9 @@ resources:
 
 autoscaling:
   enabled: {{ if eq .Environment.Name "production" }} true {{ else if eq .Environment.Name "staging" }} true {{ else }} true {{ end }}
-  minReplicas: {{ if eq .Environment.Name "production" }} 8 {{ else if eq .Environment.Name "staging" }} 4 {{ else }} 4 {{ end }}
-  maxReplicas: {{ if eq .Environment.Name "production" }} 8 {{ else if eq .Environment.Name "staging" }} 4 {{ else }} 4 {{ end }}
-  targetCPUUtilizationPercentage: {{ if eq .Environment.Name "production" }} 50 {{ else if eq .Environment.Name "staging" }} 50 {{ else }} 50 {{ end }}
+  minReplicas: {{ if eq .Environment.Name "production" }} 4 {{ else if eq .Environment.Name "staging" }} 4 {{ else }} 4 {{ end }}
+  maxReplicas: {{ if eq .Environment.Name "production" }} 4 {{ else if eq .Environment.Name "staging" }} 8 {{ else }} 4 {{ end }}
+  targetCPUUtilizationPercentage: {{ if eq .Environment.Name "production" }} 50 {{ else if eq .Environment.Name "staging" }} 75 {{ else }} 75 {{ end }}
 
 pdb:
   enabled: {{ if eq .Environment.Name "production" }} true {{ else if eq .Environment.Name "staging" }} true {{ else }} true {{ end }}

--- a/helmfile/overrides/notify/api.yaml.gotmpl
+++ b/helmfile/overrides/notify/api.yaml.gotmpl
@@ -133,8 +133,17 @@ resources:
 autoscaling:
   enabled: {{ if eq .Environment.Name "production" }} true {{ else if eq .Environment.Name "staging" }} true {{ else }} true {{ end }}
   minReplicas: {{ if eq .Environment.Name "production" }} 4 {{ else if eq .Environment.Name "staging" }} 4 {{ else }} 4 {{ end }}
-  maxReplicas: {{ if eq .Environment.Name "production" }} 4 {{ else if eq .Environment.Name "staging" }} 8 {{ else }} 4 {{ end }}
-  targetCPUUtilizationPercentage: {{ if eq .Environment.Name "production" }} 50 {{ else if eq .Environment.Name "staging" }} 75 {{ else }} 75 {{ end }}
+  maxReplicas: {{ if eq .Environment.Name "production" }} 8 {{ else if eq .Environment.Name "staging" }} 8 {{ else }} 4 {{ end }}
+  targetCPUUtilizationPercentage: {{ if eq .Environment.Name "production" }} 150 {{ else if eq .Environment.Name "staging" }} 150 {{ else }} 150 {{ end }}
+{{ if eq .Environment.Name "staging" }}
+  behavior:
+    scaleDown:
+      stabilizationWindowSeconds: 600
+      policies:
+      - type: Pods
+        value: 1
+        periodSeconds: 300
+{{ end }}
 
 pdb:
   enabled: {{ if eq .Environment.Name "production" }} true {{ else if eq .Environment.Name "staging" }} true {{ else }} true {{ end }}


### PR DESCRIPTION
## What happens when your PR merges?

API Pods will scale on 150% of request CPU usage (approx 75% of limit usage). When scaling in staging, there is a 10 minute stabilization window, and it will only scale down 1 pod per 5 minutes so that we can be sure that the load is consistent.

## What are you changing?

- [ ] Releasing a new version of Notify
- [x] Changing kubernetes configuration

## Provide some background on the changes

https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/761

## After merging this PR

- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.
