### PR TITLE
Add seed-staging-data script and update jobs.yaml for daily seeding

### DIFF
--- a/helmfile/charts/notify-jobs/scripts/seed-staging-data.sh
+++ b/helmfile/charts/notify-jobs/scripts/seed-staging-data.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# seed-staging-data.sh
+#
+# Seeds the staging database with non-PII, production-like data for performance
+# testing, using the tests-simulate-prod-data script that ships with the
+# notification-api image at /app/tests-simulate-prod-data.
+#
+# SQLALCHEMY_DATABASE_URI is injected at runtime from the notify-api Kubernetes
+# Secret via the CronJob spec — it must not be hardcoded here.
+#
+# To tune volumes, adjust NUM_EMAILS_TOTAL / NUM_SMS_TOTAL.
+# To change the target service, update the SERVICE_ID below.
+
+set -euo pipefail
+
+# tests-simulate-prod-data lives in the API image at this well-known path.
+SCRIPT_DIR="/app/tests-simulate-prod-data"
+
+echo "==> Installing / verifying Python dependencies..."
+# requirements.txt may declare versions different from the main API — run pip
+# so any delta is satisfied. Already-installed packages are a fast no-op.
+cd "$SCRIPT_DIR"
+poetry run pip install -q -r requirements.txt
+
+echo "==> Running seeding script..."
+# --live-only-service-id inserts rows only into the live notifications table
+# (not the 14M-row notification_history) for the given service UUID.
+# NUM_EMAILS_TOTAL / NUM_SMS_TOTAL cap the volume for a manageable daily run.
+NUM_EMAILS_TOTAL=900000 \
+NUM_SMS_TOTAL=600000 \
+  poetry run python generate.py \
+    --live-only-service-id "8dad0c16-6952-4424-be2a-d98b8bfc3c2d"

--- a/helmfile/overrides/notify/jobs.yaml.gotmpl
+++ b/helmfile/overrides/notify/jobs.yaml.gotmpl
@@ -9,11 +9,6 @@ secretProviderClass:
   enabled: false
   provider: aws
 
-# Secrets injected into every CronJob container via secretKeyRef from the
-# notify-api Kubernetes Secret (created by the API helmfile release).
-apiSecrets:
-  SQLALCHEMY_DATABASE_URI: ""
-
 cronJobDefaults:
   suspend: false
   concurrencyPolicy: Forbid

--- a/helmfile/overrides/notify/jobs.yaml.gotmpl
+++ b/helmfile/overrides/notify/jobs.yaml.gotmpl
@@ -9,6 +9,11 @@ secretProviderClass:
   enabled: false
   provider: aws
 
+# Secrets injected into every CronJob container via secretKeyRef from the
+# notify-api Kubernetes Secret (created by the API helmfile release).
+apiSecrets:
+  SQLALCHEMY_DATABASE_URI: ""
+
 cronJobDefaults:
   suspend: false
   concurrencyPolicy: Forbid
@@ -41,3 +46,10 @@ scheduledScriptCronJobs:
     schedule: "10 6 * * *"
     scriptType: "shell"
     scriptPath: "/opt/notify-jobs-scripts/dummy-maintenance-c.sh"
+  # Seeds the staging DB with ~1.5M non-PII live notifications once per day.
+  # Targets the performance-testing service (8dad0c16-…).
+  # SQLALCHEMY_DATABASE_URI is injected from the notify-api secret above.
+  - name: seed-staging-data
+    schedule: "0 2 * * *"
+    scriptType: "shell"
+    scriptPath: "/opt/notify-jobs-scripts/seed-staging-data.sh"


### PR DESCRIPTION
## What happens when your PR merges?

This pull request introduces a new scheduled job to seed the staging database with large volumes of non-PII, production-like data for performance testing. It adds a shell script to handle the seeding, updates the job configuration to inject the necessary database secret, and schedules the job to run daily.

## Related Cards
* https://github.com/cds-snc/notification-planning/issues/3099

## What are you changing?

- [ ] Releasing a new version of Notify
- [x] Changing kubernetes configuration

## If you are releasing a new version of Notify, what components are you updating

- [ ] API
- [ ] Admin
- [ ] Documentation
- [ ] Document download API
- [ ] notification-lambdas

## Checklist if releasing new version

- [ ] I made sure that the changes are as expected in [Notify staging](https://staging.notification.cdssandbox.xyz/)
- [ ] I have checked if the docker images I am referencing exist
  - [ ] [api lambda](https://ca-central-1.console.aws.amazon.com/ecr/repositories/private/296255494825/notify/api-lambda?region=ca-central-1) (requires Notification-Production / AdministratorAccess login)
  - [ ] [api k8s](https://gallery.ecr.aws/v6b8u5o6/notify-api)
  - [ ] [admin](https://gallery.ecr.aws/v6b8u5o6/notify-admin)
  - [ ] [documentation](https://gallery.ecr.aws/v6b8u5o6/notify-documentation)
  - [ ] [document download API](https://gallery.ecr.aws/v6b8u5o6/notify-document-download-api)
  - [ ] notification-lambdas ([heartbeat](https://ca-central-1.console.aws.amazon.com/ecr/repositories/private/296255494825/notify/heartbeat?region=ca-central-1), [ses_to_sqs_email_callbacks](https://ca-central-1.console.aws.amazon.com/ecr/repositories/private/296255494825/notify/ses_to_sqs_email_callbacks?region=ca-central-1), [system-status](https://ca-central-1.console.aws.amazon.com/ecr/repositories/private/296255494825/notify/system_status?region=ca-central-1))

## Checklist if making changes to Kubernetes

- [ ] I know how to get kubectl credentials in case it catches on fire

## After merging this PR

- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.
