### PR TITLE
[MANIFEST] Fix signoz

### DIFF
--- a/helmfile/charts/signoz-telemetry/templates/instrumentation.yaml
+++ b/helmfile/charts/signoz-telemetry/templates/instrumentation.yaml
@@ -13,37 +13,9 @@ spec:
     addK8sUIDAttributes: false
   java:
     image: ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-java:latest
-    resources:
-      requests:
-        cpu: "50m"
-        memory: "64Mi"
-      limits:
-        cpu: "100m"
-        memory: "128Mi"
   nodejs:
     image: ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-nodejs:latest
-    resources:
-      requests:
-        cpu: "50m"
-        memory: "64Mi"
-      limits:
-        cpu: "100m"
-        memory: "128Mi"
   python:
     image: ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-python:latest
-    resources:
-      requests:
-        cpu: "50m"
-        memory: "64Mi"
-      limits:
-        cpu: "100m"
-        memory: "128Mi"
   dotnet:
     image: ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-dotnet:latest
-    resources:
-      requests:
-        cpu: "50m"
-        memory: "64Mi"
-      limits:
-        cpu: "100m"
-        memory: "128Mi"

--- a/helmfile/helmfile.yaml.gotmpl
+++ b/helmfile/helmfile.yaml.gotmpl
@@ -59,6 +59,8 @@ repositories:
   url: https://vmware-tanzu.github.io/helm-charts
 - name: falco
   url: https://falcosecurity.github.io/charts
+- name: linkerd
+  url: https://helm.linkerd.io/stable
 
 releases:
   # Uses database-specific overrides
@@ -553,6 +555,7 @@ releases:
     - ./overrides/system/signoz.yaml.gotmpl
 
   - name: opentelemetry-operator
+    version: 0.112.1
     namespace: signoz
     disableValidationOnInstall: true
     labels:
@@ -566,17 +569,19 @@ releases:
 
   - name: signoz-k8s
     namespace: signoz
+    version: 0.15.1
     disableValidationOnInstall: true
     labels:
       app: signoz-k8s
       tier: apm
       category: system
       step: 3
-    chart: signoz/k8s-infra 
+    chart: signoz/k8s-infra
     values:
     - ./overrides/system/signoz-k8s.yaml.gotmpl 
 
   - name: signoz-telemetry
+    version: 0.1.0
     namespace: signoz
     disableValidationOnInstall: true
     labels:
@@ -589,6 +594,7 @@ releases:
     - ./overrides/system/signoz-telemetry.yaml.gotmpl
 
   - name: signoz-importer
+    version: 1.0.0
     namespace: signoz
     disableValidationOnInstall: true
     labels:
@@ -612,3 +618,74 @@ releases:
     version: 0.28.1
     values:
     - ./overrides/system/prometheus-cloudwatch-exporter.yaml.gotmpl
+
+  - name: linkerd-certs
+    namespace: linkerd
+    disableValidationOnInstall: true
+    disableValidation: true
+    needs:
+      - cert-manager/cert-manager
+    labels:
+      app: linkerd
+      tier: certs
+      category: system
+      step: 0
+    chart: charts/linkerd-certs
+
+  - name: linkerd-crds
+    namespace: linkerd
+    disableValidationOnInstall: true
+    disableValidation: true
+    needs:
+      - linkerd/linkerd-certs
+    labels:
+      app: linkerd
+      tier: crd
+      category: system
+      step: 1
+    chart: linkerd/linkerd-crds
+
+  - name: linkerd-control-plane
+    namespace: linkerd
+    disableValidationOnInstall: true
+    disableValidation: true
+    needs:
+      - linkerd/linkerd-crds
+    labels:
+      app: linkerd
+      tier: main
+      category: system
+      step: 2
+    chart: linkerd/linkerd-control-plane
+    values:
+    - ./overrides/system/linkerd.yaml.gotmpl
+
+  - name: linkerd-viz
+    namespace: linkerd-viz
+    disableValidationOnInstall: true
+    disableValidation: true
+    needs:
+      - linkerd/linkerd-control-plane
+    labels:
+      app: linkerd
+      tier: viz
+      category: system
+      step: 3
+    chart: linkerd/linkerd-viz
+    values:
+    - ./overrides/system/linkerd-viz.yaml.gotmpl
+
+  - name: linkerd-viz-ingress
+    namespace: linkerd-viz
+    disableValidationOnInstall: true
+    disableValidation: true
+    needs:
+      - linkerd-viz/linkerd-viz
+    labels:
+      app: linkerd
+      tier: ingress
+      category: system
+      step: 4
+    chart: charts/linkerd-viz-ingress
+    values:
+    - ./overrides/system/linkerd-viz-ingress.yaml.gotmpl

--- a/helmfile/helmfile.yaml.gotmpl
+++ b/helmfile/helmfile.yaml.gotmpl
@@ -576,8 +576,7 @@ releases:
       tier: apm
       category: system
       step: 3
-    chart: signoz/k8s-infrakubectl delete mutatingwebhookconfiguration opentelemetry-operator-mutation --ignore-not-found
-kubectl delete validatingwebhookconfiguration opentelemetry-operator-validation --ignore-not-found
+    chart: signoz/k8s-infra
     values:
     - ./overrides/system/signoz-k8s.yaml.gotmpl 
 

--- a/helmfile/helmfile.yaml.gotmpl
+++ b/helmfile/helmfile.yaml.gotmpl
@@ -567,7 +567,7 @@ releases:
     values:
     - ./overrides/system/opentelemetry.yaml.gotmpl 
 
-  - name: signoz-k8
+  - name: signoz-k8s
     namespace: signoz
     version: 0.15.1
     disableValidationOnInstall: true

--- a/helmfile/helmfile.yaml.gotmpl
+++ b/helmfile/helmfile.yaml.gotmpl
@@ -567,7 +567,7 @@ releases:
     values:
     - ./overrides/system/opentelemetry.yaml.gotmpl 
 
-  - name: signoz-k8s
+  - name: signoz-k8
     namespace: signoz
     version: 0.15.1
     disableValidationOnInstall: true
@@ -576,7 +576,8 @@ releases:
       tier: apm
       category: system
       step: 3
-    chart: signoz/k8s-infra
+    chart: signoz/k8s-infrakubectl delete mutatingwebhookconfiguration opentelemetry-operator-mutation --ignore-not-found
+kubectl delete validatingwebhookconfiguration opentelemetry-operator-validation --ignore-not-found
     values:
     - ./overrides/system/signoz-k8s.yaml.gotmpl 
 
@@ -618,74 +619,3 @@ releases:
     version: 0.28.1
     values:
     - ./overrides/system/prometheus-cloudwatch-exporter.yaml.gotmpl
-
-  - name: linkerd-certs
-    namespace: linkerd
-    disableValidationOnInstall: true
-    disableValidation: true
-    needs:
-      - cert-manager/cert-manager
-    labels:
-      app: linkerd
-      tier: certs
-      category: system
-      step: 0
-    chart: charts/linkerd-certs
-
-  - name: linkerd-crds
-    namespace: linkerd
-    disableValidationOnInstall: true
-    disableValidation: true
-    needs:
-      - linkerd/linkerd-certs
-    labels:
-      app: linkerd
-      tier: crd
-      category: system
-      step: 1
-    chart: linkerd/linkerd-crds
-
-  - name: linkerd-control-plane
-    namespace: linkerd
-    disableValidationOnInstall: true
-    disableValidation: true
-    needs:
-      - linkerd/linkerd-crds
-    labels:
-      app: linkerd
-      tier: main
-      category: system
-      step: 2
-    chart: linkerd/linkerd-control-plane
-    values:
-    - ./overrides/system/linkerd.yaml.gotmpl
-
-  - name: linkerd-viz
-    namespace: linkerd-viz
-    disableValidationOnInstall: true
-    disableValidation: true
-    needs:
-      - linkerd/linkerd-control-plane
-    labels:
-      app: linkerd
-      tier: viz
-      category: system
-      step: 3
-    chart: linkerd/linkerd-viz
-    values:
-    - ./overrides/system/linkerd-viz.yaml.gotmpl
-
-  - name: linkerd-viz-ingress
-    namespace: linkerd-viz
-    disableValidationOnInstall: true
-    disableValidation: true
-    needs:
-      - linkerd-viz/linkerd-viz
-    labels:
-      app: linkerd
-      tier: ingress
-      category: system
-      step: 4
-    chart: charts/linkerd-viz-ingress
-    values:
-    - ./overrides/system/linkerd-viz-ingress.yaml.gotmpl

--- a/helmfile/overrides/system/opentelemetry.yaml.gotmpl
+++ b/helmfile/overrides/system/opentelemetry.yaml.gotmpl
@@ -4,6 +4,6 @@
 
 admissionWebhooks:
     certManager:
-        enabled: false
-    autoGenerateCert:
         enabled: true
+    autoGenerateCert:
+        enabled: false


### PR DESCRIPTION
## What happens when your PR merges?

We didn't have the OTLP versions pinned for signoz stuff and a chart upgrade messed everything up. I've pinned all of the charts - even the ones that don't need pinning because they're tied to our own charts in the repo just to make it consistent.

## What are you changing?

- [ ] Releasing a new version of Notify
- [x] Changing kubernetes configuration

## Provide some background on the changes

Signoz done broke

## After merging this PR

- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.
