### PR TITLE
need to add priority class to otel agent

### DIFF
--- a/helmfile/overrides/system/signoz-k8s.yaml.gotmpl
+++ b/helmfile/overrides/system/signoz-k8s.yaml.gotmpl
@@ -91,6 +91,7 @@ presets:
         enabled: true
 
 otelAgent:
+  priorityClassName: system-node-critical
   config:
     receivers:
       filelog/celery:


### PR DESCRIPTION
## What happens when your PR merges?

The otel agent isn't inheriting the priority class from the root. Adding it specifically here so that it always preempts other pods.

## What are you changing?

- [ ] Releasing a new version of Notify
- [x] Changing kubernetes configuration

## Provide some background on the changes

Came across this issue while investigating prod signoz

## After merging this PR

- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.
