### PR TITLE
cleanup after ascp migration

### DIFF
--- a/helmfile/helmfile.yaml.gotmpl
+++ b/helmfile/helmfile.yaml.gotmpl
@@ -29,8 +29,6 @@ hooks:
       - "kubectl create namespace notification-canada-ca --dry-run=client -o yaml | kubectl apply -f - && kubectl label namespace notification-canada-ca goldilocks.fairwinds.com/enabled=true --overwrite && kubectl label namespace notification-canada-ca elbv2.k8s.aws/pod-readiness-gate-inject=enabled --overwrite"
 
 repositories:
-- name: secrets-store-csi-driver
-  url: https://kubernetes-sigs.github.io/secrets-store-csi-driver/charts
 - name: aws-secrets-manager 
   url: https://aws.github.io/secrets-store-csi-driver-provider-aws
 - name: stakater 
@@ -212,23 +210,8 @@ releases:
     values:
     - ./overrides/system/priority-classes.yaml.gotmpl
 
-  - name: secrets-store-csi-driver
-    namespace: kube-system
-    installed: false
-    labels:
-      app: secrets-csi
-      tier: full
-      category: system
-      step: 1
-    chart: secrets-store-csi-driver/secrets-store-csi-driver
-    version: 1.4.1
-    values:
-    - ./overrides/system/secrets-csi.yaml.gotmpl
-
   - name: aws-secrets-provider
     namespace: kube-system
-    needs:
-      - kube-system/secrets-store-csi-driver
     labels:
       app: aws-secrets
       tier: full
@@ -236,13 +219,6 @@ releases:
       step: 1
     chart: aws-secrets-manager/secrets-store-csi-driver-provider-aws
     version: 3.1.0
-    hooks:
-      - events: ["presync"]
-        showlogs: true
-        command: "sh"
-        args:
-          - "-c"
-          - "kubectl wait --for=delete pod -l app.kubernetes.io/name=secrets-store-csi-driver -n kube-system --timeout=120s 2>/dev/null || true"
     values:
     - ./overrides/system/aws-secrets.yaml.gotmpl
 

--- a/helmfile/overrides/system/aws-secrets.yaml.gotmpl
+++ b/helmfile/overrides/system/aws-secrets.yaml.gotmpl
@@ -4,13 +4,12 @@ priorityClassName: high-priority
 tolerations:
   - operator: Exists
 
-# secrets-store-csi-driver is managed as a subchart by aws-secrets-provider
+# secrets-store-csi-driver is managed as a subchart by aws-secrets-provider.
+# tokenRequests is limited to sts.amazonaws.com only — EKS Pod Identity
+# (pods.eks.amazonaws.com) is excluded because SecretProviderClasses in this
+# cluster have no roleARN and rely on the node instance profile instead.
 secrets-store-csi-driver:
   install: true
-  # Keep only the sts.amazonaws.com audience (matches old 1.4.1 behaviour).
-  # The pods.eks.amazonaws.com audience (EKS Pod Identity) is removed because
-  # SecretProviderClasses in this cluster have no roleARN, so they rely on the
-  # node instance profile. EKS Pod Identity is not configured for these pods.
   tokenRequests:
     - audience: "sts.amazonaws.com"
   linux:


### PR DESCRIPTION
## What happens when your PR merges?

The ASCP migration is complete, we can remove the old chart installation and migration steps.

## What are you changing?

- [ ] Releasing a new version of Notify
- [x] Changing kubernetes configuration

## Provide some background on the changes

https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/852

## Checklist if making changes to Kubernetes

- [x] I know how to get kubectl credentials in case it catches on fire

## After merging this PR

- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.
