### PR TITLE
Added mem based hpa config for celery workers

### DIFF
--- a/helmfile/charts/notify-celery/templates/hpa.yaml
+++ b/helmfile/charts/notify-celery/templates/hpa.yaml
@@ -16,6 +16,14 @@ spec:
         averageUtilization: {{ $node.autoscaling.targetCPUUtilizationPercentage }}
         type: Utilization
     type: Resource
+  {{- if $node.autoscaling.targetMemoryUtilizationPercentage }}
+  - resource:
+      name: memory
+      target:
+        averageUtilization: {{ $node.autoscaling.targetMemoryUtilizationPercentage }}
+        type: Utilization
+    type: Resource
+  {{- end }}
   behavior:
     scaleUp:
       stabilizationWindowSeconds: {{ $node.autoscaling.stabilizationWindowSeconds }}

--- a/helmfile/charts/notify-celery/values.yaml
+++ b/helmfile/charts/notify-celery/values.yaml
@@ -181,6 +181,7 @@ nodes:
       minReplicas: 3
       maxReplicas: 30
       targetCPUUtilizationPercentage: 25
+      targetMemoryUtilizationPercentage: 0
       scaleUpPodsValue: 6
       scaleUpPeriodSeconds: 45
     pdb:
@@ -211,6 +212,7 @@ nodes:
       minReplicas: 3
       maxReplicas: 10
       targetCPUUtilizationPercentage: 25
+      targetMemoryUtilizationPercentage: 0
       scaleUpPodsValue: 6
       scaleUpPeriodSeconds: 45
     pdb:
@@ -241,6 +243,7 @@ nodes:
       minReplicas: 3
       maxReplicas: 30
       targetCPUUtilizationPercentage: 25
+      targetMemoryUtilizationPercentage: 0
       scaleUpPodsValue: 6
       scaleUpPeriodSeconds: 45
     pdb:
@@ -271,6 +274,7 @@ nodes:
       minReplicas: 3
       maxReplicas: 3
       targetCPUUtilizationPercentage: 25
+      targetMemoryUtilizationPercentage: 0
       scaleUpPodsValue: 6
       scaleUpPeriodSeconds: 45
     pdb:

--- a/helmfile/charts/notify-celery/values.yaml
+++ b/helmfile/charts/notify-celery/values.yaml
@@ -39,6 +39,13 @@ nodes:
       minAvailable: 2
     autoscaling:
       hpaEnabled: false
+      minReplicas: 3
+      maxReplicas: 30
+      targetCPUUtilizationPercentage: 25
+      targetMemoryUtilizationPercentage: 0
+      scaleUpPodsValue: 6
+      scaleUpPeriodSeconds: 45
+      stabilizationWindowSeconds: 90
     service:
       serviceEnabled: true
   # CELERY FOR SENDING EMAILS
@@ -64,6 +71,13 @@ nodes:
       minAvailable: 2
     autoscaling:
       hpaEnabled: false
+      minReplicas: 3
+      maxReplicas: 30
+      targetCPUUtilizationPercentage: 25
+      targetMemoryUtilizationPercentage: 0
+      scaleUpPodsValue: 6
+      scaleUpPeriodSeconds: 45
+      stabilizationWindowSeconds: 90
     service:
       serviceEnabled: true
   # CELERY FOR SENDING NON-DEDICATED LONG CODE SMS
@@ -89,6 +103,13 @@ nodes:
       minAvailable: 2
     autoscaling:
       hpaEnabled: false
+      minReplicas: 3
+      maxReplicas: 30
+      targetCPUUtilizationPercentage: 25
+      targetMemoryUtilizationPercentage: 0
+      scaleUpPodsValue: 6
+      scaleUpPeriodSeconds: 45
+      stabilizationWindowSeconds: 90
     service:
       serviceEnabled: true
   # CELERY FOR SENDING SMS WITH FAIR QUEUES

--- a/helmfile/charts/notify-celery/values.yaml
+++ b/helmfile/charts/notify-celery/values.yaml
@@ -40,7 +40,7 @@ nodes:
     autoscaling:
       hpaEnabled: false
       minReplicas: 3
-      maxReplicas: 30
+      maxReplicas: 3
       targetCPUUtilizationPercentage: 25
       targetMemoryUtilizationPercentage: 0
       scaleUpPodsValue: 6
@@ -72,7 +72,7 @@ nodes:
     autoscaling:
       hpaEnabled: false
       minReplicas: 3
-      maxReplicas: 30
+      maxReplicas: 3
       targetCPUUtilizationPercentage: 25
       targetMemoryUtilizationPercentage: 0
       scaleUpPodsValue: 6
@@ -104,7 +104,7 @@ nodes:
     autoscaling:
       hpaEnabled: false
       minReplicas: 3
-      maxReplicas: 30
+      maxReplicas: 3
       targetCPUUtilizationPercentage: 25
       targetMemoryUtilizationPercentage: 0
       scaleUpPodsValue: 6

--- a/helmfile/overrides/notify/celery.yaml.gotmpl
+++ b/helmfile/overrides/notify/celery.yaml.gotmpl
@@ -170,6 +170,7 @@ nodes:
       minReplicas: {{ if eq .Environment.Name "production" }} 3 {{ else if eq .Environment.Name "staging" }} 3 {{ else }} 3 {{ end }}
       maxReplicas: {{ if eq .Environment.Name "production" }} 30 {{ else if eq .Environment.Name "staging" }} 30 {{ else }} 30 {{ end }}
       targetCPUUtilizationPercentage: {{ if eq .Environment.Name "production" }} 25 {{ else if eq .Environment.Name "staging" }} 25 {{ else }} 25 {{ end }}
+      targetMemoryUtilizationPercentage: {{ if eq .Environment.Name "production" }} 0 {{ else if eq .Environment.Name "staging" }} 80 {{ else }} 80 {{ end }}
       scaleUpPodsValue: {{ if eq .Environment.Name "production" }} 6 {{ else if eq .Environment.Name "staging" }} 6 {{ else }} 6 {{ end }}
       scaleUpPeriodSeconds: {{ if eq .Environment.Name "production" }} 45 {{ else if eq .Environment.Name "staging" }} 45 {{ else }} 45 {{ end }}
       stabilizationWindowSeconds: {{ if eq .Environment.Name "production" }} 90 {{ else if eq .Environment.Name "staging" }} 90 {{ else }} 90 {{ end }}
@@ -193,6 +194,7 @@ nodes:
       minReplicas: {{ if eq .Environment.Name "production" }} 3 {{ else if eq .Environment.Name "staging" }} 3 {{ else }} 3 {{ end }}
       maxReplicas: {{ if eq .Environment.Name "production" }} 10 {{ else if eq .Environment.Name "staging" }} 10 {{ else }} 10 {{ end }}
       targetCPUUtilizationPercentage: {{ if eq .Environment.Name "production" }} 25 {{ else if eq .Environment.Name "staging" }} 25 {{ else }} 25 {{ end }}
+      targetMemoryUtilizationPercentage: {{ if eq .Environment.Name "production" }} 0 {{ else if eq .Environment.Name "staging" }} 80 {{ else }} 80 {{ end }}
       scaleUpPodsValue: {{ if eq .Environment.Name "production" }} 6 {{ else if eq .Environment.Name "staging" }} 6 {{ else }} 6 {{ end }}
       scaleUpPeriodSeconds: {{ if eq .Environment.Name "production" }} 45 {{ else if eq .Environment.Name "staging" }} 45 {{ else }} 45 {{ end }}
       stabilizationWindowSeconds: {{ if eq .Environment.Name "production" }} 90 {{ else if eq .Environment.Name "staging" }} 90 {{ else }} 90 {{ end }}
@@ -216,6 +218,7 @@ nodes:
       minReplicas: {{ if eq .Environment.Name "production" }} 3 {{ else if eq .Environment.Name "staging" }} 3 {{ else }} 3 {{ end }}
       maxReplicas: {{ if eq .Environment.Name "production" }} 30 {{ else if eq .Environment.Name "staging" }} 30 {{ else }} 30 {{ end }}
       targetCPUUtilizationPercentage: {{ if eq .Environment.Name "production" }} 25 {{ else if eq .Environment.Name "staging" }} 25 {{ else }} 25 {{ end }}
+      targetMemoryUtilizationPercentage: {{ if eq .Environment.Name "production" }} 0 {{ else if eq .Environment.Name "staging" }} 80 {{ else }} 80 {{ end }}
       scaleUpPodsValue: {{ if eq .Environment.Name "production" }} 6 {{ else if eq .Environment.Name "staging" }} 6 {{ else }} 6 {{ end }}
       scaleUpPeriodSeconds: {{ if eq .Environment.Name "production" }} 45 {{ else if eq .Environment.Name "staging" }} 45 {{ else }} 45 {{ end }}
       stabilizationWindowSeconds: {{ if eq .Environment.Name "production" }} 90 {{ else if eq .Environment.Name "staging" }} 90 {{ else }} 90 {{ end }}
@@ -239,6 +242,7 @@ nodes:
       minReplicas: {{ if eq .Environment.Name "production" }} 2 {{ else if eq .Environment.Name "staging" }} 2 {{ else }} 2 {{ end }}
       maxReplicas: {{ if eq .Environment.Name "production" }} 2 {{ else if eq .Environment.Name "staging" }} 2 {{ else }} 2 {{ end }}
       targetCPUUtilizationPercentage: {{ if eq .Environment.Name "production" }} 25 {{ else if eq .Environment.Name "staging" }} 25 {{ else }} 25 {{ end }}
+      targetMemoryUtilizationPercentage: {{ if eq .Environment.Name "production" }} 0 {{ else if eq .Environment.Name "staging" }} 80 {{ else }} 80 {{ end }}
       scaleUpPodsValue: {{ if eq .Environment.Name "production" }} 6 {{ else if eq .Environment.Name "staging" }} 6 {{ else }} 6 {{ end }}
       scaleUpPeriodSeconds: {{ if eq .Environment.Name "production" }} 45 {{ else if eq .Environment.Name "staging" }} 45 {{ else }} 45 {{ end }}
       stabilizationWindowSeconds: {{ if eq .Environment.Name "production" }} 90 {{ else if eq .Environment.Name "staging" }} 90 {{ else }} 90 {{ end }}

--- a/helmfile/overrides/notify/celery.yaml.gotmpl
+++ b/helmfile/overrides/notify/celery.yaml.gotmpl
@@ -111,7 +111,7 @@ nodes:
     autoscaling:
       hpaEnabled: {{ if eq .Environment.Name "production" }} false {{ else }} true {{ end }}
       minReplicas: {{ if eq .Environment.Name "production" }} 3 {{ else if eq .Environment.Name "staging" }} 3 {{ else }} 3 {{ end }}
-      maxReplicas: {{ if eq .Environment.Name "production" }} 30 {{ else if eq .Environment.Name "staging" }} 30 {{ else }} 30 {{ end }}
+      maxReplicas: {{ if eq .Environment.Name "production" }} 3 {{ else if eq .Environment.Name "staging" }} 3 {{ else }} 3 {{ end }}
       targetCPUUtilizationPercentage: {{ if eq .Environment.Name "production" }} 25 {{ else if eq .Environment.Name "staging" }} 25 {{ else }} 25 {{ end }}
       targetMemoryUtilizationPercentage: {{ if eq .Environment.Name "production" }} 0 {{ else if eq .Environment.Name "staging" }} 80 {{ else }} 80 {{ end }}
       scaleUpPodsValue: {{ if eq .Environment.Name "production" }} 6 {{ else if eq .Environment.Name "staging" }} 6 {{ else }} 6 {{ end }}
@@ -135,7 +135,7 @@ nodes:
     autoscaling:
       hpaEnabled: {{ if eq .Environment.Name "production" }} false {{ else }} true {{ end }}
       minReplicas: {{ if eq .Environment.Name "production" }} 3 {{ else if eq .Environment.Name "staging" }} 3 {{ else }} 3 {{ end }}
-      maxReplicas: {{ if eq .Environment.Name "production" }} 30 {{ else if eq .Environment.Name "staging" }} 30 {{ else }} 30 {{ end }}
+      maxReplicas: {{ if eq .Environment.Name "production" }} 3 {{ else if eq .Environment.Name "staging" }} 3 {{ else }} 3 {{ end }}
       targetCPUUtilizationPercentage: {{ if eq .Environment.Name "production" }} 25 {{ else if eq .Environment.Name "staging" }} 25 {{ else }} 25 {{ end }}
       targetMemoryUtilizationPercentage: {{ if eq .Environment.Name "production" }} 0 {{ else if eq .Environment.Name "staging" }} 80 {{ else }} 80 {{ end }}
       scaleUpPodsValue: {{ if eq .Environment.Name "production" }} 6 {{ else if eq .Environment.Name "staging" }} 6 {{ else }} 6 {{ end }}
@@ -159,7 +159,7 @@ nodes:
     autoscaling:
       hpaEnabled: {{ if eq .Environment.Name "production" }} false {{ else }} true {{ end }}
       minReplicas: {{ if eq .Environment.Name "production" }} 3 {{ else if eq .Environment.Name "staging" }} 3 {{ else }} 3 {{ end }}
-      maxReplicas: {{ if eq .Environment.Name "production" }} 30 {{ else if eq .Environment.Name "staging" }} 30 {{ else }} 30 {{ end }}
+      maxReplicas: {{ if eq .Environment.Name "production" }} 3 {{ else if eq .Environment.Name "staging" }} 3 {{ else }} 3 {{ end }}
       targetCPUUtilizationPercentage: {{ if eq .Environment.Name "production" }} 25 {{ else if eq .Environment.Name "staging" }} 25 {{ else }} 25 {{ end }}
       targetMemoryUtilizationPercentage: {{ if eq .Environment.Name "production" }} 0 {{ else if eq .Environment.Name "staging" }} 80 {{ else }} 80 {{ end }}
       scaleUpPodsValue: {{ if eq .Environment.Name "production" }} 6 {{ else if eq .Environment.Name "staging" }} 6 {{ else }} 6 {{ end }}

--- a/helmfile/overrides/notify/celery.yaml.gotmpl
+++ b/helmfile/overrides/notify/celery.yaml.gotmpl
@@ -108,6 +108,15 @@ nodes:
     pdb:
       pdbEnabled: {{ if eq .Environment.Name "production" }} true {{ else if eq .Environment.Name "staging" }} true {{ else }} true {{ end }}
       minAvailable: {{ if eq .Environment.Name "production" }} 2 {{ else if eq .Environment.Name "staging" }} 2 {{ else }} 2 {{ end }}
+    autoscaling:
+      hpaEnabled: {{ if eq .Environment.Name "production" }} false {{ else }} true {{ end }}
+      minReplicas: {{ if eq .Environment.Name "production" }} 3 {{ else if eq .Environment.Name "staging" }} 3 {{ else }} 3 {{ end }}
+      maxReplicas: {{ if eq .Environment.Name "production" }} 30 {{ else if eq .Environment.Name "staging" }} 30 {{ else }} 30 {{ end }}
+      targetCPUUtilizationPercentage: {{ if eq .Environment.Name "production" }} 25 {{ else if eq .Environment.Name "staging" }} 25 {{ else }} 25 {{ end }}
+      targetMemoryUtilizationPercentage: {{ if eq .Environment.Name "production" }} 0 {{ else if eq .Environment.Name "staging" }} 80 {{ else }} 80 {{ end }}
+      scaleUpPodsValue: {{ if eq .Environment.Name "production" }} 6 {{ else if eq .Environment.Name "staging" }} 6 {{ else }} 6 {{ end }}
+      scaleUpPeriodSeconds: {{ if eq .Environment.Name "production" }} 45 {{ else if eq .Environment.Name "staging" }} 45 {{ else }} 45 {{ end }}
+      stabilizationWindowSeconds: {{ if eq .Environment.Name "production" }} 90 {{ else if eq .Environment.Name "staging" }} 90 {{ else }} 90 {{ end }}
   email-send-static:
     deployment:
       deploymentEnabled: {{ if eq .Environment.Name "production" }} true {{ else if eq .Environment.Name "staging" }} true {{ else }} true {{ end }}
@@ -123,6 +132,15 @@ nodes:
     pdb:  
       pdbEnabled: {{ if eq .Environment.Name "production" }} true {{ else if eq .Environment.Name "staging" }} true {{ else }} true {{ end }}
       minAvailable: {{ if eq .Environment.Name "production" }} 2 {{ else if eq .Environment.Name "staging" }} 2 {{ else }} 2 {{ end }}
+    autoscaling:
+      hpaEnabled: {{ if eq .Environment.Name "production" }} false {{ else }} true {{ end }}
+      minReplicas: {{ if eq .Environment.Name "production" }} 3 {{ else if eq .Environment.Name "staging" }} 3 {{ else }} 3 {{ end }}
+      maxReplicas: {{ if eq .Environment.Name "production" }} 30 {{ else if eq .Environment.Name "staging" }} 30 {{ else }} 30 {{ end }}
+      targetCPUUtilizationPercentage: {{ if eq .Environment.Name "production" }} 25 {{ else if eq .Environment.Name "staging" }} 25 {{ else }} 25 {{ end }}
+      targetMemoryUtilizationPercentage: {{ if eq .Environment.Name "production" }} 0 {{ else if eq .Environment.Name "staging" }} 80 {{ else }} 80 {{ end }}
+      scaleUpPodsValue: {{ if eq .Environment.Name "production" }} 6 {{ else if eq .Environment.Name "staging" }} 6 {{ else }} 6 {{ end }}
+      scaleUpPeriodSeconds: {{ if eq .Environment.Name "production" }} 45 {{ else if eq .Environment.Name "staging" }} 45 {{ else }} 45 {{ end }}
+      stabilizationWindowSeconds: {{ if eq .Environment.Name "production" }} 90 {{ else if eq .Environment.Name "staging" }} 90 {{ else }} 90 {{ end }}
   sms-send-static:
     deployment:
       deploymentEnabled: {{ if eq .Environment.Name "production" }} true {{ else if eq .Environment.Name "staging" }} true {{ else }} true {{ end }}
@@ -138,6 +156,15 @@ nodes:
     pdb:
       pdbEnabled: {{ if eq .Environment.Name "production" }} true {{ else if eq .Environment.Name "staging" }} true {{ else }} true {{ end }}
       minAvailable: {{ if eq .Environment.Name "production" }} 2 {{ else if eq .Environment.Name "staging" }} 2 {{ else }} 2 {{ end }}
+    autoscaling:
+      hpaEnabled: {{ if eq .Environment.Name "production" }} false {{ else }} true {{ end }}
+      minReplicas: {{ if eq .Environment.Name "production" }} 3 {{ else if eq .Environment.Name "staging" }} 3 {{ else }} 3 {{ end }}
+      maxReplicas: {{ if eq .Environment.Name "production" }} 30 {{ else if eq .Environment.Name "staging" }} 30 {{ else }} 30 {{ end }}
+      targetCPUUtilizationPercentage: {{ if eq .Environment.Name "production" }} 25 {{ else if eq .Environment.Name "staging" }} 25 {{ else }} 25 {{ end }}
+      targetMemoryUtilizationPercentage: {{ if eq .Environment.Name "production" }} 0 {{ else if eq .Environment.Name "staging" }} 80 {{ else }} 80 {{ end }}
+      scaleUpPodsValue: {{ if eq .Environment.Name "production" }} 6 {{ else if eq .Environment.Name "staging" }} 6 {{ else }} 6 {{ end }}
+      scaleUpPeriodSeconds: {{ if eq .Environment.Name "production" }} 45 {{ else if eq .Environment.Name "staging" }} 45 {{ else }} 45 {{ end }}
+      stabilizationWindowSeconds: {{ if eq .Environment.Name "production" }} 90 {{ else if eq .Environment.Name "staging" }} 90 {{ else }} 90 {{ end }}
   sms-send-fair-static:
     deployment:
       deploymentEnabled: {{ if or (eq .Environment.Name "dev") (eq .Environment.Name "staging") }} true {{ else }} false {{ end }}
@@ -153,6 +180,8 @@ nodes:
     pdb:
       pdbEnabled: {{ if or (eq .Environment.Name "dev") (eq .Environment.Name "staging") }} false {{ else }} false {{ end }}
       minAvailable: {{ if or (eq .Environment.Name "dev") (eq .Environment.Name "staging") }} 1 {{ else }} 1 {{ end }}
+    autoscaling:
+      hpaEnabled: false
   core-tasks-scalable:
     deployment:
       deploymentEnabled: {{ if eq .Environment.Name "production" }} true {{ else if eq .Environment.Name "staging" }} true {{ else }} true {{ end }}


### PR DESCRIPTION
## What happens when your PR merges?

**tl;dr:** This will scale up k8s pods for celery workers when memory > 80% of utilization. This only applies for **dev and staging** environments at the moment.

**Why**: Goldilocks showed Celery workers are CPU over-provisioned and memory under-provisioned. The existing HPA only scaled on CPU, which was a poor signal — actual CPU usage (~15–49m) sits well below the 100m request, so the 25% threshold (25m) was nearly always met at idle, making the HPA either unresponsive or erratic. Memory pressure was the real bottleneck.

**What changed:**

Added targetMemoryUtilizationPercentage to the HPA template — the HPA now scales on both CPU and memory simultaneously (Kubernetes "max wins" rule: whichever metric demands more replicas takes effect). Gated by a {{- if }} guard so a value of 0 disables it cleanly.

Enabled the memory metric for all scalable and static task workers in staging/dev at 80% — production is explicitly set to 0 (disabled) until the metric is validated in lower environments.

Extended HPA to the static workers (core-tasks-static, email-send-static, sms-send-static) — these previously ran with a fixed replica count and no HPA at all. They're now managed by HPA in staging/dev with minReplicas=maxReplicas=3, meaning replica count is unchanged for now but memory utilization is being tracked. sms-send-fair-static and the Beat scheduler workers were intentionally left out.

- Prefix the title of your PR:
  - `fix:` - tag `main` as a new patch release
  - `feat:` - tag `main` as a new minor release
  - `BREAKING CHANGE:` - tag `main` as a new major release
  - `[MANIFEST]` or `[AUTO-PR]` - tag `main` as a new patch release and deploy to production
  - `chore:` - use for changes to non-app code (ex: GitHub actions)
- Alternatively, change the [VERSION file](https://github.com/cds-snc/notification-manifests/blob/main/VERSION) - this will not create a new tag, but rather will release the tag in `VERSION` to production.

## What are you changing?

- [ ] Releasing a new version of Notify
- [ ] Changing kubernetes configuration

## Provide some background on the changes

> Give details ex. Security patching, content update, more API pods etc

## If you are releasing a new version of Notify, what components are you updating

- [ ] API
- [ ] Admin
- [ ] Documentation
- [ ] Document download API
- [ ] notification-lambdas

## Checklist if releasing new version

- [ ] I made sure that the changes are as expected in [Notify staging](https://staging.notification.cdssandbox.xyz/)
- [ ] I have checked if the docker images I am referencing exist
  - [ ] [api lambda](https://ca-central-1.console.aws.amazon.com/ecr/repositories/private/296255494825/notify/api-lambda?region=ca-central-1) (requires Notification-Production / AdministratorAccess login)
  - [ ] [api k8s](https://gallery.ecr.aws/v6b8u5o6/notify-api)
  - [ ] [admin](https://gallery.ecr.aws/v6b8u5o6/notify-admin)
  - [ ] [documentation](https://gallery.ecr.aws/v6b8u5o6/notify-documentation)
  - [ ] [document download API](https://gallery.ecr.aws/v6b8u5o6/notify-document-download-api)
  - [ ] notification-lambdas ([heartbeat](https://ca-central-1.console.aws.amazon.com/ecr/repositories/private/296255494825/notify/heartbeat?region=ca-central-1), [ses_to_sqs_email_callbacks](https://ca-central-1.console.aws.amazon.com/ecr/repositories/private/296255494825/notify/ses_to_sqs_email_callbacks?region=ca-central-1), [system-status](https://ca-central-1.console.aws.amazon.com/ecr/repositories/private/296255494825/notify/system_status?region=ca-central-1))

## Checklist if making changes to Kubernetes

- [ ] I know how to get kubectl credentials in case it catches on fire

## After merging this PR

- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.
