### PR TITLE
NodeSelector Tweak for DB Upgrade K8s Job

### DIFF
--- a/helmfile/charts/notify-database/templates/run-database-job.yaml
+++ b/helmfile/charts/notify-database/templates/run-database-job.yaml
@@ -84,3 +84,7 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/helmfile/charts/notify-database/values.yaml
+++ b/helmfile/charts/notify-database/values.yaml
@@ -20,7 +20,7 @@ serviceAccount:
   serviceAccountName: "notify-database"
 
 nodeSelector:
-  karpenter.sh/capacity-type: spot
+  karpenter.sh/capacity-type: ON_DEMAND
 
 tolerations: []
 

--- a/helmfile/charts/notify-database/values.yaml
+++ b/helmfile/charts/notify-database/values.yaml
@@ -20,7 +20,9 @@ serviceAccount:
   serviceAccountName: "notify-database"
 
 nodeSelector:
-  eks.amazonaws.com/capacityType: ON_DEMAND
+  karpenter.sh/capacity-type: spot
+
+tolerations: []
 
 secretProviderClass:
   secretname: notify-database

--- a/helmfile/overrides/notify/database.yaml.gotmpl
+++ b/helmfile/overrides/notify/database.yaml.gotmpl
@@ -100,7 +100,7 @@ serviceAccount:
     eks.amazonaws.com/role-arn: arn:aws:iam::{{ requiredEnv "AWS_ACCOUNT_ID" }}:role/secrets-csi-role-database
 
 nodeSelector:
-  karpenter.sh/capacity-type: spot
+  karpenter.sh/capacity-type: ON_DEMAND
 
 tolerations:
   - key: nidhogg.uswitch.com/amazon-cloudwatch.aws-cloudwatch-agent

--- a/helmfile/overrides/notify/database.yaml.gotmpl
+++ b/helmfile/overrides/notify/database.yaml.gotmpl
@@ -100,4 +100,18 @@ serviceAccount:
     eks.amazonaws.com/role-arn: arn:aws:iam::{{ requiredEnv "AWS_ACCOUNT_ID" }}:role/secrets-csi-role-database
 
 nodeSelector:
-  eks.amazonaws.com/capacityType: ON_DEMAND
+  karpenter.sh/capacity-type: spot
+
+tolerations:
+  - key: nidhogg.uswitch.com/amazon-cloudwatch.aws-cloudwatch-agent
+    operator: Exists
+    effect: NoSchedule
+  - key: nidhogg.uswitch.com/amazon-cloudwatch.ebs-csi-node
+    operator: Exists
+    effect: NoSchedule
+  - key: nidhogg.uswitch.com/amazon-cloudwatch.fb-agent-fluent-bit
+    operator: Exists
+    effect: NoSchedule
+  - key: nidhogg.uswitch.com/amazon-cloudwatch.secrets-store-csi-driver
+    operator: Exists
+    effect: NoSchedule


### PR DESCRIPTION
This pull request updates the configuration for the `notify-database` Helm chart to improve node scheduling flexibility and support for tolerations. The main changes involve switching from on-demand to spot instances and adding support for specifying tolerations, both in the chart values and the job template.

**Node scheduling updates:**

- Changed the node selector label from `eks.amazonaws.com/capacityType: ON_DEMAND` to `karpenter.sh/capacity-type: spot` in both `values.yaml` and the override file, switching the default scheduling from on-demand to spot instances. [[1]](diffhunk://#diff-2f631009629feff01884cc4b9a4e4b5aa72bb389dfdf9f6b0bc62b5dafb7d3f3L23-R25) [[2]](diffhunk://#diff-82b49a58116716f45a784a218e758b9fb3cf6453b4ca62636af336f885cedec3L103-R117)

**Tolerations support:**

- Added a `tolerations` field to `values.yaml` (defaulting to an empty list) to allow specifying tolerations for the database job.
- Updated the job template (`run-database-job.yaml`) to include tolerations if they are defined in values.
- Set specific tolerations in the override file to allow the job to schedule on nodes with certain taints related to monitoring and storage agents.

## What are you changing?

- [ ] Releasing a new version of Notify
- [ ] Changing kubernetes configuration

## Provide some background on the changes

> Give details ex. Security patching, content update, more API pods etc

## If you are releasing a new version of Notify, what components are you updating

- [ ] API
- [ ] Admin
- [ ] Documentation
- [ ] Document download API
- [ ] notification-lambdas

## Checklist if releasing new version

- [ ] I made sure that the changes are as expected in [Notify staging](https://staging.notification.cdssandbox.xyz/)
- [ ] I have checked if the docker images I am referencing exist
  - [ ] [api lambda](https://ca-central-1.console.aws.amazon.com/ecr/repositories/private/296255494825/notify/api-lambda?region=ca-central-1) (requires Notification-Production / AdministratorAccess login)
  - [ ] [api k8s](https://gallery.ecr.aws/v6b8u5o6/notify-api)
  - [ ] [admin](https://gallery.ecr.aws/v6b8u5o6/notify-admin)
  - [ ] [documentation](https://gallery.ecr.aws/v6b8u5o6/notify-documentation)
  - [ ] [document download API](https://gallery.ecr.aws/v6b8u5o6/notify-document-download-api)
  - [ ] notification-lambdas ([heartbeat](https://ca-central-1.console.aws.amazon.com/ecr/repositories/private/296255494825/notify/heartbeat?region=ca-central-1), [ses_to_sqs_email_callbacks](https://ca-central-1.console.aws.amazon.com/ecr/repositories/private/296255494825/notify/ses_to_sqs_email_callbacks?region=ca-central-1), [system-status](https://ca-central-1.console.aws.amazon.com/ecr/repositories/private/296255494825/notify/system_status?region=ca-central-1))

## Checklist if making changes to Kubernetes

- [ ] I know how to get kubectl credentials in case it catches on fire

## After merging this PR

- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.
