### PR TITLE
DB Upgrade k8s job spot karpenter

### DIFF
--- a/helmfile/charts/notify-database/values.yaml
+++ b/helmfile/charts/notify-database/values.yaml
@@ -20,7 +20,7 @@ serviceAccount:
   serviceAccountName: "notify-database"
 
 nodeSelector:
-  karpenter.sh/capacity-type: ON_DEMAND
+  karpenter.sh/capacity-type: spot
 
 tolerations: []
 

--- a/helmfile/overrides/notify/database.yaml.gotmpl
+++ b/helmfile/overrides/notify/database.yaml.gotmpl
@@ -100,7 +100,7 @@ serviceAccount:
     eks.amazonaws.com/role-arn: arn:aws:iam::{{ requiredEnv "AWS_ACCOUNT_ID" }}:role/secrets-csi-role-database
 
 nodeSelector:
-  karpenter.sh/capacity-type: ON_DEMAND
+  karpenter.sh/capacity-type: spot
 
 tolerations:
   - key: nidhogg.uswitch.com/amazon-cloudwatch.aws-cloudwatch-agent


### PR DESCRIPTION
This pull request updates the deployment configuration for the `notify-database` service to use spot instances instead of on-demand instances. This change is applied in both the main Helm chart values and the environment-specific override.

Deployment configuration changes:

* Updated the `nodeSelector` in `helmfile/charts/notify-database/values.yaml` to use `karpenter.sh/capacity-type: spot` instead of `ON_DEMAND`, shifting database pods to run on spot instances.
* Made the same `nodeSelector` change in the environment override file `helmfile/overrides/notify/database.yaml.gotmpl` to ensure consistency across deployments.

## What are you changing?

- [ ] Releasing a new version of Notify
- [ ] Changing kubernetes configuration

## Provide some background on the changes

> Give details ex. Security patching, content update, more API pods etc

## If you are releasing a new version of Notify, what components are you updating

- [ ] API
- [ ] Admin
- [ ] Documentation
- [ ] Document download API
- [ ] notification-lambdas

## Checklist if releasing new version

- [ ] I made sure that the changes are as expected in [Notify staging](https://staging.notification.cdssandbox.xyz/)
- [ ] I have checked if the docker images I am referencing exist
  - [ ] [api lambda](https://ca-central-1.console.aws.amazon.com/ecr/repositories/private/296255494825/notify/api-lambda?region=ca-central-1) (requires Notification-Production / AdministratorAccess login)
  - [ ] [api k8s](https://gallery.ecr.aws/v6b8u5o6/notify-api)
  - [ ] [admin](https://gallery.ecr.aws/v6b8u5o6/notify-admin)
  - [ ] [documentation](https://gallery.ecr.aws/v6b8u5o6/notify-documentation)
  - [ ] [document download API](https://gallery.ecr.aws/v6b8u5o6/notify-document-download-api)
  - [ ] notification-lambdas ([heartbeat](https://ca-central-1.console.aws.amazon.com/ecr/repositories/private/296255494825/notify/heartbeat?region=ca-central-1), [ses_to_sqs_email_callbacks](https://ca-central-1.console.aws.amazon.com/ecr/repositories/private/296255494825/notify/ses_to_sqs_email_callbacks?region=ca-central-1), [system-status](https://ca-central-1.console.aws.amazon.com/ecr/repositories/private/296255494825/notify/system_status?region=ca-central-1))

## Checklist if making changes to Kubernetes

- [ ] I know how to get kubectl credentials in case it catches on fire

## After merging this PR

- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.
