### PR TITLE
expand the available nodes for karpenter to provision

### DIFF
--- a/helmfile/overrides/system/karpenter.yaml.gotmpl
+++ b/helmfile/overrides/system/karpenter.yaml.gotmpl
@@ -24,7 +24,8 @@ nodeClass:
 
 nodePool:
   instanceCategories: "['m', 'r', 'c']"
-  instanceFamily: "['m7i', 'r7i', 'c7i']"
-  instanceCPU: "['4']"
+  # 7th gen Intel + AMD, 6th gen Intel + AMD for broader spot pool availability
+  instanceFamily: "['m7i', 'm7a', 'r7i', 'r7a', 'c7i', 'c7a', 'm6i', 'm6a', 'r6i', 'r6a', 'c6i', 'c6a']"
+  instanceCPU: "['4', '8']"
   # Exclude signoz workload - it runs on dedicated EKS managed node group
   excludeWorkloadTypeLabel: true


### PR DESCRIPTION
## What happens when your PR merges?

We're seeing a bunch of spot instances being removed and not renewed properly because of insufficient capacity at the AWS level. I've expanded the whitelist of spot instances karpenter can provision to include slightly larger, and both intel and AMD nodes so that there's a larger variety of instances to pick from.

## What are you changing?

- [ ] Releasing a new version of Notify
- [x] Changing kubernetes configuration

## Provide some background on the changes

Running into some unavailable pod errors in staging and production due to no spot instances being provisioned.

## After merging this PR

- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.
