### PR TITLE
Enable isolated pods for periodic and nightly celery workers in production + refactorings

### DIFF
--- a/helmfile/charts/notify-celery/values.yaml
+++ b/helmfile/charts/notify-celery/values.yaml
@@ -279,30 +279,6 @@ nodes:
     service:
       serviceEnabled: true
   # CELERY FOR NIGHTLY TASKS
-  nightly-static:
-    name: nightly-static
-    scriptArg: "sh /app/scripts/run_celery_nightly.sh"
-    deployment:
-      deploymentEnabled: true
-      terminationGracePeriodSeconds: 60
-      resources:
-        requests:
-          cpu: "100m"
-          memory: "800Mi"
-        limits:
-          cpu: "550m"
-          memory: "1024Mi"
-      priorityClassName: high-priority
-      nodeSelector:
-        eks.amazonaws.com/capacityType: ON_DEMAND
-      replicas: 1
-    pdb:
-      pdbEnabled: true
-      minAvailable: 0
-    autoscaling:
-      hpaEnabled: false
-    service:
-      serviceEnabled: true  
   nightly-burst:
     name: nightly-burst
     scriptArg: "sh /app/scripts/run_celery_nightly.sh"
@@ -310,9 +286,9 @@ nodes:
       deploymentEnabled: true
       priorityClassName: celery
       terminationGracePeriodSeconds: 60
-      replicas: 0
+      replicas: 1
       nodeSelector:
-        karpenter.sh/capacity-type: spot
+        eks.amazonaws.com/capacityType: ON_DEMAND
       resources:
         requests:
           cpu: "100m" 
@@ -322,14 +298,14 @@ nodes:
           memory: "1024Mi"
     autoscaling:
       hpaEnabled: true
-      minReplicas: 0
-      maxReplicas: 3
+      minReplicas: 1
+      maxReplicas: 4
       targetCPUUtilizationPercentage: 25
       scaleUpPodsValue: 1
       scaleUpPeriodSeconds: 45
     pdb:
       pdbEnabled: true
-      minAvailable: 0
+      minAvailable: 1
     service:
       serviceEnabled: true
   # CELERY FOR PERIODIC TASKS

--- a/helmfile/charts/notify-celery/values.yaml
+++ b/helmfile/charts/notify-celery/values.yaml
@@ -157,10 +157,10 @@ nodes:
       hpaEnabled: false
     service:
       serviceEnabled: true
-  # SCALABLE CONFIGS
+  # burst CONFIGS
   # CELERY FOR CORE TASKS
-  core-tasks-scalable:
-    name: core-tasks-scalable
+  core-tasks-burst:
+    name: core-tasks-burst
     scriptArg: "sh /app/scripts/run_celery_core_tasks.sh"
     deployment:
       deploymentEnabled: true
@@ -189,8 +189,8 @@ nodes:
     service:
       serviceEnabled: true
   # CELERY FOR DELIVERY RECEIPTS
-  delivery-receipts-scalable:
-    name: delivery-receipts-scalable
+  delivery-receipts-burst:
+    name: delivery-receipts-burst
     scriptArg: "sh /app/scripts/run_celery_receipts.sh"
     deployment:
       deploymentEnabled: true
@@ -219,8 +219,8 @@ nodes:
     service:
       serviceEnabled: true
   # CELERY FOR SENDING EMAILS
-  scalable-email:
-    name: email-send-scalable
+  email-burst:
+    name: email-send-burst
     scriptArg: "sh /app/scripts/run_celery_send_email.sh"
     deployment:
       deploymentEnabled: true
@@ -249,8 +249,8 @@ nodes:
     service:
       serviceEnabled: true
   # CELERY FOR SENDING NON-DEDICATED LONG CODE SMS
-  scalable-sms:
-    name: sms-send-scalable
+  sms-burst:
+    name: sms-send-burst
     scriptArg: "sh /app/scripts/run_celery_send_sms.sh"
     deployment:
       deploymentEnabled: true
@@ -279,8 +279,8 @@ nodes:
     service:
       serviceEnabled: true
   # CELERY FOR NIGHTLY TASKS
-  scalable-nightly:
-    name: scalable-nightly
+  nightly-burst:
+    name: nightly-burst
     scriptArg: "sh /app/scripts/run_celery_nightly.sh"
     deployment:
       deploymentEnabled: true
@@ -309,8 +309,32 @@ nodes:
     service:
       serviceEnabled: true
   # CELERY FOR PERIODIC TASKS
-  scalable-periodic:
-    name: scalable-periodic
+  periodic-static:
+    name: periodic-static
+    scriptArg: "sh /app/scripts/run_celery_periodic.sh"
+    deployment:
+      deploymentEnabled: true
+      terminationGracePeriodSeconds: 60
+      resources:
+        requests:
+          cpu: "100m"
+          memory: "800Mi"
+        limits:
+          cpu: "550m"
+          memory: "1024Mi"
+      priorityClassName: high-priority
+      nodeSelector:
+        eks.amazonaws.com/capacityType: ON_DEMAND
+      replicas: 6
+    pdb:
+      pdbEnabled: true
+      minAvailable: 3
+    autoscaling:
+      hpaEnabled: false
+    service:
+      serviceEnabled: true
+  periodic-burst:
+    name: periodic-burst
     scriptArg: "sh /app/scripts/run_celery_periodic.sh"
     deployment:
       deploymentEnabled: true
@@ -318,7 +342,7 @@ nodes:
       terminationGracePeriodSeconds: 60
       replicas: 3
       nodeSelector:
-        eks.amazonaws.com/capacityType: ON_DEMAND
+        karpenter.sh/capacity-type: spot
       resources:
         requests:
           cpu: "100m"
@@ -328,14 +352,14 @@ nodes:
           memory: "1024Mi"
     autoscaling:
       hpaEnabled: true
-      minReplicas: 3
-      maxReplicas: 6
+      minReplicas: 1
+      maxReplicas: 4
       targetCPUUtilizationPercentage: 25
       scaleUpPodsValue: 1
       scaleUpPeriodSeconds: 45
     pdb:
       pdbEnabled: true
-      minAvailable: 3
+      minAvailable: 1
     service:
       serviceEnabled: true
 

--- a/helmfile/charts/notify-celery/values.yaml
+++ b/helmfile/charts/notify-celery/values.yaml
@@ -279,6 +279,30 @@ nodes:
     service:
       serviceEnabled: true
   # CELERY FOR NIGHTLY TASKS
+  nightly-static:
+    name: nightly-static
+    scriptArg: "sh /app/scripts/run_celery_nightly.sh"
+    deployment:
+      deploymentEnabled: true
+      terminationGracePeriodSeconds: 60
+      resources:
+        requests:
+          cpu: "100m"
+          memory: "800Mi"
+        limits:
+          cpu: "550m"
+          memory: "1024Mi"
+      priorityClassName: high-priority
+      nodeSelector:
+        eks.amazonaws.com/capacityType: ON_DEMAND
+      replicas: 1
+    pdb:
+      pdbEnabled: true
+      minAvailable: 0
+    autoscaling:
+      hpaEnabled: false
+    service:
+      serviceEnabled: true  
   nightly-burst:
     name: nightly-burst
     scriptArg: "sh /app/scripts/run_celery_nightly.sh"
@@ -286,9 +310,9 @@ nodes:
       deploymentEnabled: true
       priorityClassName: celery
       terminationGracePeriodSeconds: 60
-      replicas: 1
+      replicas: 0
       nodeSelector:
-        eks.amazonaws.com/capacityType: ON_DEMAND
+        karpenter.sh/capacity-type: spot
       resources:
         requests:
           cpu: "100m" 
@@ -298,14 +322,14 @@ nodes:
           memory: "1024Mi"
     autoscaling:
       hpaEnabled: true
-      minReplicas: 1
+      minReplicas: 0
       maxReplicas: 3
       targetCPUUtilizationPercentage: 25
       scaleUpPodsValue: 1
       scaleUpPeriodSeconds: 45
     pdb:
       pdbEnabled: true
-      minAvailable: 1
+      minAvailable: 0
     service:
       serviceEnabled: true
   # CELERY FOR PERIODIC TASKS

--- a/helmfile/overrides/notify/celery.yaml.gotmpl
+++ b/helmfile/overrides/notify/celery.yaml.gotmpl
@@ -170,21 +170,6 @@ nodes:
     pdb:
       pdbEnabled: true
       minAvailable: {{ if eq .Environment.Name "production" }} 3 {{ else if eq .Environment.Name "staging" }} 3 {{ else }} 1 {{ end }}
-  nightly-static:
-    deployment:
-      deploymentEnabled: true
-      terminationGracePeriodSeconds: {{ if eq .Environment.Name "production" }} 60 {{ else if eq .Environment.Name "staging" }} 60 {{ else }} 60 {{ end }}
-      replicas: {{ if eq .Environment.Name "production" }} 1 {{ else if eq .Environment.Name "staging" }} 1 {{ else }} 1 {{ end }}
-      resources:
-        requests:
-          cpu: {{ if eq .Environment.Name "production" }} "100m" {{ else if eq .Environment.Name "staging" }} "100m" {{ else }} "100m" {{ end }}
-          memory: {{ if eq .Environment.Name "production" }} "800Mi" {{ else if eq .Environment.Name "staging" }} "800Mi" {{ else }} "800Mi" {{ end }}
-        limits:
-          cpu: {{ if eq .Environment.Name "production" }} "550m" {{ else if eq .Environment.Name "staging" }} "550m" {{ else }} "550m" {{ end }}
-          memory: {{ if eq .Environment.Name "production" }} "1024Mi" {{ else if eq .Environment.Name "staging" }} "1024Mi" {{ else }} "1024Mi" {{ end }}
-    pdb:
-      pdbEnabled: true
-      minAvailable: {{ if eq .Environment.Name "production" }} 0 {{ else if eq .Environment.Name "staging" }} 0 {{ else }} 0 {{ end }}
   core-tasks-burst:
     deployment:
       deploymentEnabled: {{ if eq .Environment.Name "production" }} true {{ else if eq .Environment.Name "staging" }} true {{ else }} true {{ end }}
@@ -281,7 +266,7 @@ nodes:
     deployment:
       deploymentEnabled: true
       terminationGracePeriodSeconds: {{ if eq .Environment.Name "production" }} 60 {{ else if eq .Environment.Name "staging" }} 60 {{ else }} 60 {{ end }}
-      replicas: {{ if eq .Environment.Name "production" }} 0 {{ else if eq .Environment.Name "staging" }} 0 {{ else }} 0 {{ end }}
+      replicas: {{ if eq .Environment.Name "production" }} 1 {{ else if eq .Environment.Name "staging" }} 1 {{ else }} 1 {{ end }}
       resources:
         requests:
           cpu: {{ if eq .Environment.Name "production" }} "100m" {{ else if eq .Environment.Name "staging" }} "100m" {{ else }} "100m" {{ end }}
@@ -291,15 +276,15 @@ nodes:
           memory: {{ if eq .Environment.Name "production" }} "1024Mi" {{ else if eq .Environment.Name "staging" }} "1024Mi" {{ else }} "1024Mi" {{ end }}
     autoscaling:
       hpaEnabled: true
-      minReplicas: {{ if eq .Environment.Name "production" }} 0 {{ else if eq .Environment.Name "staging" }} 0 {{ else }} 0 {{ end }}
-      maxReplicas: {{ if eq .Environment.Name "production" }} 3 {{ else if eq .Environment.Name "staging" }} 3 {{ else }} 3 {{ end }}
+      minReplicas: {{ if eq .Environment.Name "production" }} 1 {{ else if eq .Environment.Name "staging" }} 1 {{ else }} 1 {{ end }}
+      maxReplicas: {{ if eq .Environment.Name "production" }} 4 {{ else if eq .Environment.Name "staging" }} 4 {{ else }} 4 {{ end }}
       targetCPUUtilizationPercentage: {{ if eq .Environment.Name "production" }} 25 {{ else if eq .Environment.Name "staging" }} 25 {{ else }} 25 {{ end }}
       scaleUpPodsValue: {{ if eq .Environment.Name "production" }} 1 {{ else if eq .Environment.Name "staging" }} 1 {{ else }} 1 {{ end }}
       scaleUpPeriodSeconds: {{ if eq .Environment.Name "production" }} 45 {{ else if eq .Environment.Name "staging" }} 45 {{ else }} 45 {{ end }}
       stabilizationWindowSeconds: {{ if eq .Environment.Name "production" }} 90 {{ else if eq .Environment.Name "staging" }} 90 {{ else }} 90 {{ end }}
     pdb:
       pdbEnabled: true
-      minAvailable: {{ if eq .Environment.Name "production" }} 0 {{ else if eq .Environment.Name "staging" }} 0 {{ else }} 0 {{ end }}
+      minAvailable: {{ if eq .Environment.Name "production" }} 1 {{ else if eq .Environment.Name "staging" }} 1 {{ else }} 1 {{ end }}
   periodic-burst:
     deployment:
       deploymentEnabled: true

--- a/helmfile/overrides/notify/celery.yaml.gotmpl
+++ b/helmfile/overrides/notify/celery.yaml.gotmpl
@@ -155,7 +155,22 @@ nodes:
     pdb:
       pdbEnabled: {{ if or (eq .Environment.Name "dev") (eq .Environment.Name "staging") }} false {{ else }} false {{ end }}
       minAvailable: {{ if or (eq .Environment.Name "dev") (eq .Environment.Name "staging") }} 1 {{ else }} 1 {{ end }}
-  core-tasks-scalable:
+  periodic-static:
+    deployment:
+      deploymentEnabled: true
+      terminationGracePeriodSeconds: {{ if eq .Environment.Name "production" }} 60 {{ else if eq .Environment.Name "staging" }} 60 {{ else }} 60 {{ end }}
+      replicas: {{ if eq .Environment.Name "production" }} 6 {{ else if eq .Environment.Name "staging" }} 6 {{ else }} 3 {{ end }}
+      resources:
+        requests:
+          cpu: {{ if eq .Environment.Name "production" }} "100m" {{ else if eq .Environment.Name "staging" }} "100m" {{ else }} "100m" {{ end }}
+          memory: {{ if eq .Environment.Name "production" }} "800Mi" {{ else if eq .Environment.Name "staging" }} "800Mi" {{ else }} "800Mi" {{ end }}
+        limits:
+          cpu: {{ if eq .Environment.Name "production" }} "550m" {{ else if eq .Environment.Name "staging" }} "550m" {{ else }} "550m" {{ end }}
+          memory: {{ if eq .Environment.Name "production" }} "1024Mi" {{ else if eq .Environment.Name "staging" }} "1024Mi" {{ else }} "1024Mi" {{ end }}
+    pdb:
+      pdbEnabled: true
+      minAvailable: {{ if eq .Environment.Name "production" }} 3 {{ else if eq .Environment.Name "staging" }} 3 {{ else }} 1 {{ end }}
+  core-tasks-burst:
     deployment:
       deploymentEnabled: {{ if eq .Environment.Name "production" }} true {{ else if eq .Environment.Name "staging" }} true {{ else }} true {{ end }}
       terminationGracePeriodSeconds: {{ if eq .Environment.Name "production" }} 60 {{ else if eq .Environment.Name "staging" }} 60 {{ else }} 60 {{ end }}
@@ -178,7 +193,7 @@ nodes:
     pdb:
       pdbEnabled: {{ if eq .Environment.Name "production" }} true {{ else if eq .Environment.Name "staging" }} true {{ else }} true {{ end }}
       minAvailable: {{ if eq .Environment.Name "production" }} 2 {{ else if eq .Environment.Name "staging" }} 2 {{ else }} 2 {{ end }}
-  delivery-receipts-scalable:
+  delivery-receipts-burst:
     deployment:
       deploymentEnabled: {{ if eq .Environment.Name "production" }} true {{ else if eq .Environment.Name "staging" }} true {{ else }} true {{ end }}
       terminationGracePeriodSeconds: {{ if eq .Environment.Name "production" }} 60 {{ else if eq .Environment.Name "staging" }} 60 {{ else }} 60 {{ end }}
@@ -201,7 +216,7 @@ nodes:
     pdb:
       pdbEnabled: {{ if eq .Environment.Name "production" }} true {{ else if eq .Environment.Name "staging" }} true {{ else }} true {{ end }}
       minAvailable: {{ if eq .Environment.Name "production" }} 2 {{ else if eq .Environment.Name "staging" }} 2 {{ else }} 2 {{ end }}
-  scalable-email:
+  email-burst:
     deployment:
       deploymentEnabled: {{ if eq .Environment.Name "production" }} true {{ else if eq .Environment.Name "staging" }} true {{ else }} true {{ end }}
       terminationGracePeriodSeconds: {{ if eq .Environment.Name "production" }} 60 {{ else if eq .Environment.Name "staging" }} 60 {{ else }} 60 {{ end }}
@@ -224,7 +239,7 @@ nodes:
     pdb:
       pdbEnabled: {{ if eq .Environment.Name "production" }} true {{ else if eq .Environment.Name "staging" }} true {{ else }} true {{ end }}
       minAvailable: {{ if eq .Environment.Name "production" }} 2 {{ else if eq .Environment.Name "staging" }} 2 {{ else }} 2 {{ end }}
-  scalable-sms:
+  sms-burst:
     deployment:
       deploymentEnabled: {{ if eq .Environment.Name "production" }} true {{ else if eq .Environment.Name "staging" }} true {{ else }} true {{ end }}
       terminationGracePeriodSeconds: {{ if eq .Environment.Name "production" }} 60 {{ else if eq .Environment.Name "staging" }} 60 {{ else }} 60 {{ end }}
@@ -247,7 +262,7 @@ nodes:
     pdb:
       pdbEnabled: {{ if eq .Environment.Name "production" }} true {{ else if eq .Environment.Name "staging" }} true {{ else }} true {{ end }}
       minAvailable: {{ if eq .Environment.Name "production" }} 2 {{ else if eq .Environment.Name "staging" }} 2 {{ else }} 2 {{ end }}
-  scalable-nightly:
+  nightly-burst:
     deployment:
       deploymentEnabled: {{ if eq .Environment.Name "production" }} false {{ else if eq .Environment.Name "staging" }} true {{ else }} true {{ end }}
       terminationGracePeriodSeconds: {{ if eq .Environment.Name "production" }} 60 {{ else if eq .Environment.Name "staging" }} 60 {{ else }} 60 {{ end }}
@@ -270,11 +285,11 @@ nodes:
     pdb:
       pdbEnabled: {{ if eq .Environment.Name "production" }} false {{ else if eq .Environment.Name "staging" }} true {{ else }} true {{ end }}
       minAvailable: {{ if eq .Environment.Name "production" }} 1 {{ else if eq .Environment.Name "staging" }} 1 {{ else }} 1 {{ end }}
-  scalable-periodic:
+  periodic-burst:
     deployment:
-      deploymentEnabled: {{ if eq .Environment.Name "production" }} false {{ else if eq .Environment.Name "staging" }} true {{ else }} true {{ end }}
+      deploymentEnabled: true
       terminationGracePeriodSeconds: {{ if eq .Environment.Name "production" }} 60 {{ else if eq .Environment.Name "staging" }} 60 {{ else }} 60 {{ end }}
-      replicas: {{ if eq .Environment.Name "production" }} 3 {{ else if eq .Environment.Name "staging" }} 3 {{ else }} 3 {{ end }}
+      replicas: {{ if eq .Environment.Name "production" }} 4 {{ else if eq .Environment.Name "staging" }} 4 {{ else }} 1 {{ end }}
       resources:
         requests:
           cpu: {{ if eq .Environment.Name "production" }} "100m" {{ else if eq .Environment.Name "staging" }} "100m" {{ else }} "100m" {{ end }}
@@ -283,13 +298,13 @@ nodes:
           cpu: {{ if eq .Environment.Name "production" }} "550m" {{ else if eq .Environment.Name "staging" }} "550m" {{ else }} "550m" {{ end }}
           memory: {{ if eq .Environment.Name "production" }} "1024Mi" {{ else if eq .Environment.Name "staging" }} "1024Mi" {{ else }} "1024Mi" {{ end }}
     autoscaling:
-      hpaEnabled: {{ if eq .Environment.Name "production" }} false {{ else if eq .Environment.Name "staging" }} true {{ else }} true {{ end }}
-      minReplicas: {{ if eq .Environment.Name "production" }} 3 {{ else if eq .Environment.Name "staging" }} 3 {{ else }} 3 {{ end }}
-      maxReplicas: {{ if eq .Environment.Name "production" }} 6 {{ else if eq .Environment.Name "staging" }} 6 {{ else }} 6 {{ end }}
+      hpaEnabled: true
+      minReplicas: {{ if eq .Environment.Name "production" }} 1 {{ else if eq .Environment.Name "staging" }} 1 {{ else }} 1 {{ end }}
+      maxReplicas: {{ if eq .Environment.Name "production" }} 4 {{ else if eq .Environment.Name "staging" }} 4 {{ else }} 1 {{ end }}
       targetCPUUtilizationPercentage: {{ if eq .Environment.Name "production" }} 25 {{ else if eq .Environment.Name "staging" }} 25 {{ else }} 25 {{ end }}
       scaleUpPodsValue: {{ if eq .Environment.Name "production" }} 1 {{ else if eq .Environment.Name "staging" }} 1 {{ else }} 1 {{ end }}
       scaleUpPeriodSeconds: {{ if eq .Environment.Name "production" }} 45 {{ else if eq .Environment.Name "staging" }} 45 {{ else }} 45 {{ end }}
       stabilizationWindowSeconds: {{ if eq .Environment.Name "production" }} 90 {{ else if eq .Environment.Name "staging" }} 90 {{ else }} 90 {{ end }}
     pdb:
-      pdbEnabled: {{ if eq .Environment.Name "production" }} false {{ else if eq .Environment.Name "staging" }} true {{ else }} true {{ end }}
-      minAvailable: {{ if eq .Environment.Name "production" }} 3 {{ else if eq .Environment.Name "staging" }} 3 {{ else }} 3 {{ end }}
+      pdbEnabled: true
+      minAvailable: {{ if eq .Environment.Name "production" }} 1 {{ else if eq .Environment.Name "staging" }} 1 {{ else }} 1 {{ end }}

--- a/helmfile/overrides/notify/celery.yaml.gotmpl
+++ b/helmfile/overrides/notify/celery.yaml.gotmpl
@@ -170,6 +170,21 @@ nodes:
     pdb:
       pdbEnabled: true
       minAvailable: {{ if eq .Environment.Name "production" }} 3 {{ else if eq .Environment.Name "staging" }} 3 {{ else }} 1 {{ end }}
+  nightly-static:
+    deployment:
+      deploymentEnabled: true
+      terminationGracePeriodSeconds: {{ if eq .Environment.Name "production" }} 60 {{ else if eq .Environment.Name "staging" }} 60 {{ else }} 60 {{ end }}
+      replicas: {{ if eq .Environment.Name "production" }} 1 {{ else if eq .Environment.Name "staging" }} 1 {{ else }} 1 {{ end }}
+      resources:
+        requests:
+          cpu: {{ if eq .Environment.Name "production" }} "100m" {{ else if eq .Environment.Name "staging" }} "100m" {{ else }} "100m" {{ end }}
+          memory: {{ if eq .Environment.Name "production" }} "800Mi" {{ else if eq .Environment.Name "staging" }} "800Mi" {{ else }} "800Mi" {{ end }}
+        limits:
+          cpu: {{ if eq .Environment.Name "production" }} "550m" {{ else if eq .Environment.Name "staging" }} "550m" {{ else }} "550m" {{ end }}
+          memory: {{ if eq .Environment.Name "production" }} "1024Mi" {{ else if eq .Environment.Name "staging" }} "1024Mi" {{ else }} "1024Mi" {{ end }}
+    pdb:
+      pdbEnabled: true
+      minAvailable: {{ if eq .Environment.Name "production" }} 0 {{ else if eq .Environment.Name "staging" }} 0 {{ else }} 0 {{ end }}
   core-tasks-burst:
     deployment:
       deploymentEnabled: {{ if eq .Environment.Name "production" }} true {{ else if eq .Environment.Name "staging" }} true {{ else }} true {{ end }}
@@ -264,9 +279,9 @@ nodes:
       minAvailable: {{ if eq .Environment.Name "production" }} 2 {{ else if eq .Environment.Name "staging" }} 2 {{ else }} 2 {{ end }}
   nightly-burst:
     deployment:
-      deploymentEnabled: {{ if eq .Environment.Name "production" }} false {{ else if eq .Environment.Name "staging" }} true {{ else }} true {{ end }}
+      deploymentEnabled: true
       terminationGracePeriodSeconds: {{ if eq .Environment.Name "production" }} 60 {{ else if eq .Environment.Name "staging" }} 60 {{ else }} 60 {{ end }}
-      replicas: {{ if eq .Environment.Name "production" }} 1 {{ else if eq .Environment.Name "staging" }} 1 {{ else }} 1 {{ end }}
+      replicas: {{ if eq .Environment.Name "production" }} 0 {{ else if eq .Environment.Name "staging" }} 0 {{ else }} 0 {{ end }}
       resources:
         requests:
           cpu: {{ if eq .Environment.Name "production" }} "100m" {{ else if eq .Environment.Name "staging" }} "100m" {{ else }} "100m" {{ end }}
@@ -275,16 +290,16 @@ nodes:
           cpu: {{ if eq .Environment.Name "production" }} "550m" {{ else if eq .Environment.Name "staging" }} "550m" {{ else }} "550m" {{ end }}
           memory: {{ if eq .Environment.Name "production" }} "1024Mi" {{ else if eq .Environment.Name "staging" }} "1024Mi" {{ else }} "1024Mi" {{ end }}
     autoscaling:
-      hpaEnabled: {{ if eq .Environment.Name "production" }} false {{ else if eq .Environment.Name "staging" }} true {{ else }} true {{ end }}
-      minReplicas: {{ if eq .Environment.Name "production" }} 1 {{ else if eq .Environment.Name "staging" }} 1 {{ else }} 1 {{ end }}
+      hpaEnabled: true
+      minReplicas: {{ if eq .Environment.Name "production" }} 0 {{ else if eq .Environment.Name "staging" }} 0 {{ else }} 0 {{ end }}
       maxReplicas: {{ if eq .Environment.Name "production" }} 3 {{ else if eq .Environment.Name "staging" }} 3 {{ else }} 3 {{ end }}
       targetCPUUtilizationPercentage: {{ if eq .Environment.Name "production" }} 25 {{ else if eq .Environment.Name "staging" }} 25 {{ else }} 25 {{ end }}
       scaleUpPodsValue: {{ if eq .Environment.Name "production" }} 1 {{ else if eq .Environment.Name "staging" }} 1 {{ else }} 1 {{ end }}
       scaleUpPeriodSeconds: {{ if eq .Environment.Name "production" }} 45 {{ else if eq .Environment.Name "staging" }} 45 {{ else }} 45 {{ end }}
       stabilizationWindowSeconds: {{ if eq .Environment.Name "production" }} 90 {{ else if eq .Environment.Name "staging" }} 90 {{ else }} 90 {{ end }}
     pdb:
-      pdbEnabled: {{ if eq .Environment.Name "production" }} false {{ else if eq .Environment.Name "staging" }} true {{ else }} true {{ end }}
-      minAvailable: {{ if eq .Environment.Name "production" }} 1 {{ else if eq .Environment.Name "staging" }} 1 {{ else }} 1 {{ end }}
+      pdbEnabled: true
+      minAvailable: {{ if eq .Environment.Name "production" }} 0 {{ else if eq .Environment.Name "staging" }} 0 {{ else }} 0 {{ end }}
   periodic-burst:
     deployment:
       deploymentEnabled: true


### PR DESCRIPTION
## What happens when your PR merges?

- Prefix the title of your PR:
  - `fix:` - tag `main` as a new patch release
  - `feat:` - tag `main` as a new minor release
  - `BREAKING CHANGE:` - tag `main` as a new major release
  - `[MANIFEST]` or `[AUTO-PR]` - tag `main` as a new patch release and deploy to production
  - `chore:` - use for changes to non-app code (ex: GitHub actions)
- Alternatively, change the [VERSION file](https://github.com/cds-snc/notification-manifests/blob/main/VERSION) - this will not create a new tag, but rather will release the tag in `VERSION` to production.

## What are you changing?

There are numerous changes contained in this pull requests:

* Renamed the scalable deployment to burst to better express intent behind these (yes they scale up and down, but they are meant for bursty traffic)
* Enabled isolation of periodic + nightly Celery workers in production
* Scaled up periodic pods to 6 instances always with 4 burst

We are enabling isolation of the periodic + nightly Celery workers in their own pods. The goal is to have these isolated from other workers if these crash, so these can continue to work independently. The opposite is true: if nightly task crash, don't affect the other running Celery tasks (such as periodic tasks which are vital for sending notifications). 

- [ ] Releasing a new version of Notify
- [ ] Changing kubernetes configuration

## Provide some background on the changes

> Give details ex. Security patching, content update, more API pods etc

## If you are releasing a new version of Notify, what components are you updating

- [ ] API
- [ ] Admin
- [ ] Documentation
- [ ] Document download API
- [ ] notification-lambdas

## Checklist if releasing new version

- [ ] I made sure that the changes are as expected in [Notify staging](https://staging.notification.cdssandbox.xyz/)
- [ ] I have checked if the docker images I am referencing exist
  - [ ] [api lambda](https://ca-central-1.console.aws.amazon.com/ecr/repositories/private/296255494825/notify/api-lambda?region=ca-central-1) (requires Notification-Production / AdministratorAccess login)
  - [ ] [api k8s](https://gallery.ecr.aws/v6b8u5o6/notify-api)
  - [ ] [admin](https://gallery.ecr.aws/v6b8u5o6/notify-admin)
  - [ ] [documentation](https://gallery.ecr.aws/v6b8u5o6/notify-documentation)
  - [ ] [document download API](https://gallery.ecr.aws/v6b8u5o6/notify-document-download-api)
  - [ ] notification-lambdas ([heartbeat](https://ca-central-1.console.aws.amazon.com/ecr/repositories/private/296255494825/notify/heartbeat?region=ca-central-1), [ses_to_sqs_email_callbacks](https://ca-central-1.console.aws.amazon.com/ecr/repositories/private/296255494825/notify/ses_to_sqs_email_callbacks?region=ca-central-1), [system-status](https://ca-central-1.console.aws.amazon.com/ecr/repositories/private/296255494825/notify/system_status?region=ca-central-1))

## Checklist if making changes to Kubernetes

- [ ] I know how to get kubectl credentials in case it catches on fire

## After merging this PR

- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.
