### PR TITLE
client side otel

### DIFF
--- a/helmfile/overrides/notify/admin.yaml.gotmpl
+++ b/helmfile/overrides/notify/admin.yaml.gotmpl
@@ -51,6 +51,11 @@ admin:
   OTEL_SERVICE_NAME: "notification-admin"
   OTEL_RESOURCE_ATTRIBUTES: "service.namespace=notification-canada-ca,deployment.environment={{ .Environment.Name }}"
 {{ end }}
+{{ if ne .Environment.Name "production" }}
+  ENABLE_CLIENT_SIDE_OTEL: "true"
+  OTLP_ENDPOINT: "http://signoz-otel-collector.signoz.svc.cluster.local:4318"
+{{ end }}
+
 
 adminSecrets:
   ADMIN_CLIENT_SECRET: MANIFEST_ADMIN_CLIENT_SECRET


### PR DESCRIPTION
## What happens when your PR merges?

Enable client side otel in staging

## What are you changing?

- [ ] Releasing a new version of Notify
- [x] Changing kubernetes configuration

## Provide some background on the changes

https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/806


## After merging this PR

- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.
