### PR TITLE
adding back missing, required, action

### DIFF
--- a/.github/actions/update-lambda-function/action.yaml
+++ b/.github/actions/update-lambda-function/action.yaml
@@ -1,0 +1,44 @@
+name: Update lambda function
+description: Updates a lambda function, publishes a new version and updates the function alias
+inputs:
+  alias-name:
+    description: Name of the alias to update
+    required: true
+  function-name:
+    description: Name of the function to update
+    required: true
+  image-uri:
+    description: Image tag to update the function with (if not specified, only the lambda description is updated to trigger a reload)
+    default: ''
+    required: false
+
+runs:
+  using: "composite"
+  steps:
+  
+    - name: Update lambda image
+      if: inputs.image-uri != ''
+      shell: bash
+      run: |
+        aws lambda update-function-code \
+          --function-name ${{ inputs.function-name }} \
+          --image-uri ${{ inputs.image-uri }} > /dev/null 2>&1
+
+    - name: Update lambda description
+      if: inputs.image-uri == ''
+      shell: bash
+      run: |
+        aws lambda update-function-configuration \
+          --function-name ${{ inputs.function-name }} \
+          --description $(date -u +"%Y-%m-%dT%H:%M:%SZ") > /dev/null 2>&1
+
+    - name: Publish version and update alias
+      shell: bash
+      run: |
+        aws lambda wait function-updated --function-name ${{ inputs.function-name }}
+        VERSION="$(aws lambda publish-version --function-name ${{ inputs.function-name }} | jq -r '.Version')"
+
+        aws lambda update-alias \
+          --function-name ${{ inputs.function-name }} \
+          --name ${{ inputs.alias-name }} \
+          --function-version "$VERSION" > /dev/null 2>&1

--- a/helmfile/overrides/system/signoz-importer.yaml.gotmpl
+++ b/helmfile/overrides/system/signoz-importer.yaml.gotmpl
@@ -15,7 +15,6 @@ dashboards:
   - aws-elasticache-redis.json
   - aws-rds-postgres.json
   - clickhouse-overview.json
-  - lambda-api.json
   - k8s-api.json
   - notify-api-traces.json
   - notify-admin-traces.json


### PR DESCRIPTION
## What happens when your PR merges?

This pull request introduces a new GitHub Action for updating AWS Lambda functions. The action allows you to update a Lambda function's image, publish a new version, and update the function's alias. If no image is specified, it will update the description to trigger a reload instead.

**New GitHub Action for Lambda Management:**

* Added `.github/actions/update-lambda-function/action.yaml` to automate Lambda function updates, including updating the image, publishing a new version, and updating the alias. If no image is provided, the action updates the function description to trigger a reload.

## If you are releasing a new version of Notify, what components are you updating

- [ ] API
- [ ] Admin
- [ ] Documentation
- [ ] Document download API
- [ ] notification-lambdas

## Checklist if releasing new version

- [ ] I made sure that the changes are as expected in [Notify staging](https://staging.notification.cdssandbox.xyz/)
- [ ] I have checked if the docker images I am referencing exist
  - [ ] [api k8s](https://gallery.ecr.aws/v6b8u5o6/notify-api)
  - [ ] [admin](https://gallery.ecr.aws/v6b8u5o6/notify-admin)
  - [ ] [documentation](https://gallery.ecr.aws/v6b8u5o6/notify-documentation)
  - [ ] [document download API](https://gallery.ecr.aws/v6b8u5o6/notify-document-download-api)
  - [ ] notification-lambdas ([heartbeat](https://ca-central-1.console.aws.amazon.com/ecr/repositories/private/296255494825/notify/heartbeat?region=ca-central-1), [ses_to_sqs_email_callbacks](https://ca-central-1.console.aws.amazon.com/ecr/repositories/private/296255494825/notify/ses_to_sqs_email_callbacks?region=ca-central-1), [system-status](https://ca-central-1.console.aws.amazon.com/ecr/repositories/private/296255494825/notify/system_status?region=ca-central-1))

## Checklist if making changes to Kubernetes

- [ ] I know how to get kubectl credentials in case it catches on fire

## After merging this PR

- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.
