### PR TITLE
Tweaking Secrets management for DB upgrade pod

### DIFF
--- a/helmfile/charts/notify-database/templates/run-database-job.yaml
+++ b/helmfile/charts/notify-database/templates/run-database-job.yaml
@@ -22,35 +22,31 @@ spec:
         - name: init-postgres
           image: alpine
           command:
-            [
-              "sh",
-              "-c",
-              "until nslookup $POSTGRES_HOST; do echo waiting for postgres; sleep 2; done;",
-            ]
-          env:
-            - name: POSTGRES_HOST
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.secretProviderClass.secretname }}
-                  key: POSTGRES_HOST
+            - sh
+            - -c
+            - until nslookup "$(cat /mnt/secrets-store/{{ .Values.dbSecrets.POSTGRES_HOST }})"; do echo waiting for postgres; sleep 2; done;
+          {{- if .Values.secretProviderClass.enabled }}
+          volumeMounts:
+            - name: secrets-store-inline
+              mountPath: "/mnt/secrets-store"
+              readOnly: true
+          {{- end }}
       containers:
         - name: db-migration
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          command: ["poetry"]
-          args: ["run", "flask", "db", "{{ .Values.database.args }}"]
+          command:
+            - sh
+            - -ceu
+            - |
+              {{- range $key, $val := .Values.dbSecrets }}
+              export {{ $key }}="$(cat /mnt/secrets-store/{{ $val }})"
+              {{- end }}
+              exec poetry run flask db {{ .Values.database.args }}
           env:
             # Common ENV Variables
             {{- range $key, $val := .Values.db }}
             - name: {{ $key }}
               value: {{ $val | quote }}
-            {{- end }}
-            # Secret ENV Variables
-            {{- range $key, $val := .Values.dbSecrets }}
-            - name: {{ $key }}
-              valueFrom:
-                secretKeyRef:
-                  name: {{ $.Values.secretProviderClass.secretname }}
-                  key: {{ $key }}
             {{- end }}
             # Node-specific variables
             - name: STATSD_HOST


### PR DESCRIPTION
This pull request updates the `run-database-job.yaml` Helm template to improve how database secrets are handled and injected into the init and migration containers. The changes switch from using Kubernetes `env` with `secretKeyRef` to mounting secrets as files and exporting them via shell script, which increases compatibility with secrets providers like CSI and enhances security and flexibility.

**Secret management improvements:**

* Changed the `init-postgres` and `db-migration` containers to read secrets from files mounted at `/mnt/secrets-store` instead of using `env` variables with `secretKeyRef`. The secrets are now exported as environment variables via shell script, supporting more secret backends and improving security.
* Added conditional mounting of the `secrets-store-inline` volume for secrets injection when `.Values.secretProviderClass.enabled` is true, making secret provisioning more flexible.

**Container command updates:**

* Updated the `db-migration` container to use a shell script for exporting secrets and running the migration command, replacing the previous direct `poetry run flask db ...` invocation.
* Modified the `init-postgres` container's command to resolve the Postgres host by reading from the mounted secret file, improving reliability in dynamic secret environments.

## Checklist if releasing new version

- [ ] I made sure that the changes are as expected in [Notify staging](https://staging.notification.cdssandbox.xyz/)
- [ ] I have checked if the docker images I am referencing exist
  - [ ] [api k8s](https://gallery.ecr.aws/v6b8u5o6/notify-api)
  - [ ] [admin](https://gallery.ecr.aws/v6b8u5o6/notify-admin)
  - [ ] [documentation](https://gallery.ecr.aws/v6b8u5o6/notify-documentation)
  - [ ] [document download API](https://gallery.ecr.aws/v6b8u5o6/notify-document-download-api)
  - [ ] notification-lambdas ([heartbeat](https://ca-central-1.console.aws.amazon.com/ecr/repositories/private/296255494825/notify/heartbeat?region=ca-central-1), [ses_to_sqs_email_callbacks](https://ca-central-1.console.aws.amazon.com/ecr/repositories/private/296255494825/notify/ses_to_sqs_email_callbacks?region=ca-central-1), [system-status](https://ca-central-1.console.aws.amazon.com/ecr/repositories/private/296255494825/notify/system_status?region=ca-central-1))

## Checklist if making changes to Kubernetes

- [ ] I know how to get kubectl credentials in case it catches on fire

## After merging this PR

- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.
