### PR TITLE
fix: Add `API_BASE_URL` to the env for the documentation site

### DIFF
--- a/helmfile/charts/notify-documentation/templates/deployment.yaml
+++ b/helmfile/charts/notify-documentation/templates/deployment.yaml
@@ -44,6 +44,10 @@ spec:
             - name: http
               containerPort: {{ .Values.service.port }}
               protocol: TCP
+          {{- with .Values.env }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           livenessProbe:
             {{- toYaml .Values.livenessProbe | nindent 12 }}
           readinessProbe:

--- a/helmfile/charts/notify-documentation/values.yaml
+++ b/helmfile/charts/notify-documentation/values.yaml
@@ -5,6 +5,8 @@ image:
   pullPolicy: Always
   tag: "latest"
 
+env: []
+
 pdb:
   enabled: true
   minAvailable: 1

--- a/helmfile/overrides/notify/documentation.yaml.gotmpl
+++ b/helmfile/overrides/notify/documentation.yaml.gotmpl
@@ -2,6 +2,11 @@ image:
   repository: "{{ .StateValues.DOCUMENTATION_IMAGE_REPOSITORY }}"
   tag: "{{ .StateValues.DOCUMENTATION_DOCKER_TAG }}"
 
+# Point the docs (OpenAPI spec + examples) at the API for the current environment.
+env:
+  - name: API_BASE_URL
+    value: "https://api.{{ requiredEnv "BASE_DOMAIN" }}"
+
 targetGroupBinding:
   enabled: true
   targetGroupARN: {{requiredEnv "DOCUMENTATION_TARGET_GROUP_ARN"}}


### PR DESCRIPTION
## What are you changing?

- [ ] Releasing a new version of Notify
- [x] Changing kubernetes configuration

## Provide some background on the changes

The goal here is to enable the staging doc site: https://documentation.staging.notification.cdssandbox.xyz/en/apispec.html
To point to the staging api, so we can test out/troubleshoot the swagger api requests in staging. Currently the staging doc site points to the prod api.

## If you are releasing a new version of Notify, what components are you updating

- [ ] API
- [ ] Admin
- [x] Documentation
- [ ] Document download API
- [ ] notification-lambdas

## Checklist if releasing new version

- [ ] I made sure that the changes are as expected in [Notify staging](https://staging.notification.cdssandbox.xyz/)
- [ ] I have checked if the docker images I am referencing exist
  - [ ] [api k8s](https://gallery.ecr.aws/v6b8u5o6/notify-api)
  - [ ] [admin](https://gallery.ecr.aws/v6b8u5o6/notify-admin)
  - [ ] [documentation](https://gallery.ecr.aws/v6b8u5o6/notify-documentation)
  - [ ] [document download API](https://gallery.ecr.aws/v6b8u5o6/notify-document-download-api)
  - [ ] notification-lambdas ([heartbeat](https://ca-central-1.console.aws.amazon.com/ecr/repositories/private/296255494825/notify/heartbeat?region=ca-central-1), [ses_to_sqs_email_callbacks](https://ca-central-1.console.aws.amazon.com/ecr/repositories/private/296255494825/notify/ses_to_sqs_email_callbacks?region=ca-central-1), [system-status](https://ca-central-1.console.aws.amazon.com/ecr/repositories/private/296255494825/notify/system_status?region=ca-central-1))

## Checklist if making changes to Kubernetes

- [ ] I know how to get kubectl credentials in case it catches on fire

## After merging this PR

- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.
