### PR TITLE
Fix: Add terraform tools setup to setup-cluster-access action

### DIFF
--- a/.github/actions/setup-cluster-access/action.yaml
+++ b/.github/actions/setup-cluster-access/action.yaml
@@ -28,8 +28,8 @@ runs:
 
     - name: Setup Terraform tools
       uses: cds-snc/terraform-tools-setup@v1
-      with:
-        terragrunt-version: "0.66.9"
+      env:
+        TERRAGRUNT_VERSION: 0.66.9
 
     - name: Retrieve VPN Config
       shell: bash

--- a/.github/actions/setup-cluster-access/action.yaml
+++ b/.github/actions/setup-cluster-access/action.yaml
@@ -26,6 +26,11 @@ runs:
       env:
         OP_SERVICE_ACCOUNT_TOKEN: ${{ inputs.op-service-account-token }}
 
+    - name: Setup Terraform tools
+      uses: cds-snc/terraform-tools-setup@v1
+      with:
+        terragrunt-version: "0.66.9"
+
     - name: Retrieve VPN Config
       shell: bash
       run: scripts/createVPNConfig.sh ${{ inputs.environment }}


### PR DESCRIPTION
## Problem
The `setup-cluster-access` reusable action was missing the terraform tools setup step. The `createVPNConfig.sh` script requires `terragrunt` to retrieve VPN configuration and AWS outputs, but terragrunt was not installed, causing the workflow to fail with "command not found".

## Solution
Added the `cds-snc/terraform-tools-setup@v1` action to install terragrunt and other required terraform tools before calling `createVPNConfig.sh`.

## Changes
- Added `Setup Terraform tools` step with terragrunt-version "0.66.9" to `setup-cluster-access` action
- This ensures all dependencies are available before the VPN config script runs

## Testing
This fix enables the Velero backup/restore workflows to successfully establish cluster access via VPN and retrieve the necessary configuration data.