### PR TITLE
Fix: Reorder setup-cluster-access steps (AWS creds before VPN config)

### DIFF
--- a/.github/actions/setup-cluster-access/action.yaml
+++ b/.github/actions/setup-cluster-access/action.yaml
@@ -31,6 +31,13 @@ runs:
       env:
         TERRAGRUNT_VERSION: 0.66.9
 
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
+      with:
+        role-to-assume: arn:aws:iam::${{ inputs.aws-account-id }}:role/${{ inputs.role-name }}
+        role-session-name: ClusterAccess
+        aws-region: ca-central-1
+
     - name: Retrieve VPN Config
       shell: bash
       run: scripts/createVPNConfig.sh ${{ inputs.environment }}
@@ -46,13 +53,6 @@ runs:
       with:
         config_file: /var/tmp/${{ inputs.environment }}.ovpn
         echo_config: false
-
-    - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
-      with:
-        role-to-assume: arn:aws:iam::${{ inputs.aws-account-id }}:role/${{ inputs.role-name }}
-        role-session-name: ClusterAccess
-        aws-region: ca-central-1
 
     - name: Configure kubeconfig
       shell: bash


### PR DESCRIPTION
## Problem
The `setup-cluster-access` action was attempting to retrieve the VPN configuration before AWS credentials were configured. The `createVPNConfig.sh` script uses `terragrunt output` which requires AWS authentication, causing the workflow to fail when trying to query Terraform state from S3.

## Solution
Reordered the steps so that "Configure AWS credentials" happens before "Retrieve VPN Config". This ensures AWS credentials are available when terragrunt needs them.

## Changes
- Moved "Configure AWS credentials" step before "Retrieve VPN Config" step
- All other steps remain in the same order

## Step Order (Now Correct)
1. Install 1Password CLI
2. Setup Terraform tools
3. **Configure AWS credentials** ← moved up
4. **Retrieve VPN Config** ← moved down
5. Install OpenVPN
6. Connect to VPN
7. Configure kubeconfig