### PR TITLE
Fix: Use correct IAM role names for Velero workflows per environment

### DIFF
--- a/.github/workflows/velero_list_backups.yaml
+++ b/.github/workflows/velero_list_backups.yaml
@@ -34,7 +34,7 @@ jobs:
           environment: ${{ github.event.inputs.environment }}
           aws-account-id: ${{ (github.event.inputs.environment == 'dev' && secrets.DEV_AWS_ACCOUNT_ID) || (github.event.inputs.environment == 'staging' && secrets.STAGING_AWS_ACCOUNT_ID) || secrets.PRODUCTION_AWS_ACCOUNT_ID }}
           op-service-account-token: ${{ (github.event.inputs.environment == 'dev' && secrets.OP_SERVICE_ACCOUNT_TOKEN_DEV) || (github.event.inputs.environment == 'staging' && secrets.OP_SERVICE_ACCOUNT_TOKEN_STAGING) || secrets.OP_SERVICE_ACCOUNT_TOKEN_PRODUCTION }}
-          role-name: notification-manifests-helmfile-${{ github.event.inputs.environment }}-apply
+          role-name: ${{ (github.event.inputs.environment == 'dev' && 'notification-manifests-k8s-lambda-apply-main-branch') || format('notification-manifests-helmfile-{0}-apply', github.event.inputs.environment) }}
 
       - name: Setup Velero CLI
         uses: ./.github/actions/setup-velero

--- a/.github/workflows/velero_restore.yaml
+++ b/.github/workflows/velero_restore.yaml
@@ -38,7 +38,7 @@ jobs:
           environment: ${{ github.event.inputs.environment }}
           aws-account-id: ${{ (github.event.inputs.environment == 'dev' && secrets.DEV_AWS_ACCOUNT_ID) || (github.event.inputs.environment == 'staging' && secrets.STAGING_AWS_ACCOUNT_ID) || secrets.PRODUCTION_AWS_ACCOUNT_ID }}
           op-service-account-token: ${{ (github.event.inputs.environment == 'dev' && secrets.OP_SERVICE_ACCOUNT_TOKEN_DEV) || (github.event.inputs.environment == 'staging' && secrets.OP_SERVICE_ACCOUNT_TOKEN_STAGING) || secrets.OP_SERVICE_ACCOUNT_TOKEN_PRODUCTION }}
-          role-name: notification-manifests-helmfile-${{ github.event.inputs.environment }}-apply
+          role-name: ${{ (github.event.inputs.environment == 'dev' && 'notification-manifests-k8s-lambda-apply-main-branch') || format('notification-manifests-helmfile-{0}-apply', github.event.inputs.environment) }}
 
       - name: Setup Velero CLI
         uses: ./.github/actions/setup-velero

--- a/.github/workflows/velero_snapshot.yaml
+++ b/.github/workflows/velero_snapshot.yaml
@@ -43,7 +43,7 @@ jobs:
           environment: ${{ steps.env.outputs.environment }}
           aws-account-id: ${{ (steps.env.outputs.environment == 'dev' && secrets.DEV_AWS_ACCOUNT_ID) || (steps.env.outputs.environment == 'staging' && secrets.STAGING_AWS_ACCOUNT_ID) || secrets.PRODUCTION_AWS_ACCOUNT_ID }}
           op-service-account-token: ${{ (steps.env.outputs.environment == 'dev' && secrets.OP_SERVICE_ACCOUNT_TOKEN_DEV) || (steps.env.outputs.environment == 'staging' && secrets.OP_SERVICE_ACCOUNT_TOKEN_STAGING) || secrets.OP_SERVICE_ACCOUNT_TOKEN_PRODUCTION }}
-          role-name: notification-manifests-helmfile-${{ steps.env.outputs.environment }}-apply
+          role-name: ${{ (steps.env.outputs.environment == 'dev' && 'notification-manifests-k8s-lambda-apply-main-branch') || format('notification-manifests-helmfile-{0}-apply', steps.env.outputs.environment) }}
 
       - name: Setup Velero CLI
         uses: ./.github/actions/setup-velero


### PR DESCRIPTION
## Problem
The Velero workflows were using an incorrect IAM role naming pattern for all environments. The role `notification-manifests-helmfile-dev-apply` does not exist in AWS.

## Actual AWS Roles
After reviewing existing workflows, the correct IAM roles are:
- **Dev**: `notification-manifests-k8s-lambda-apply-main-branch` (different pattern)
- **Staging**: `notification-manifests-helmfile-staging-apply`
- **Production**: `notification-manifests-helmfile-production-apply`

## Solution
Updated all three Velero workflows to use conditional expressions that map to the correct role name per environment:
- Dev uses the special `notification-manifests-k8s-lambda-apply-main-branch` role
- Staging and Production use the `notification-manifests-helmfile-{env}-apply` pattern

## Changed Files
- `.github/workflows/velero_list_backups.yaml`
- `.github/workflows/velero_snapshot.yaml`
- `.github/workflows/velero_restore.yaml`

This fixes the infinite OIDC assumption loop caused by the non-existent role.