### PR TITLE
Fix: Remove unnecessary terraform init step from setup-cluster-access

### DIFF
--- a/.github/actions/setup-cluster-access/action.yaml
+++ b/.github/actions/setup-cluster-access/action.yaml
@@ -38,11 +38,6 @@ runs:
         role-session-name: ClusterAccess
         aws-region: ca-central-1
 
-    - name: Initialize Terraform
-      shell: bash
-      run: terraform init
-      working-directory: terraform/gha_vpn_config
-
     - name: Retrieve VPN Config
       shell: bash
       run: scripts/createVPNConfig.sh ${{ inputs.environment }}


### PR DESCRIPTION
## Problem
The `setup-cluster-access` action was adding an unnecessary `terraform init` step that tried to run in a non-existent directory (`terraform/gha_vpn_config`). This caused the workflow to fail with:

```
Error: An error occurred trying to start process '/usr/bin/bash' with working directory 
'/home/runner/work/notification-manifests/notification-manifests/terraform/gha_vpn_config'. 
No such file or directory
```

## Solution
Removed the redundant terraform init step. The `createVPNConfig.sh` script already handles terraform initialization with:
```bash
terragrunt init -reconfigure -upgrade
```

This runs before calling `terragrunt output`, so the extra step is unnecessary and was preventing the workflow from proceeding.

## Changes
- Removed "Initialize Terraform" step from `.github/actions/setup-cluster-access/action.yaml`
- This unblocks VPN config retrieval during the cluster access setup