### PR TITLE
Fix: Cache Terraform providers before VPN config retrieval

### DIFF
--- a/.github/actions/setup-cluster-access/action.yaml
+++ b/.github/actions/setup-cluster-access/action.yaml
@@ -38,6 +38,14 @@ runs:
         role-session-name: ClusterAccess
         aws-region: ca-central-1
 
+    - name: Cache Terraform providers
+      shell: bash
+      run: |
+        git clone https://github.com/cds-snc/notification-terraform.git /var/tmp/notification-terraform-init
+        cd /var/tmp/notification-terraform-init/env/${{ inputs.environment }}/eks
+        terraform init -upgrade || true
+        rm -rf /var/tmp/notification-terraform-init
+
     - name: Retrieve VPN Config
       shell: bash
       run: scripts/createVPNConfig.sh ${{ inputs.environment }}


### PR DESCRIPTION
## Problem
The Velero workflows were failing with terraform provider not found errors:

```
Error: Required plugins are not installed

The installed provider plugins are not consistent with the packages selected in the dependency lock file:
  - registry.terraform.io/hashicorp/aws: there is no package for registry.terraform.io/hashicorp/aws 6.15.0 cached in .terraform/providers
  - ... (and others)
```

This happens because `createVPNConfig.sh` clones `notification-terraform` and uses `terragrunt output`, but the Terraform providers aren't downloaded when the script runs.

## Solution
Added a "Cache Terraform providers" step before "Retrieve VPN Config" that:
1. Clones the notification-terraform repository
2. Runs `terraform init -upgrade` in the environment's EKS directory
3. Caches all required providers for the environment
4. Cleans up the temporary clone

This ensures all providers are available when `createVPNConfig.sh` calls `terragrunt output`.

## Changes
- Added "Cache Terraform providers" step to `.github/actions/setup-cluster-access/action.yaml`
- Runs after AWS credentials are configured
- Runs before VPN config retrieval
- Uses `|| true` to allow non-critical failures