### PR TITLE
Fix Velero backup tagging and list ordering

### DIFF
--- a/.github/workflows/helmfile_production_apply.yaml
+++ b/.github/workflows/helmfile_production_apply.yaml
@@ -30,6 +30,7 @@ jobs:
     uses: ./.github/workflows/velero_snapshot.yaml
     with:
       environment: production
+      backup_type: helm
     secrets: inherit
 
   helmfile-apply:

--- a/.github/workflows/helmfile_staging_apply.yaml
+++ b/.github/workflows/helmfile_staging_apply.yaml
@@ -31,6 +31,7 @@ jobs:
     uses: ./.github/workflows/velero_snapshot.yaml
     with:
       environment: staging
+      backup_type: helm
     secrets: inherit
 
   helmfile-apply:

--- a/.github/workflows/velero_list_backups.yaml
+++ b/.github/workflows/velero_list_backups.yaml
@@ -48,7 +48,13 @@ jobs:
           velero backup get | tee velero_output.txt
           echo ""
           echo "Filtered list (Completed, 0 errors, notification namespace only):"
-          awk 'BEGIN {printf "%-55s %s\n", "NAME", "CREATED"} $2=="Completed" && $3=="0" && $1 ~ /notification-canada-ca/ {printf "%-55s %s %s\n", $1, $5, $6}' velero_output.txt | head -n 6 > backups.txt
+          awk '$2=="Completed" && $3=="0" && $1 ~ /notification-canada-ca/ {print $1 "\t" $5 " " $6}' velero_output.txt \
+            | sort -k2,2r \
+            | head -n 5 > backups_raw.txt
+          {
+            printf "%-55s %s\n" "NAME" "CREATED"
+            awk -F "\t" '{printf "%-55s %s\n", $1, $2}' backups_raw.txt
+          } > backups.txt
           cat backups.txt
           echo ""
           echo "Use the backup name from the first column in the Velero Restore workflow."

--- a/.github/workflows/velero_snapshot.yaml
+++ b/.github/workflows/velero_snapshot.yaml
@@ -2,8 +2,6 @@ name: Velero - Snapshot
 run-name: Velero - Snapshot
 
 on:
-  schedule:
-    - cron: '0 10 * * *' # 10:00 UTC = 6:00 AM EDT (Summer) / 5:00 AM EST (Winter)
   workflow_call:
     inputs:
       environment:
@@ -11,7 +9,7 @@ on:
         required: true
         type: string
       backup_type:
-        description: Backup type tag (e.g. helm, manual, nightly)
+        description: Backup type tag (e.g. helm, manual)
         required: false
         type: string
         default: helm
@@ -33,7 +31,6 @@ on:
         options:
           - manual
           - helm
-          - nightly
 
 concurrency:
   group: velero-snapshot-${{ inputs.environment || github.event.inputs.environment || 'staging' }}
@@ -77,10 +74,8 @@ jobs:
         run: |
           TIMESTAMP=$(date +%Y%m%d-%H%M%S)
           
-          # Determine trigger type for backup naming
-          if [ "${{ github.event_name }}" == "schedule" ]; then
-            BACKUP_TYPE="nightly"
-          elif [ -n "${{ inputs.backup_type }}" ]; then
+          # Determine backup type for naming
+          if [ -n "${{ inputs.backup_type }}" ]; then
             BACKUP_TYPE="${{ inputs.backup_type }}"
           else
             BACKUP_TYPE="manual"

--- a/.github/workflows/velero_snapshot.yaml
+++ b/.github/workflows/velero_snapshot.yaml
@@ -10,6 +10,11 @@ on:
         description: Environment
         required: true
         type: string
+      backup_type:
+        description: Backup type tag (e.g. helm, manual, nightly)
+        required: false
+        type: string
+        default: helm
   workflow_dispatch:
     inputs:
       environment:
@@ -20,6 +25,15 @@ on:
           - dev
           - staging
           - production
+      backup_type:
+        description: Backup type tag
+        required: false
+        type: choice
+        default: manual
+        options:
+          - manual
+          - helm
+          - nightly
 
 concurrency:
   group: velero-snapshot-${{ inputs.environment || github.event.inputs.environment || 'staging' }}
@@ -66,8 +80,8 @@ jobs:
           # Determine trigger type for backup naming
           if [ "${{ github.event_name }}" == "schedule" ]; then
             BACKUP_TYPE="nightly"
-          elif [ "${{ github.event_name }}" == "workflow_call" ]; then
-            BACKUP_TYPE="helm"
+          elif [ -n "${{ inputs.backup_type }}" ]; then
+            BACKUP_TYPE="${{ inputs.backup_type }}"
           else
             BACKUP_TYPE="manual"
           fi


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows related to Velero backups and Helmfile deployments. The main improvements are the introduction of a flexible `backup_type` parameter for Velero snapshot workflows, enhanced backup listing and filtering, and better integration between Helmfile and Velero workflows. These changes improve backup traceability, make workflows more configurable, and enhance the display of backup information.

**Workflow input and parameter enhancements:**

* Added a `backup_type` input to the `velero_snapshot.yaml` workflow, allowing the backup type to be specified (e.g., `helm`, `manual`, `nightly`) with sensible defaults for both workflow calls and manual dispatches. [[1]](diffhunk://#diff-35c111ae779a78bb44476b6407fba32c19fdaf4d2dfd2b105d1c714d062366b6R13-R17) [[2]](diffhunk://#diff-35c111ae779a78bb44476b6407fba32c19fdaf4d2dfd2b105d1c714d062366b6R28-R36)
* Updated the logic for determining the `BACKUP_TYPE` environment variable in the Velero snapshot workflow to use the new input, making backup naming more flexible and accurate.

**Integration with Helmfile workflows:**

* Modified both `helmfile_production_apply.yaml` and `helmfile_staging_apply.yaml` to pass `backup_type: helm` when invoking the Velero snapshot workflow, ensuring backups triggered by Helmfile deployments are properly tagged. [[1]](diffhunk://#diff-1342074e91c60e9e4e918e055f0be3d37761690b2946c937f2f10376aaa8bfa4R33) [[2]](diffhunk://#diff-4b61f71b14e2e1231703d2a804473192c4fd909a0d558a336a54074705c3f564R34)

**Backup listing and output improvements:**

* Enhanced the backup listing in `velero_list_backups.yaml` by improving the filtering, sorting, and formatting of recent completed backups. The output is now more readable and consistently shows the five most recent backups.