### PR TITLE
Refactor remaining cluster workflows to use setup-cluster-access

### DIFF
--- a/.github/workflows/database_migration_production_manual.yaml
+++ b/.github/workflows/database_migration_production_manual.yaml
@@ -65,11 +65,6 @@ jobs:
           helmfile-version: "v1.4.4"
           helm-s3-plugin-version: "v0.16.2"
 
-      - name: Install OpenVPN
-        run: |
-          sudo apt update
-          sudo apt install -y openvpn openvpn-systemd-resolved
-
       - name: Setup Terraform tools
         uses: cds-snc/terraform-tools-setup@v1
         env: # In case you want to override default versions
@@ -78,24 +73,17 @@ jobs:
           TERRAGRUNT_VERSION: 0.66.9
           TF_SUMMARIZE_VERSION: 0.2.3                           
 
-      - name: Install 1Pass CLI
-        run: |
-          curl -o 1pass.deb https://downloads.1password.com/linux/debian/amd64/stable/1password-cli-amd64-latest.deb
-          sudo dpkg -i 1pass.deb 
 
-      - name: Retrieve VPN Config
-        run: |
-          scripts/createVPNConfig.sh production 2> /dev/null   
-
-      - name: Connect to VPN
-        uses: "kota65535/github-openvpn-connect-action@cd2ed8a90cc7b060dc4e001143e811b5f7ea0af5" # v3.1.0
+      - name: Setup cluster access
+        uses: ./.github/actions/setup-cluster-access
         with:
-          config_file: /var/tmp/production.ovpn
-          echo_config: false            
-
-      - name: Configure kubeconfig
-        run: |
-          aws eks update-kubeconfig --name notification-canada-ca-production-eks-cluster --alias production
+          environment: production
+          aws-account-id: ${{ secrets.PRODUCTION_AWS_ACCOUNT_ID }}
+          op-service-account-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN_PRODUCTION }}
+          role-name: notification-manifests-database-migration-production
+          gha-vpn-id: ${{ secrets.GHA_VPN_ID_PRODUCTION }}
+          gha-vpn-cert: ${{ secrets.GHA_VPN_CERT_PRODUCTION }}
+          gha-vpn-key: ${{ secrets.GHA_VPN_KEY_PRODUCTION }}
 
       - name: Load Context Variables
         run: |

--- a/.github/workflows/database_migration_staging_manual.yaml
+++ b/.github/workflows/database_migration_staging_manual.yaml
@@ -54,16 +54,6 @@ jobs:
           helmfile-version: "v1.4.4"
           helm-s3-plugin-version: "v0.16.2"
 
-      - name: Install OpenVPN
-        run: |
-          sudo apt update
-          sudo apt install -y openvpn openvpn-systemd-resolved
-
-      - name: Install 1Pass CLI
-        run: |
-          curl -o 1pass.deb https://downloads.1password.com/linux/debian/amd64/stable/1password-cli-amd64-latest.deb
-          sudo dpkg -i 1pass.deb 
-
       - name: Setup Terraform tools
         uses: cds-snc/terraform-tools-setup@v1
         env: # In case you want to override default versions
@@ -72,19 +62,16 @@ jobs:
           TERRAGRUNT_VERSION: 0.66.9
           TF_SUMMARIZE_VERSION: 0.2.3                    
 
-      - name: Retrieve VPN Config
-        run: |
-          scripts/createVPNConfig.sh staging 2> /dev/null  
-
-      - name: Connect to VPN
-        uses: "kota65535/github-openvpn-connect-action@cd2ed8a90cc7b060dc4e001143e811b5f7ea0af5" # v3.1.0
+      - name: Setup cluster access
+        uses: ./.github/actions/setup-cluster-access
         with:
-          config_file: /var/tmp/staging.ovpn
-          echo_config: false            
-
-      - name: Configure kubeconfig
-        run: |
-          aws eks update-kubeconfig --name notification-canada-ca-staging-eks-cluster --alias staging 
+          environment: staging
+          aws-account-id: ${{ secrets.STAGING_AWS_ACCOUNT_ID }}
+          op-service-account-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN_STAGING }}
+          role-name: notification-manifests-database-migration-staging
+          gha-vpn-id: ${{ secrets.GHA_VPN_ID_STAGING }}
+          gha-vpn-cert: ${{ secrets.GHA_VPN_CERT_STAGING }}
+          gha-vpn-key: ${{ secrets.GHA_VPN_KEY_STAGING }}
 
       - name: Load Context Variables
         run: |

--- a/.github/workflows/deploy_dev.yaml
+++ b/.github/workflows/deploy_dev.yaml
@@ -62,16 +62,6 @@ jobs:
           helmfile-version: "v1.4.4"
           helm-s3-plugin-version: "v0.16.2"
 
-      - name: Install OpenVPN
-        run: |
-          sudo apt update
-          sudo apt install -y openvpn openvpn-systemd-resolved
-
-      - name: Install 1Pass CLI
-        run: |
-          curl -o 1pass.deb https://downloads.1password.com/linux/debian/amd64/stable/1password-cli-amd64-latest.deb
-          sudo dpkg -i 1pass.deb 
-
       - name: Setup Terraform tools
         uses: cds-snc/terraform-tools-setup@v1
         env: # In case you want to override default versions
@@ -80,19 +70,16 @@ jobs:
           TERRAGRUNT_VERSION: 0.66.9
           TF_SUMMARIZE_VERSION: 0.2.3                    
 
-      - name: Retrieve VPN Config
-        run: |
-          scripts/createVPNConfig.sh dev 2> /dev/null
-
-      - name: Connect to VPN
-        uses: "kota65535/github-openvpn-connect-action@cd2ed8a90cc7b060dc4e001143e811b5f7ea0af5" # v3.1.0
+      - name: Setup cluster access
+        uses: ./.github/actions/setup-cluster-access
         with:
-          config_file: /var/tmp/dev.ovpn
-          echo_config: false
-
-      - name: Configure kubeconfig
-        run: |
-          aws eks update-kubeconfig --name notification-canada-ca-dev-eks-cluster --alias dev 
+          environment: dev
+          aws-account-id: ${{ secrets.DEV_AWS_ACCOUNT_ID }}
+          op-service-account-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN_DEV }}
+          role-name: notification-manifests-k8s-lambda-apply-main-branch
+          gha-vpn-id: ${{ secrets.GHA_VPN_ID_DEV }}
+          gha-vpn-cert: ${{ secrets.GHA_VPN_CERT_DEV }}
+          gha-vpn-key: ${{ secrets.GHA_VPN_KEY_DEV }}
 
       - name: Load Context Variables
         run: |

--- a/.github/workflows/helmfile_staging_apply_specific_app.yaml
+++ b/.github/workflows/helmfile_staging_apply_specific_app.yaml
@@ -15,17 +15,6 @@ on:
         required: false
   repository_dispatch:
     types: [webhook]
-    inputs:
-      app:
-        description: 'Application to rollout'
-        required: true
-      selector:
-        description: 'Selector for helmfile'
-        required: true        
-      tag:
-        description: 'Tag to rollout'
-        default: 'latest'
-        required: false
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -33,19 +22,15 @@ env:
   DOCKER_TAG: ${{ github.event.inputs.tag }}
   OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN_STAGING }}
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   rollout:
     runs-on: ubuntu-latest
     name: Rollout on EKS
     steps:
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
-        id: awsconfig
-        with:
-          aws-access-key-id: ${{ secrets.STAGING_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.STAGING_AWS_SECRET_ACCESS_KEY }}
-          aws-region: ca-central-1
-
       - name: Checkout
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
@@ -60,11 +45,6 @@ jobs:
           helmfile-version: "v1.4.4"
           helm-s3-plugin-version: "v0.16.2"
 
-      - name: Install OpenVPN
-        run: |
-          sudo apt update
-          sudo apt install -y openvpn openvpn-systemd-resolved
-
       - name: Setup Terraform tools
         uses: cds-snc/terraform-tools-setup@v1
         env: # In case you want to override default versions
@@ -73,24 +53,16 @@ jobs:
           TERRAGRUNT_VERSION: 0.66.9
           TF_SUMMARIZE_VERSION: 0.2.3                                  
 
-      - name: Install 1Pass CLI
-        run: |
-          curl -o 1pass.deb https://downloads.1password.com/linux/debian/amd64/stable/1password-cli-amd64-latest.deb
-          sudo dpkg -i 1pass.deb 
-
-      - name: Retrieve VPN Config
-        run: |
-          scripts/createVPNConfig.sh staging 2> /dev/null     
-
-      - name: Connect to VPN
-        uses: "kota65535/github-openvpn-connect-action@cd2ed8a90cc7b060dc4e001143e811b5f7ea0af5" # v3.1.0
+      - name: Setup cluster access
+        uses: ./.github/actions/setup-cluster-access
         with:
-          config_file: /var/tmp/staging.ovpn
-          echo_config: false                  
-
-      - name: Configure kubeconfig
-        run: |
-          aws eks update-kubeconfig --name notification-canada-ca-staging-eks-cluster --alias staging   
+          environment: staging
+          aws-account-id: ${{ secrets.STAGING_AWS_ACCOUNT_ID }}
+          op-service-account-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN_STAGING }}
+          role-name: notification-manifests-helmfile-staging-apply
+          gha-vpn-id: ${{ secrets.GHA_VPN_ID_STAGING }}
+          gha-vpn-cert: ${{ secrets.GHA_VPN_CERT_STAGING }}
+          gha-vpn-key: ${{ secrets.GHA_VPN_KEY_STAGING }}
 
       - name: Load EnvVars
         run: |


### PR DESCRIPTION
## Summary
This PR migrates the next batch of workflows to use the shared cluster connectivity action:
- `.github/actions/setup-cluster-access`

Updated workflows:
- `.github/workflows/helmfile_staging_apply_specific_app.yaml`
- `.github/workflows/database_migration_staging_manual.yaml`
- `.github/workflows/database_migration_production_manual.yaml`
- `.github/workflows/deploy_dev.yaml`

## What Changed
- Removed duplicated steps for:
  - OpenVPN install
  - 1Password CLI install
  - VPN config retrieval
  - VPN connection
  - kubeconfig setup
- Replaced them with a single `Setup cluster access` step in each workflow.
- Preserved existing role access intent by passing each workflow's role name into the shared action.
- For `helmfile_staging_apply_specific_app.yaml`, removed static key-based AWS credential usage in favor of OIDC via the shared action and added explicit workflow permissions for `id-token`.
- Removed invalid `repository_dispatch.inputs` block in `helmfile_staging_apply_specific_app.yaml` (not supported by workflow schema).

## Validation
- Confirmed no legacy cluster access blocks remain in the four workflows.
- YAML diagnostics are clean for edited files except an existing warning pattern for `DEV` VPN secrets (`GHA_VPN_ID_DEV`, `GHA_VPN_CERT_DEV`, `GHA_VPN_KEY_DEV`) already used in existing Velero workflows.

## Related
ZenHub card: https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/908