### PR TITLE
TGB migration script improvements

### DIFF
--- a/scripts/migrations/migrate-target-groupbindings.sh
+++ b/scripts/migrations/migrate-target-groupbindings.sh
@@ -78,13 +78,22 @@ if [[ "${MODE}" == "--revert" ]]; then
 fi
 
 ###############################################################################
+# Assume DNS role for the rest of the script (production only)
+###############################################################################
+if [[ "${ENVIRONMENT}" == "production" ]]; then
+  pushd "${TERRAFORM_REPO}/scripts"
+  source ./assumeDnsRole.sh || { echo "ERROR: assumeDnsRole.sh failed — aborting" >&2; popd; exit 1; }
+  popd
+fi
+
+###############################################################################
 # Step 1: admin-tt-step-1 — terragrunt apply (auto-approve)
 ###############################################################################
 echo "==> [Step 1] Checking out admin-tt-step-1 and running terragrunt apply"
 cd "${TERRAFORM_REPO}"
 git checkout admin-tt-step-1
 cd "${TERRAFORM_EKS_DIR}"
-terragrunt apply -auto-approve
+terragrunt apply -auto-approve || { echo "ERROR: terragrunt apply (step 1) failed — aborting" >&2; exit 1; }
 
 ###############################################################################
 # Step 2: admin-tt-step-3 — start terragrunt apply and run helmfile in parallel


### PR DESCRIPTION
## What happens when your PR merges?

Saving after the fact - had to make two adjustments to the migration script for target group bindings:

1. Assume DNS role if the environment is production
2. Halt the script if the first terraform step fails.

## What are you changing?

- [ ] Releasing a new version of Notify
- [ ] Changing kubernetes configuration
- [x] Script

## Provide some background on the changes

IP target group migration

## After merging this PR

- [ ] I have verified that the tests / deployment actions succeeded
- [ ] I have verified that any affected pods were restarted successfully
- [ ] I have verified that I can still log into [Notify production](https://notification.canada.ca)
- [ ] I have verified that the smoke tests still pass on production
- [ ] I have communicated the release in the #notify Slack channel.
