### PR TITLE
fix: switch velero kubectl sidecar to alpine/kubectl

### DIFF
--- a/helmfile/overrides/system/velero.yaml.gotmpl
+++ b/helmfile/overrides/system/velero.yaml.gotmpl
@@ -8,8 +8,6 @@ initContainers:
 priorityClassName: system-cluster-critical
 
 kubectl:
-  # alpine/k8s's kubectl failed the velero-upgrade-crds Job in staging (BackoffLimitExceeded).
-  # Switched to alpine/kubectl, which Ben confirmed working for the same issue.
   image:
     repository: docker.io/alpine/kubectl
     tag: "1.36.3"

--- a/helmfile/overrides/system/velero.yaml.gotmpl
+++ b/helmfile/overrides/system/velero.yaml.gotmpl
@@ -8,10 +8,12 @@ initContainers:
 priorityClassName: system-cluster-critical
 
 kubectl:
+  # alpine/k8s's kubectl failed the velero-upgrade-crds Job in staging (BackoffLimitExceeded).
+  # Switched to alpine/kubectl, which Ben confirmed working for the same issue.
   image:
-    repository: alpine/k8s
-    tag: "1.36.2"
-    digest: sha256:44ef4942e171939b9c665a4a84beb80e2dcdb9a24330d4651cfdfd2e9deecc47
+    repository: docker.io/alpine/kubectl
+    tag: "1.36.3"
+    digest: sha256:dae261106d5555008acede256b7102c8a6decde7209198434f5999f051460f57
 
 configuration:
   features: "EnableCSI" 


### PR DESCRIPTION
## Summary | Résumé

Follow-up to #5081: the `alpine/k8s:1.36.2` kubectl image pin that landed there passed `helmfile diff` cleanly, but actually failed in staging - the `velero-upgrade-crds` Job hit `BackoffLimitExceeded`. Ben hit the same issue before and confirmed switching to `alpine/kubectl` fixes it.

## Why alpine/k8s failed but helmfile diff didn't catch it

`helmfile diff` only compares rendered manifests against the live cluster state - it can't catch a Job actually crashing at runtime. The `velero-upgrade-crds` Job's `kubectl` initContainer copies the `sh`/`kubectl` binaries out into a shared volume, which the main `velero/velero` container then execs directly. `alpine/k8s`'s `kubectl` binary apparently doesn't run correctly once copied into that different container's filesystem/runtime - `alpine/kubectl` does.

## What changed

`helmfile/overrides/system/velero.yaml.gotmpl`: swapped `kubectl.image` from `alpine/k8s:1.36.2` to `docker.io/alpine/kubectl:1.36.3` (digest confirmed via the Docker Hub registry API).

Verified via a live `helmfile -e staging diff --selector name=velero` - resolves cleanly to `docker.io/alpine/kubectl@sha256:dae261106d5555008acede256b7102c8a6decde7209198434f5999f051460f57` in both the `velero-cleanup-crds` Job and the `velero-upgrade-crds` Job's kubectl initContainer.

## Related Issues | Cartes liées

Follow-up to #5081.

## Release Instructions | Instructions pour le déploiement

Watch the `velero-upgrade-crds`/`velero-cleanup-crds` jobs on the next staging apply to confirm they actually succeed this time (not just plan cleanly).

## Reviewer checklist | Liste de vérification du réviseur

* [x] This PR does not break existing functionality.
* [x] This PR does not violate GCNotify's privacy policies.
* [x] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [x] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

## After merging this PR

* [ ] I have verified that the tests / deployment actions succeeded
* [ ] I have verified that the smoke tests still pass on production
* [ ] I have communicated the release in the #notify Slack channel
