### PR TITLE
fix: switch velero kubectl sidecar to bitnamilegacy/kubectl

### DIFF
--- a/helmfile/overrides/system/velero.yaml.gotmpl
+++ b/helmfile/overrides/system/velero.yaml.gotmpl
@@ -9,9 +9,9 @@ priorityClassName: system-cluster-critical
 
 kubectl:
   image:
-    repository: docker.io/alpine/kubectl
-    tag: "1.36.3"
-    digest: sha256:dae261106d5555008acede256b7102c8a6decde7209198434f5999f051460f57
+    repository: docker.io/bitnamilegacy/kubectl
+    tag: "1.33.4"
+    digest: sha256:ed0b31a0508da84ee655c5c6e01bd3897fc56ad6cf69debb27fa1893a06d2246
 
 configuration:
   features: "EnableCSI" 


### PR DESCRIPTION
## Summary | Résumé

Follow-up to #5081 and #5087. Both of those pinned `kubectl.image` for the velero CRD-upgrade Job to an Alpine-based image (`alpine/k8s`, then `alpine/kubectl`) - both passed `helmfile diff` cleanly but failed for real in staging with `BackoffLimitExceeded` on the `velero-upgrade-crds` Job.

## Root cause (confirmed directly against staging)

The `velero-upgrade-crds`/`velero-cleanup-crds` Jobs run a `kubectl` initContainer that copies its own `sh` and `kubectl` binaries into a shared `emptyDir`, then the main `velero/velero:v1.17.0` container (which has no shell or libc of its own) execs `/tmp/sh -c "... | /tmp/kubectl apply -f -"` directly from those copied binaries.

Alpine's `sh` (busybox) is dynamically linked against musl libc (`/lib/ld-musl-x86_64.so.1`), which doesn't exist in the `velero/velero` image - so the copied `sh` can't exec there. This is true for both `alpine/k8s` and `alpine/kubectl`, which is why swapping between them didn't help.

I reproduced the exact failure with a throwaway debug pod using the same initContainer/copy/exec pattern directly against the staging cluster, then confirmed `docker.io/bitnamilegacy/kubectl` - the image family this repo used successfully for years via `public.ecr.aws/bitnami/kubectl`, until that ECR mirror was retired (see #5081) - copies/execs cleanly and successfully applies all velero CRDs end-to-end.

## What changed

`helmfile/overrides/system/velero.yaml.gotmpl`: `kubectl.image` now points to `docker.io/bitnamilegacy/kubectl:1.33.4` (pinned by digest). It's a few minor versions behind the cluster's server version (v1.36.2), but `kubectl apply` of static CRD manifests isn't sensitive to that gap - confirmed via the same manual reproduction (all CRDs applied successfully, exit 0).

Verified via a live `helmfile -e staging diff --selector name=velero` **and** a direct pod-based reproduction of the actual `velero-upgrade-crds` Job logic against the staging cluster (not just a diff, since diff alone didn't catch the two previous failures).

## Related Issues | Cartes liées

Follow-up to #5081 and #5087 (both merged, but the underlying fix didn't actually work in staging).

## Release Instructions | Instructions pour le déploiement

Watch the `velero-upgrade-crds`/`velero-cleanup-crds` jobs on the next staging apply to confirm they succeed.

## Reviewer checklist | Liste de vérification du réviseur

* [x] This PR does not break existing functionality.
* [x] This PR does not violate GCNotify's privacy policies.
* [x] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
* [x] This PR does not significantly alter performance.
* [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

## After merging this PR

* [ ] I have verified that the tests / deployment actions succeeded
* [ ] I have verified that the smoke tests still pass on production
* [ ] I have communicated the release in the #notify Slack channel
