### PR TITLE
Fix intermittent DB migration Job timeouts by using on-demand nodes

### DIFF
--- a/helmfile/charts/notify-database/values.yaml
+++ b/helmfile/charts/notify-database/values.yaml
@@ -19,8 +19,12 @@ serviceAccount:
   create: true
   serviceAccountName: "notify-database"
 
+# Run on the always-warm EKS managed on-demand node group instead of a Karpenter
+# spot node: a new spot node can take 5+ minutes to provision and become
+# schedulable (spot capacity fulfillment + node bootstrap + nidhogg startup
+# taints), which blocks this job and any deploy waiting on it.
 nodeSelector:
-  karpenter.sh/capacity-type: spot
+  eks.amazonaws.com/capacityType: ON_DEMAND
 
 tolerations: []
 

--- a/helmfile/overrides/notify/database.yaml.gotmpl
+++ b/helmfile/overrides/notify/database.yaml.gotmpl
@@ -99,19 +99,7 @@ serviceAccount:
   annotations:
     eks.amazonaws.com/role-arn: arn:aws:iam::{{ requiredEnv "AWS_ACCOUNT_ID" }}:role/secrets-csi-role-database
 
-nodeSelector:
-  karpenter.sh/capacity-type: spot
+# nodeSelector/tolerations intentionally not overridden here: the chart's
+# values.yaml default (on-demand node group) applies and doesn't need the
+# nidhogg startup-taint tolerations that were required for spot nodes.
 
-tolerations:
-  - key: nidhogg.uswitch.com/amazon-cloudwatch.aws-cloudwatch-agent
-    operator: Exists
-    effect: NoSchedule
-  - key: nidhogg.uswitch.com/amazon-cloudwatch.ebs-csi-node
-    operator: Exists
-    effect: NoSchedule
-  - key: nidhogg.uswitch.com/amazon-cloudwatch.fb-agent-fluent-bit
-    operator: Exists
-    effect: NoSchedule
-  - key: nidhogg.uswitch.com/amazon-cloudwatch.secrets-store-csi-driver
-    operator: Exists
-    effect: NoSchedule


### PR DESCRIPTION
## Problem

The `notify-db-migration-job` (run by every deploy to dev/staging/production via `.github/actions/db-migration`) intermittently times out. The wait step (`kubectl wait --for=condition=complete ... --timeout=400s`) has ~6.7 minutes total, but the job's pod is pinned to Karpenter spot nodes only:

```yaml
nodeSelector:
  karpenter.sh/capacity-type: spot
```

When there's no already-warm spot node with room, Karpenter has to provision a brand new one (EC2 spot capacity fulfillment + node bootstrap), which can eat several minutes on its own, leaving little time for the actual migration before the GitHub Action's 400s wait gives up - blocking staging and production releases.

## History / why this is safe

Checked git history for this field before touching it:
- The job originally (Mar 2025, #3652) used `eks.amazonaws.com/capacityType: ON_DEMAND` - the same always-warm EKS managed on-demand node group already used today by `notify-api`, `notify-admin`, `notify-celery`, `notify-document-download`, and most system components.
- PR #4814 switched it to a Karpenter-style selector, which didn't actually work (this cluster's Karpenter NodePool only provisions `spot` - there's no Karpenter on-demand pool), so PR #4815 patched it to `spot` the very next day as a stopgap ("spot because that's all karpenter allows").
- Nobody went back to the original on-demand config - this PR is effectively reverting to that known-good state, not introducing something new/untested.

## Fix

1. `helmfile/charts/notify-database/values.yaml`: nodeSelector back to `eks.amazonaws.com/capacityType: ON_DEMAND`.
2. `helmfile/overrides/notify/database.yaml.gotmpl`: this release's only values file *also* set `nodeSelector: karpenter.sh/capacity-type: spot` plus tolerations for nidhogg startup taints, which would have been deep-merged on top of the chart's on-demand default - producing an impossible nodeSelector requiring both labels on the same node (permanently unschedulable, worse than today). Removed that stale override so the chart default applies cleanly.

## Verification

- `helm lint`/`helm template` on the chart alone confirms the rendered Job requests `eks.amazonaws.com/capacityType: ON_DEMAND`.
- Reproduced the real merge with a `helm template -f <override values>` test: confirmed the *before* state produces a broken two-key nodeSelector, and the *after* state (override removed) produces a single correct `eks.amazonaws.com/capacityType: ON_DEMAND` selector.
