### PR TITLE
Revert: unpin cds-snc/notification-pr-bot back to @main

### DIFF
--- a/.github/workflows/refresh_release_pr.yaml
+++ b/.github/workflows/refresh_release_pr.yaml
@@ -28,7 +28,7 @@ jobs:
           echo "GITHUB_TOKEN=$TOKEN" >> $GITHUB_ENV
 
       - name: Refresh production release PR
-        uses: cds-snc/notification-pr-bot@b70dc73610a8e72a7af40e5ccc320e14ce773988 # main
+        uses: cds-snc/notification-pr-bot@main
         env:
           TOKEN: ${{ env.GITHUB_TOKEN }}
           TARGET_REPO: notification-manifests

--- a/renovate.json
+++ b/renovate.json
@@ -12,5 +12,8 @@
     "**/test/**",
     "**/tests/**",
     "**/__fixtures__/**"
+  ],
+  "ignoreDeps": [
+    "cds-snc/notification-pr-bot"
   ]
 }


### PR DESCRIPTION
## Why

The recent GH Actions SHA-pinning work (#5067) pinned `cds-snc/notification-pr-bot` to a commit SHA like any third-party action. That action is our own internal tool that we update frequently, so pinning it defeats the point - every update requires a manual repin instead of just picking up the latest `main` automatically.

## Changes

- `.github/workflows/refresh_release_pr.yaml`: revert `cds-snc/notification-pr-bot@<sha> # main` back to `cds-snc/notification-pr-bot@main`.
- `renovate.json`: add `cds-snc/notification-pr-bot` to `ignoreDeps` so Renovate's `pinGitHubActionDigests` preset doesn't re-pin it on the next scan.

Companion PRs are going out to the other repos that use this action (notification-api, notification-admin, notification-terraform, notification-documentation, notification-document-download-api).