### PR TITLE
Add PR check to enforce SHA-pinned GitHub Actions

### DIFF
--- a/.github/workflows/check_pinned_actions.yaml
+++ b/.github/workflows/check_pinned_actions.yaml
@@ -1,0 +1,54 @@
+name: "Check pinned GitHub Actions"
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/**"
+      - ".github/actions/**"
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/**"
+      - ".github/actions/**"
+
+permissions: {}
+
+jobs:
+  check-pinned-actions:
+    name: "Scan for unpinned actions"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: "Install uv"
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+
+      # Only fails on unpinned-uses: zizmor's other audits are out of scope for this check.
+      - name: "Scan for unpinned actions"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          uvx "zizmor@1.29.0" --format=json-v1 --no-exit-codes .github/workflows .github/actions > zizmor-results.json
+
+          UNPINNED=$(jq '[.[] | select(.ident == "unpinned-uses")]' zizmor-results.json)
+          COUNT=$(echo "$UNPINNED" | jq 'length')
+
+          if [ "$COUNT" -gt 0 ]; then
+            echo "::error::Found $COUNT unpinned GitHub Action reference(s). All actions must be pinned to a full 40-character commit SHA."
+            echo "$UNPINNED" | jq -r '.[] | "  - \(.locations[0].symbolic.key.Local.verbatim_path): \(.desc)"'
+            echo ""
+            echo "To fix: replace the tag/branch with the action's full commit SHA and add a '# vX.Y.Z' comment, e.g."
+            echo "    uses: owner/repo@<40-char-sha> # v1.2.3"
+            echo ""
+            echo "If a version genuinely cannot be pinned to a SHA, add an inline exception with justification:"
+            echo "    uses: owner/repo@ref # zizmor: ignore[unpinned-uses] <reason>"
+            exit 1
+          fi
+
+          echo "No unpinned GitHub Actions found."

--- a/.github/workflows/refresh_release_pr.yaml
+++ b/.github/workflows/refresh_release_pr.yaml
@@ -28,7 +28,8 @@ jobs:
           echo "GITHUB_TOKEN=$TOKEN" >> $GITHUB_ENV
 
       - name: Refresh production release PR
-        uses: cds-snc/notification-pr-bot@main
+        # First-party bot intentionally tracks main (see renovate.json ignoreDeps) - can't hash-pin without losing that.
+        uses: cds-snc/notification-pr-bot@main # zizmor: ignore[unpinned-uses]
         env:
           TOKEN: ${{ env.GITHUB_TOKEN }}
           TARGET_REPO: notification-manifests


### PR DESCRIPTION
## Description

Follow-up to the GH Actions SHA-pinning remediation (#5067): adds a mandatory PR check that automatically fails if a workflow or composite action references a third-party action by a mutable tag/branch instead of a full 40-character commit SHA.

## Why not Renovate or the existing OSSF Scorecard job?

- **Renovate** (`helpers:pinGitHubActionDigests`) already auto-proposes PRs to keep pins updated, but it's a remediation bot — it can't block a human PR that introduces a new unpinned action.
- **Scorecard** (`ossf-scorecard.yml`) already reports on `Pinned-Dependencies`, but only runs weekly/on push to `main` as a scoring job — it never runs on `pull_request` and doesn't fail the build.

Neither currently blocks a PR, which is the actual gap this card asks to close.

## What this does

- New workflow: `.github/workflows/check_pinned_actions.yaml`, triggered on `pull_request`/`push:main` when `.github/workflows/**` or `.github/actions/**` change.
- Runs [`zizmor`](https://docs.zizmor.sh) (an actively-maintained, purpose-built GitHub Actions security linter) and filters its results down to just the `unpinned-uses` finding, so it stays scoped to SHA-pinning only (zizmor's other audits, e.g. `template-injection`, are a separate concern, out of scope here — several pre-existing findings would otherwise fail this check for unrelated reasons).
- Fails the check with actionable output (file + finding) and remediation guidance in the logs if any unpinned action is found.
- **Exception mechanism**: an inline `# zizmor: ignore[unpinned-uses] <reason>` comment skips the check for that line. Demonstrated on `cds-snc/notification-pr-bot@main` in `refresh_release_pr.yaml`, which intentionally tracks `main` (already excluded from Renovate via `renovate.json`'s `ignoreDeps`) and can't be hash-pinned without losing that behavior.

## To make this a real merge gate

Branch protection on `main` needs "Scan for unpinned actions" added as a required status check (not done in this PR — repo settings, not code).

## Testing

Ran `zizmor` locally against this repo's `.github/workflows`/`.github/actions`:
- Found exactly one `unpinned-uses` finding (`notification-pr-bot@main`) — confirmed with an inline ignore comment.
- Verified the CI script's jq filter both passes cleanly on this repo and correctly fails against a throwaway workflow with `uses: actions/checkout@v4`.
